### PR TITLE
Update Docs to enable wsl engine on windows

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -77,5 +77,14 @@ result-frontend_1 | docker-start.sh: line 9: $'\r': command not found
 result-frontend_1 | docker-start.sh: line 10: $'\r': command not found
 ```
 
-If you are getting the above command not found error then, Open the docker-start.sh file in Notepad++, then look in the bottom right hand corner. You'll see "Windows (CRLF)" change it to "Unix (LF)" and this will resolve the issue.
-And if this method doesn't work then remove the extra empty lines from the script and run docker compose up command again.
+If you are getting the above command not found error then, Open the docker-start.sh file in Notepad++, then look in the bottom right-hand corner. You'll see "Windows (CRLF)" change it to "Unix (LF)" and this will resolve the issue.
+And if this method doesn't work then try to enable the WSL2 engine on the docker desktop step.
+
+#### 4. Enable WSL Engine on Docker Desktop
+
+Before enabling the WSL engine, please verify wsl engine is installed on your system. If not present download the WSL2 kernel and install it [WSL2 Package](https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-4---download-the-linux-kernel-update-package).
+
+1. Start Docker Desktop from the Windows Start menu.
+2. From the Docker menu, select **Settings** >**General**.
+3. Select the **Use WSL 2 based engine** check box.
+4. Click **Apply & Restart**.

--- a/docs/SETUP-DOCKER-COMPOSE.md
+++ b/docs/SETUP-DOCKER-COMPOSE.md
@@ -8,6 +8,8 @@ Prerequisites for this are:
 * Docker
 * Docker Compose
 
+**Note:** For windows user, enable WSL engine on Docker Desktop. Check [FAQ](./FAQ.md) to enable WSL
+
 as a first step you need to clone the Git Repo to your local computer, this is done by opening terminal/command prompt (or some visual git client you may have) and executing:
 
 ```


### PR DESCRIPTION
Solution for docker-start .sh command not found the issue for Windows users.
