### PR TITLE
Adjust ad sync plugin to new license profiles

### DIFF
--- a/packages/dataiku/dss-plugin-azure-ad-sync/python-lib/azure_client.py
+++ b/packages/dataiku/dss-plugin-azure-ad-sync/python-lib/azure_client.py
@@ -36,7 +36,8 @@ class AzureClient:
     }
     # remapping due to license profiles names changes and the groups on azure AD already present
     PROFILES_REMAPPING = {
-        "DATA-ANALYST": "DATA-SCIENTIST"
+        "DATA-ANALYST": "DESIGNER",
+        "DATA-SCIENTIST": "DESIGNER"
     }
 
     INSTANCE_GROUP_MATRIX = ()


### PR DESCRIPTION
Adjust to new profiles in dataiku licenses given our existing azure AD groups