### PR TITLE
Updated the probe values for dashboard and naas

### DIFF
--- a/deployment/kubernetes/helm/charts/dashboard/values.yaml
+++ b/deployment/kubernetes/helm/charts/dashboard/values.yaml
@@ -34,9 +34,9 @@ resources:
     cpu: "500m"
 
 probes:
-  initialDelaySeconds: 60
+  initialDelaySeconds: 120
   timeoutSeconds: 10
-  periodSeconds: 10
+  periodSeconds: 20
   failureThreshold: 3
   livenessProbe:
     path: /dashboards/actuator/health/liveness

--- a/deployment/kubernetes/helm/charts/naas/values.yaml
+++ b/deployment/kubernetes/helm/charts/naas/values.yaml
@@ -39,7 +39,7 @@ app:
   probes:
     initialDelaySeconds: 180
     timeoutSeconds: 10
-    periodSeconds: 10
+    periodSeconds: 30
     failureThreshold: 3
     livenessProbe:
       path: /naas/actuator/health/liveness


### PR DESCRIPTION
Dashboard is taking a min of 80 secs to expose the endpoints on /actuator and also
Naas is taking a min of 160 secs to expose the endpoints on /actuator .