### PR TITLE
Build error fix related to react types

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -169,5 +169,9 @@
     "webpack-dev-server": "^3.11.2",
     "webpack-merge": "^5.8.0",
     "whatwg-fetch": "^3.0.0"
+  },
+  "resolutions": {
+    "@types/react": "17.0.11",
+    "@types/react-dom": "17.0.7"
   }
 }


### PR DESCRIPTION
#177 

https://github.com/mercedes-benz/DnA/issues/177

https://stackoverflow.com/questions/71791347/npm-package-cannot-be-used-as-a-jsx-component-type-errors/71797147

 