### PR TITLE
include addedByProvider key and while creating a copy, set consumers list to empty  by default 

### DIFF
--- a/packages/data-product-mfe/src/components/ProviderForm/OtherRelavantInfo/index.js
+++ b/packages/data-product-mfe/src/components/ProviderForm/OtherRelavantInfo/index.js
@@ -78,6 +78,7 @@ const OtherRelevantInfo = ({ onSave, history, user }) => {
   };
 
   const updateTeamMemberList = (teamMemberObj) => {
+    teamMemberObj['addedByProvider'] = true;
     if (editTeamMember) {
       teamMembers.splice(editTeamMemberIndex, 1);
       teamMembers.splice(editTeamMemberIndex, 0, teamMemberObj);

--- a/packages/data-product-mfe/src/components/ProviderForm/index.js
+++ b/packages/data-product-mfe/src/components/ProviderForm/index.js
@@ -87,6 +87,7 @@ const ProviderForm = ({ user, history }) => {
         res.data.notifyUsers = false;
         res.data.publish = false;
         res.data.providerInformation.providerFormSubmitted = false;
+        res.data.providerInformation.users = [];
         delete res.data.providerInformation.createdBy;
         delete res.data.providerInformation.createdDate;
         delete res.data.providerInformation.lastModifiedDate;


### PR DESCRIPTION
1. include addedByProvider attribute specific to each users while adding the consumer as a Provider

2. while creating a copy, set consumers list to empty by default to ensure Provider edit's and shares with whom so ever he wants