### PR TITLE
Storage file not listing issue fix

### DIFF
--- a/packages/storage-mfe/src/components/Explorer/redux/fileExplorer.actions.js
+++ b/packages/storage-mfe/src/components/Explorer/redux/fileExplorer.actions.js
@@ -92,7 +92,7 @@ export const getFiles = (files, bucketName, fileToOpen) => {
     });
     ProgressIndicator.show();
     try {
-      const prefix = !fileToOpen.objectName ? '/' : fileToOpen.objectName;
+      const prefix = !fileToOpen.objectName ? undefined : fileToOpen.objectName;
       const res = await bucketsObjectApi.getObjects(bucketName, prefix);
 
       if (res?.data) {


### PR DESCRIPTION
 - Workaround fix considering backward compatibility and on the latest minio not supporting root prefix '/' but  supported in earlier versions.