### PR TITLE
Ignoring tooltip-data attribute validation and resolves #1837

### DIFF
--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -51,5 +51,6 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 0,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,
+    'react/no-unknown-property': ['error', { ignore: ['tooltip-data', 'required-error'] }],
   },
 };


### PR DESCRIPTION
Based on uilab js component library tooltip-data attribute is used for keeping data for tooltip on the elements.