### PR TITLE
Change Chronos default email notification to true

### DIFF
--- a/packages/backend/dnambc-lib/src/main/java/com/daimler/data/assembler/UserNotificationPrefAssembler.java
+++ b/packages/backend/dnambc-lib/src/main/java/com/daimler/data/assembler/UserNotificationPrefAssembler.java
@@ -60,7 +60,15 @@ public class UserNotificationPrefAssembler  implements GenericAssembler<UserNoti
 				vo.setDataProductNotificationPref(dataProductNotificationPrefVO);
 				
 				NotificationPreference chronosNotificationPrefJson = data.getChronosNotificationPref();
-				NotificationPreferenceVO chronosNotificationPrefVO = this.toNotificationPrefVO(chronosNotificationPrefJson);
+				NotificationPreferenceVO chronosNotificationPrefVO = new NotificationPreferenceVO();
+				if(chronosNotificationPrefJson != null) {
+					chronosNotificationPrefVO.setEnableAppNotifications(chronosNotificationPrefJson.isEnableAppNotifications());
+					chronosNotificationPrefVO.setEnableEmailNotifications(chronosNotificationPrefJson.isEnableEmailNotifications());
+				}
+				else {
+					chronosNotificationPrefVO.setEnableAppNotifications(true);
+					chronosNotificationPrefVO.setEnableEmailNotifications(true);
+				}
 				vo.setChronosNotificationPref(chronosNotificationPrefVO);
 				
 				NotificationPreference codespaceNotificationPrefJson = data.getCodespaceNotificationPref();

--- a/packages/backend/dnambc-lib/src/main/resources/application.yml
+++ b/packages/backend/dnambc-lib/src/main/resources/application.yml
@@ -78,7 +78,7 @@ notification:
       dashboardNotificationPref: ${DEFAULT_EMAIL_DASHBOARD_NOTIFICATION_PREF:false}
       dataComplianceNotificationPref: ${DEFAULT_EMAIL_DATA_COMPLIANCE_NOTIFICATION_PREF:true}
       dataProductNotificationPref: ${DEFAULT_EMAIL_DATA_PRODUCT_NOTIFICATION_PREF:true}
-      chronosNotificationPref: ${DEFAULT_EMAIL_CHRONOS_NOTIFICATION_PREF:false}
+      chronosNotificationPref: ${DEFAULT_EMAIL_CHRONOS_NOTIFICATION_PREF:true}
       codespaceNotificationPref: ${DEFAULT_EMAIL_CODESPACE_NOTIFICATION_PREF:false}
   app:
       solutionNotificationPref: ${DEFAULT_APP_SOLUTION_NOTIFICATION_PREF:true}


### PR DESCRIPTION
Chronos will by default notify new users via email if their runs are finished. They can disable this in the settings.