### PR TITLE
Upgrade to Matomo Java Tracker 3.0.6

### DIFF
--- a/packages/backend/dnambc-lib/build.gradle
+++ b/packages/backend/dnambc-lib/build.gradle
@@ -827,8 +827,9 @@ dependencies {
 	
 	//Matomo tracking 
 	// https://mvnrepository.com/artifact/org.piwik.java.tracking/matomo-java-tracker
-    implementation group: 'org.piwik.java.tracking', name: 'matomo-java-tracker', version: '1.6'
-	
+    implementation group: 'org.piwik.java.tracking', name: 'matomo-java-tracker-java11', version: '3.0.6'
+    implementation group: 'org.piwik.java.tracking', name: 'matomo-java-tracker-servlet-javax', version: '3.0.6'
+
 	
 
 	//2nd level caching dependency 


### PR DESCRIPTION
### Hey @agnelpraveen and team,

Just wanted to give your project a little boost with the latest and greatest from Matomo Java Tracker! 🚀

### Changes in a Nutshell:

- **Bug Fixes & Performance Boosts:** Say goodbye to some pesky bugs and enjoy a faster, smoother tracking experience.

- **Security Makeover:** We're getting the latest security swag to keep our project locked down.

- **Stay Cool with Compatibility:** Now we're best buddies with Matomo versions up to 5, so no more awkward compatibility issues.

- **Less Baggage:** Matomo Java Tracker 3.0.6 is lean and mean with fewer dependencies. Less stuff, more speed!

- **New Toys:** Check out the cool new dimension parameter for super-customizable tracking.

- **Java 11 Party:** We're upgrading to the latest Java 11 implementation. It's like giving our project a cool new set of wheels.

- **Smooth Moves:** If you're coming from version 2, no worries! There's a handy migration guide [here](https://github.com/matomo-org/matomo-java-tracker#migration-from-version-2-to-302) to make the switch painless.

### How to Test:

1. Update to Matomo Java Tracker version 3.0.6.
2. Make sure our project still builds like a champ.
3. Double-check that our Matomo tracking mojo is still on point.
4. Test out any new features and give that dimension parameter a spin.

### Where to Get Help:

- Dive into the [Javadoc](https://javadoc.io/doc/org.piwik.java.tracking/matomo-java-tracker/3.0.6/index.html) for the nitty-gritty details.
- Got issues or bright ideas? Hit up the [Matomo Java Tracker GitHub](https://github.com/matomo-org/matomo-java-tracker).

### Your Feedback Matters:

Give it a whirl and let us know how it goes! Your feedback is like gold to us. 🌟

Cheers,
Daniel
