### PR TITLE
Disabling colloborator for private recipes and some type fixes

### DIFF
--- a/packages/frontend/src/components/mbc/codeSpace/newCodeSpace/NewCodeSpace.tsx
+++ b/packages/frontend/src/components/mbc/codeSpace/newCodeSpace/NewCodeSpace.tsx
@@ -19,6 +19,7 @@ import AddUser from '../../addUser/AddUser';
 import { Envs } from 'globals/Envs';
 import { recipesMaster } from '../../../../services/utils';
 import ConfirmModal from 'components/formElements/modal/confirmModal/ConfirmModal';
+import { DEPLOYMENT_DISABLED_RECIPE_IDS } from 'globals/constants';
 
 const classNames = cn.bind(Styles);
 
@@ -951,7 +952,7 @@ const NewCodeSpace = (props: ICodeSpaceProps) => {
               />
             </>
           )}
-          {!isPublicRecipeChoosen && !isUserDefinedGithubRecipe && (
+          {!isPublicRecipeChoosen && !isUserDefinedGithubRecipe && !DEPLOYMENT_DISABLED_RECIPE_IDS.includes(recipeValue) && (
             <div className={classNames('input-field-group include-error')}>
               <label htmlFor="userId" className="input-label">
                 Find and add the collaborators you want to work with your code (Optional)

--- a/packages/frontend/src/components/mbc/shared/caption/Caption.tsx
+++ b/packages/frontend/src/components/mbc/shared/caption/Caption.tsx
@@ -8,6 +8,7 @@ const classNames = cn.bind(Styles);
 export interface ICaptionProps {
   title: string;
   disableTitle?: boolean;
+  children?: React.ReactNode;
 }
 
 const Caption:React.FC<ICaptionProps> = ({ title, disableTitle, children }) => {

--- a/packages/frontend/src/components/mbc/widgets/BarChartWidget/BarChartWidget.tsx
+++ b/packages/frontend/src/components/mbc/widgets/BarChartWidget/BarChartWidget.tsx
@@ -8,7 +8,7 @@ export interface IBarChartWidgetProps {
   xAxisSubLabel?: string;
   yAxisLabel: string;
   yAxisSubLabel?: string;
-  tooltipContentComponent: React.StatelessComponent<any>;
+  tooltipContentComponent: React.FunctionComponent<any>;
   onChartBarClick: (value: any) => void;
 }
 

--- a/packages/frontend/src/components/mbc/widgets/ScatterChartWidget/ScatterChartWidget.tsx
+++ b/packages/frontend/src/components/mbc/widgets/ScatterChartWidget/ScatterChartWidget.tsx
@@ -8,7 +8,7 @@ export interface IScatterChartWidgetProps {
   xAxisSubLabel?: string;
   yAxisLabel: string;
   yAxisSubLabel?: string;
-  tooltipContentComponent: React.StatelessComponent<any>;
+  tooltipContentComponent: React.FunctionComponent<any>;
   onScatterChartBubbleClick: (value: any) => void;
 }
 

--- a/packages/frontend/src/components/mbc/widgets/StackedBarChartWidget/StackedBarChartWidget.tsx
+++ b/packages/frontend/src/components/mbc/widgets/StackedBarChartWidget/StackedBarChartWidget.tsx
@@ -9,7 +9,7 @@ export interface IStackedBarChartWidgetProps {
   xAxisSubLabel?: string;
   yAxisLabel: string;
   yAxisSubLabel?: string;
-  tooltipContentComponent: React.StatelessComponent<any>;
+  tooltipContentComponent: React.FunctionComponent<any>;
   onChartBarClick?: (value: any) => void;
 }
 

--- a/packages/frontend/src/utils/ErrorBoundary.tsx
+++ b/packages/frontend/src/utils/ErrorBoundary.tsx
@@ -10,7 +10,7 @@ interface IErrorState {
   errorInfo: any;
 }
 
-export default class ErrorBoundary extends React.Component<{}, IErrorState> {
+export default class ErrorBoundary extends React.Component<{ children: React.ReactNode }, IErrorState> {
   constructor(props: any) {
     super(props);
     this.state = { hasError: false, error: false, errorInfo: null };


### PR DESCRIPTION
For private recipes, we can't control the collaborators since the members manage with owner of the recipe in GitHub