### PR TITLE
Enabled the codespace popup again with correct url

### DIFF
--- a/packages/frontend/src/components/mbc/codeSpace/CodeSpace.tsx
+++ b/packages/frontend/src/components/mbc/codeSpace/CodeSpace.tsx
@@ -234,14 +234,14 @@ const CodeSpace = (props: ICodeSpaceProps) => {
           const serverStarted = res.serverStatus === 'SERVER_STARTED';
 
           if (serverStarted) {
-            // const loginWindow = window.open(
-            //   Envs.CODESPACE_OIDC_POPUP_URL + res.workspaceId + '/',
-            //   'codeSpaceSessionWindow',
-            //   'width=100,height=100,location=no,menubar=no,status=no,titlebar=no,toolbar=no',
-            // );
+            const loginWindow = window.open(
+              Envs.CODESPACE_OIDC_POPUP_URL + `user/${props.user.id.toLowerCase()}/${res.workspaceId}/`,
+              'codeSpaceSessionWindow',
+              'width=100,height=100,location=no,menubar=no,status=no,titlebar=no,toolbar=no',
+            );
 
-            // setTimeout(() => {
-              // loginWindow?.close();
+            setTimeout(() => {
+              loginWindow?.close();
 
               setLoading(false);
               const status = res.status;
@@ -303,7 +303,7 @@ const CodeSpace = (props: ICodeSpaceProps) => {
                   'warning',
                 );
               }
-            // }, Envs.CODESPACE_OIDC_POPUP_WAIT_TIME);
+            }, Envs.CODESPACE_OIDC_POPUP_WAIT_TIME);
           } else {
             setLoading(true);
             CodeSpaceApiClient.startStopWorkSpace(res.id, false)


### PR DESCRIPTION
For the first time always goes to the oidc redirection... seen the issue... So enabling the popup again with the latest url pointing to user codespace