### PR TITLE
Fix ArgoCD TEST deployment: register repo and handle 403/404 in status check

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -448,6 +448,9 @@ public class ArgoCdService {
         } catch (org.springframework.web.client.HttpClientErrorException.NotFound e) {
             log.info("ArgoCD application not found: {}", appName);
             return ResponseEntity.status(404).build();
+        } catch (org.springframework.web.client.HttpClientErrorException.Forbidden e) {
+            log.warn("Permission denied accessing ArgoCD application: {}", appName);
+            return ResponseEntity.status(403).build();
         } catch (Exception e) {
             log.error("Failed to get ArgoCD app status for {}", appName, e);
             return ResponseEntity.status(500).build();
@@ -458,6 +461,15 @@ public class ArgoCdService {
         try {
             ResponseEntity<String> argoResponse = getStatusOfArgoApp(token, appName);
             if (argoResponse == null || !argoResponse.getStatusCode().is2xxSuccessful()) {
+                int statusCode = argoResponse != null ? argoResponse.getStatusCode().value() : 0;
+                if (statusCode == 403) {
+                    log.warn("ArgoCD app {} - permission denied, marking as FAILED", appName);
+                    return "FAILED";
+                }
+                if (statusCode == 404) {
+                    log.warn("ArgoCD app {} - not found, marking as FAILED", appName);
+                    return "FAILED";
+                }
                 log.info("ArgoCD app {} not ready yet - DEPLOYING", appName);
                 return "DEPLOYING";
             }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
@@ -2157,6 +2157,9 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
                         log.info("ArgoCD deployment - projectName: {}, gitRepoUrl: {}, imageTag: {}, repoName: {}, gheWorkspaceMigrated: {}", 
                                  projectName, gitRepoUrl, imageTag, repoName, gheWorkspaceMigrated);
                         
+                        String repoAccessPat = gheWorkspaceMigrated ? ghePat : gitPat;
+                        argoCdService.registerRepository(argoToken, gitRepoUrl, "x-access-token", repoAccessPat);
+                        
                         argoDeployResult = argoCdService.createArgoApp(argoToken, projectName.toLowerCase(), workspaceOwner, 
                                                                         environment, gitRepoUrl, imageTag, isValutInjectorEnable);
                     } else {


### PR DESCRIPTION
## Summary

ArgoCD deployments succeed in DEV but fail in TEST (staging) with two distinct errors observed in Grafana. This PR addresses both.

### Fix 1: `400 Bad Request — authentication required` (BaseWorkspaceService.java)

When deploying to TEST, ArgoCD cannot access the git repository (e.g. `https://mercedes-benz.ghe.com/DNA-CodeSpaces/test-cs-argocd-deploy.git`) because it was never registered with credentials.

**Root cause:** `ArgoCdService.registerRepository()` exists but is never called anywhere in the deployment flow. ArgoCD needs the git repository to be registered with credentials before it can create an application that references it. DEV likely had the repo registered manually or via a different mechanism; TEST did not.

**Fix:** Calls `argoCdService.registerRepository()` with the appropriate GHE/Git PAT immediately before `createArgoApp()` in the `deployWorkspace` method. The PAT is selected based on `gheWorkspaceMigrated` (same pattern used in `GitClient`). If the repo is already registered, the existing `registerRepository` method handles the 409 Conflict gracefully by logging and continuing.

### Fix 2: `403 Forbidden — permission denied` (ArgoCdService.java)

The background `DeploymentStatusMonitorJob` (runs every 10s) checks all workspaces in "DEPLOYING" state by calling ArgoCD's GET `/applications/{appName}` API. For apps like `test-cs-python-starter-int`, ArgoCD returns 403.

**Root cause:** `getStatusOfArgoApp()` only caught `HttpClientErrorException.NotFound` (404), not `Forbidden` (403). The 403 fell into the generic `Exception` catch, returned status 500, and `checkArgoAppDeploymentStatus()` treated all non-2xx responses as "DEPLOYING" — causing the workspace to be **stuck in DEPLOYING state forever**, with the scheduler retrying and logging the 403 error every 10 seconds.

**Fix:**
- Added explicit `HttpClientErrorException.Forbidden` catch in `getStatusOfArgoApp()` to return 403 cleanly
- In `checkArgoAppDeploymentStatus()`, 403 and 404 responses now return `"FAILED"` instead of `"DEPLOYING"`, so the scheduler stops retrying and the workspace status is updated to reflect the actual failure

