### PR TITLE
Revert: Remove registerRepository call before createArgoApp

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
@@ -2157,9 +2157,6 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
                         log.info("ArgoCD deployment - projectName: {}, gitRepoUrl: {}, imageTag: {}, repoName: {}, gheWorkspaceMigrated: {}", 
                                  projectName, gitRepoUrl, imageTag, repoName, gheWorkspaceMigrated);
                         
-                        String repoAccessPat = gheWorkspaceMigrated ? ghePat : gitPat;
-                        argoCdService.registerRepository(argoToken, gitRepoUrl, "x-access-token", repoAccessPat);
-                        
                         argoDeployResult = argoCdService.createArgoApp(argoToken, projectName.toLowerCase(), workspaceOwner, 
                                                                         environment, gitRepoUrl, imageTag, isValutInjectorEnable);
                     } else {


### PR DESCRIPTION
## Summary

Reverts the `registerRepository()` call that was added in PR #4955 to the `deployWorkspace` method in `BaseWorkspaceService.java`. This removes the 3 lines that selected a PAT (`ghePat` or `gitPat`) and called `argoCdService.registerRepository()` immediately before `createArgoApp()`.

The `registerRepository` method itself in `ArgoCdService.java` is **not** removed — only the call site in the deployment flow is reverted. The separate fix from PR #4955 for 403 Forbidden handling in `ArgoCdService.checkArgoAppDeploymentStatus()` is also **not** affected by this revert.

## Review & Testing Checklist for Human

- [ ] **Confirm intent**: Verify that only the `registerRepository` call should be reverted, and that the 403/404 status handling changes from PR #4955 should remain
- [ ] **TEST environment deployment**: After merging, attempt a deployment in TEST — the original `400 Bad Request: authentication required` error may resurface if the ArgoCD repo is not registered through another mechanism. Ensure there is an alternative plan for repo registration (e.g., manual registration, ArgoCD UI, or a different automation)
- [ ] **DEV environment**: Verify DEV deployments are unaffected (this call was a no-op in DEV since repos were already registered)

### Notes
- The `registerRepository()` method remains available in `ArgoCdService` and can be re-integrated if needed with a different approach
- This revert does not touch `ArgoCdService.java` — only `BaseWorkspaceService.java`

Link to Devin session: https://mercedes-benz.devinenterprise.com/sessions/abb59d9c197344d99543ccb9237f2f24