### PR TITLE
Release: hotfix: fix role creation API validation & update Alice Role Request UI

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -659,7 +659,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		adminRoleRequestDto.setDescription(permissionName +" role for workspace " + workspaceName);
 		adminRoleRequestDto.setDynamic(false);
 		adminRoleRequestDto.setGlobalCentralAvailable(true);
-		adminRoleRequestDto.setId(workspaceName + "_" +  permissionName);
+		adminRoleRequestDto.setId((workspaceName + "_" +  permissionName).replace(" ", ""));
 		adminRoleRequestDto.setJobTitle(false);
 		adminRoleRequestDto.setMarketAvailabilities(new ArrayList<>());
 		adminRoleRequestDto.setName((workspaceName + " " +  permissionName).replace("_", " "));
@@ -683,7 +683,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		createRoleVO.setState(ConstantsUtility.PENDING_STATE);
 		try {
 			log.info("Calling identity management system to add role {} for workspace {} ", workspaceName + "_" + permissionName, workspaceName);
-			CreateRoleResponseDto getResponse = identityClient.getRole(createRequestDto.getName());
+			CreateRoleResponseDto getResponse = identityClient.getRole(createRequestDto.getId());
 			if(getResponse!=null && getResponse.getId()!=null) {
 				createRoleVO.setId(getResponse.getId());
 				createRoleVO.setLink(identityRoleUrl+workspaceName + "_" +  permissionName);

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -662,7 +662,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		adminRoleRequestDto.setId(workspaceName + "_" +  permissionName);
 		adminRoleRequestDto.setJobTitle(false);
 		adminRoleRequestDto.setMarketAvailabilities(new ArrayList<>());
-		adminRoleRequestDto.setName(workspaceName + "_" +  permissionName);
+		adminRoleRequestDto.setName((workspaceName + " " +  permissionName).replace("_", " "));
 		adminRoleRequestDto.setNeedsAdditionalSelfRequestApproval(false);
 		adminRoleRequestDto.setNeedsCustomScopes(false);
 		adminRoleRequestDto.setNeedsOrgScopes(false);
@@ -2060,7 +2060,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		roleRequestDto.setId(roleName);
 		roleRequestDto.setJobTitle(false);
 		roleRequestDto.setMarketAvailabilities(new ArrayList<>());
-		roleRequestDto.setName(roleName);
+		roleRequestDto.setName(roleName.replace("_", " "));
 		roleRequestDto.setNeedsAdditionalSelfRequestApproval(false);
 		roleRequestDto.setNeedsCustomScopes(false);
 		roleRequestDto.setNeedsOrgScopes(false);

--- a/packages/fabric-backend/lib/src/main/resources/application-dev.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-fabric-workspace-service
-    version: 1.2.8
+    version: 1.2.9
 
   flyway:
     enabled: ${FLYWAY_ENABLED:false}

--- a/packages/fabric-backend/lib/src/main/resources/application-dev.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-fabric-workspace-service
-    version: 1.2.9
+    version: 1.2.8
 
   flyway:
     enabled: ${FLYWAY_ENABLED:false}

--- a/packages/fabric-backend/lib/src/main/resources/application.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-fabric-workspace-service
-    version: 1.5.2
+    version: 1.5.3
   profile:
     active: production
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dna-web",
-  "version": "3.15.8",
+  "version": "3.15.9",
   "description": "Web Frontend for DnA@MBC based on Digital Design System(UILab)",
   "license": "MIT",
   "author": {

--- a/packages/frontend/src/components/mbc/aliceRoleRequest/AliceRoleRequest.scss
+++ b/packages/frontend/src/components/mbc/aliceRoleRequest/AliceRoleRequest.scss
@@ -43,9 +43,7 @@
    
       .roleName {
         flex: 1;  
-        max-width: 50%;
-        // width: calc(50% - 9px);
-        // margin-right: 20px;
+        max-width: 33%;
       }
    
       .disabledSection {

--- a/packages/frontend/src/components/mbc/aliceRoleRequest/AliceRoleRequest.tsx
+++ b/packages/frontend/src/components/mbc/aliceRoleRequest/AliceRoleRequest.tsx
@@ -37,15 +37,15 @@ const AliceRoleRequest = () => {
   const validateRole = () => {
     const specialCharPattern = /[^A-Za-z0-9\-_./]/;
     if (roleName.trim() === "") {
-      setRoleNameError('Role name cannot be empty');
+      setRoleNameError('Role ID cannot be empty');
       return false
     }
     if (roleName.includes(" ")) {
-      setRoleNameError('Role name cannot contain spaces');
+      setRoleNameError('Role ID cannot contain spaces');
       return false;
     }
     if (specialCharPattern.test(roleName)) {
-      setRoleNameError('Role name can only contain letters, numbers, and the following characters: . _ -');
+      setRoleNameError('Role ID can only contain letters, numbers, and the following characters: . _ -');
       return false;
     }
     return true;
@@ -200,9 +200,9 @@ const AliceRoleRequest = () => {
                 <div className={classNames(Styles.roleName)}>
                   <TextBox
                     type="text"
-                    controlId={'productNameInput'}
-                    labelId={'productNameLabel'}
-                    label={'Role Name'}
+                    controlId={'roleIdInput'}
+                    labelId={'roleIdLabel'}
+                    label={'Role ID'}
                     placeholder={'Type here'}
                     value={roleName}
                     errorText={roleNameError}
@@ -228,13 +228,27 @@ const AliceRoleRequest = () => {
                 <div className={classNames(Styles.roleName, Styles.disabledSection)}>
                   <TextBox
                     type="text"
-                    controlId={'productNameInput'}
-                    labelId={'productNameLabel'}
+                    controlId={'roleNameDisplay'}
+                    labelId={'roleNameDisplayLabel'}
                     label={'Role to be created'}
                     placeholder={'Type here'}
-                    value={roleName?.length > 0 ? Envs.ALICE_APP_ID + "_" + roleName : ''}
+                    value={roleName?.length > 0 ? (Envs.ALICE_APP_ID + ' ' + roleName).replace(/_/g, ' ') : ''}
                     required={false}
                     maxLength={50}
+                    onChange={onRoleNameChange}
+                  />
+                </div>
+
+                <div className={classNames(Styles.roleName, Styles.disabledSection)}>
+                  <TextBox
+                    type="text"
+                    controlId={'entitlementDisplay'}
+                    labelId={'entitlementDisplayLabel'}
+                    label={'Entitlement to be created'}
+                    placeholder={'Type here'}
+                    value={roleName?.length > 0 ? Envs.ALICE_APP_ID + '.' + Envs.ALICE_APP_ID + '_' + roleName : ''}
+                    required={false}
+                    maxLength={100}
                     onChange={onRoleNameChange}
                   />
                 </div>


### PR DESCRIPTION
## Summary

### Problem
Role creation fails with 400 Bad Request due to two distinct API validation issues:

1. **Role name rejects underscores** — The identity management API validates role names against a regex that rejects underscores, but the code was constructing role names with underscores.

2. **Role ID rejects spaces** — For workspaces with spaces in their name, the role ID was constructed with spaces, which fails the roleId regex.

Additionally, `callRoleCreate()` was passing the role **name** to `getRole()`, which expects the role **ID** — causing a 404 lookup failure before every create attempt.

### Changes

**Backend (`BaseFabricWorkspaceService.java`)**

| Method | Fix |
|---|---|
| `prepareRoleCreateRequestDto()` | Strip spaces from role `id` (`.replace(" ", "")`); replace underscores with spaces in role `name` |
| `prepareGenericRoleCreateRequestDto()` | Replace underscores with spaces in role `name` |
| `callRoleCreate()` | Use `createRequestDto.getId()` instead of `.getName()` for the `getRole()` lookup |

**Frontend (`AliceRoleRequest.tsx` / `.scss`)**
- Renamed user input label from **Role Name** → **Role ID**
- Updated **Role to be created** display field to show the role name without underscores
- Added new non-editable **Entitlement to be created** field showing `{Application ID}.{Application ID}_{Role ID}`
- Adjusted layout from two-column to three-column for the new field
- Updated validation error messages to reference "Role ID"

**Version bumps**
- `application.yml`: `1.5.2` → `1.5.3`
- `packages/frontend/package.json`: `3.15.8` → `3.15.9`

## Review & Testing Checklist for Human

- [ ] **Test workspace-role creation with spaces in workspace name** — verify the role ID sent to the API has no spaces while the name uses spaces instead of underscores
- [ ] **Test role creation with underscores in role name** — verify the API accepts the transformed name while the ID is preserved
- [ ] **Verify `getRole` lookup works** — confirm that re-running role creation for an already-existing role correctly finds it via `getId()` instead of returning 404
- [ ] **Verify the Entitlement format** — confirm the "Entitlement to be created" field matches the expected naming convention
- [ ] **Verify UI layout** — check that the three fields display correctly at various screen widths

### Notes
- The `application-dev.yml` version was intentionally left unchanged per request