### PR TITLE
Fix duplicate data in fabric_workspace_nsql: bypass lossy getById round-trip

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/assembler/FabricWorkspaceAssembler.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/assembler/FabricWorkspaceAssembler.java
@@ -148,13 +148,7 @@ public class FabricWorkspaceAssembler implements GenericAssembler<FabricWorkspac
 					cdcPublishedLakeHouseDetails.setIsLakeHousesPublishedToCdc(data.getCdcPublishedLakeHouseDetails().getIsLakeHousesPublishedToCdc());
 					vo.setCdcPublishedLakeHouseDetails(cdcPublishedLakeHouseDetails);
 				}
-				Object ddxDetails = data.getDdxPublishedLakeHouseDetails();
-				if (ddxDetails instanceof List<?>) {
-					boolean allStrings = ((List<?>) ddxDetails).stream().allMatch(item -> item instanceof String);
-					vo.setDdxPublishedLakeHouseDetails(allStrings ? (List<String>) ddxDetails : null);
-				} else {
-					vo.setDdxPublishedLakeHouseDetails(null);
-				}
+				vo.setDdxPublishedLakeHouseDetails(data.getDdxPublishedLakeHouseDetails());
 			}
 		}
 		return vo;
@@ -373,13 +367,7 @@ public class FabricWorkspaceAssembler implements GenericAssembler<FabricWorkspac
 				cdcLakehouseDetails.setIsLakeHousesPublishedToCdc(vo.getCdcPublishedLakeHouseDetails().isIsLakeHousesPublishedToCdc());
 				data.setCdcPublishedLakeHouseDetails(cdcLakehouseDetails);
 			}
-			Object ddxDetails = vo.getDdxPublishedLakeHouseDetails();
-			if (ddxDetails instanceof List<?>) {
-				boolean allStrings = ((List<?>) ddxDetails).stream().allMatch(item -> item instanceof String);
-				data.setDdxPublishedLakeHouseDetails(allStrings ? (List<String>) ddxDetails : null);
-			} else {
-				data.setDdxPublishedLakeHouseDetails(null);
-			}
+			data.setDdxPublishedLakeHouseDetails(vo.getDdxPublishedLakeHouseDetails());
 			entity.setData(data);
 		}
 		return entity;

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseDdxOnboardingService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseDdxOnboardingService.java
@@ -23,7 +23,9 @@ import com.daimler.data.assembler.FabricWorkspaceAssembler;
 import com.daimler.data.assembler.LakehouseDetailAssembler;
 import com.daimler.data.controller.exceptions.GenericMessage;
 import com.daimler.data.controller.exceptions.MessageDescription;
+import com.daimler.data.db.entities.FabricWorkspaceNsql;
 import com.daimler.data.db.entities.LakehouseDetailNsql;
+import com.daimler.data.db.json.FabricWorkspace;
 import com.daimler.data.db.repo.fabric.FabricWorkspaceRepository;
 import com.daimler.data.db.repo.lakehouseDetail.LakehouseDetailRepository;
 import com.daimler.data.dto.fabric.FabricSqlEndpointResponseDto;
@@ -425,12 +427,21 @@ public class BaseDdxOnboardingService implements DdxOnboardingService {
 
     private void updateDdxLakeHouseDetails(String workspaceId, String lakehouseId, String lakehouseName, String catalogName, DdxResponseDto onboardingResponse, CreatedByVO createdBy) {
         try {
-            FabricWorkspaceVO workspace = fabricWorkspaceService.getById(workspaceId);
+            // Load the entity directly from the repository to avoid the lossy
+            // getById round-trip (VO <-> Entity conversion drops fields like
+            // capacityAssignmentProgress and can overwrite JSONB data).
+            Optional<FabricWorkspaceNsql> entityOpt = jpaRepo.findById(workspaceId);
+            if (entityOpt.isEmpty()) {
+                log.error("Workspace not found with id {} while updating DDX lakehouse details", workspaceId);
+                return;
+            }
+            FabricWorkspaceNsql workspaceEntity = entityOpt.get();
+            FabricWorkspace workspaceData = workspaceEntity.getData();
 
             // Build the lakehouse detail VO for the new table
             DdxPublishedLakeHouseDetailsVO details = new DdxPublishedLakeHouseDetailsVO();
             details.setWorkspaceId(workspaceId);
-            details.setWorkspaceName(workspace.getName());
+            details.setWorkspaceName(workspaceData != null ? workspaceData.getName() : null);
             details.setLakehouseName(lakehouseName);
             details.setLakeHouseId(lakehouseId);
             details.setIsLakeHousesPublishedToDdx(true);
@@ -450,14 +461,20 @@ public class BaseDdxOnboardingService implements DdxOnboardingService {
             entity.setId(lakehouseId);
             lakehouseDetailRepo.save(entity);
 
-            // Add the ID to workspace's ddxPublishedLakeHouseDetails list
-            List<String> detailIds = Optional.ofNullable(workspace.getDdxPublishedLakeHouseDetails())
-                .orElse(new ArrayList<>());
-            if (!detailIds.contains(lakehouseId)) {
-                detailIds.add(lakehouseId);
+            // Update the workspace's ddxPublishedLakeHouseDetails list directly
+            // on the managed entity — no VO round-trip needed.
+            if (workspaceData != null) {
+                List<String> detailIds = workspaceData.getDdxPublishedLakeHouseDetails();
+                if (detailIds == null) {
+                    detailIds = new ArrayList<>();
+                }
+                if (!detailIds.contains(lakehouseId)) {
+                    detailIds.add(lakehouseId);
+                }
+                workspaceData.setDdxPublishedLakeHouseDetails(detailIds);
+                workspaceEntity.setData(workspaceData);
+                jpaRepo.save(workspaceEntity);
             }
-            workspace.setDdxPublishedLakeHouseDetails(detailIds);
-            jpaRepo.save(assembler.toEntity(workspace));
 
             log.info("Successfully updated DDX published lakehouse details for workspace: {}, lakehouseId: {}", workspaceId, lakehouseId);
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

Fixes data corruption/duplication in the `fabric_workspace_nsql` table caused by `updateDdxLakeHouseDetails()` calling `fabricWorkspaceService.getById()`, which internally performs a destructive read-modify-write cycle (Entity → VO → new Entity → save) that silently drops JSONB fields not present in the Swagger-generated VO (e.g. `capacityAssignmentProgress`).

**`BaseDdxOnboardingService.java`**: Replaced the `fabricWorkspaceService.getById()` call in `updateDdxLakeHouseDetails` with a direct `jpaRepo.findById()`. The method now reads and modifies the JSONB data in-place on the managed JPA entity, avoiding the lossy VO round-trip and the extra unnecessary save that `getById` performed internally.

**`FabricWorkspaceAssembler.java`**: Simplified `ddxPublishedLakeHouseDetails` handling in both `toVo()` and `toEntity()` — replaced verbose `Object` → `instanceof List<?>` → `allStrings` check blocks with direct `List<String>` assignment, since both `FabricWorkspace` and `FabricWorkspaceVO` now declare this field as `List<String>`.

## Review & Testing Checklist

- [ ] **Verify no legacy data exists with old `ddxPublishedLakeHouseDetails` format**: The assembler simplification removes the defensive `instanceof` checks that handled the case where this field was previously a complex `DdxPublishedLakeHouseDetails` JSON object. If any rows in `fabric_workspace_nsql` still contain the old object format in this field, Jackson deserialization will fail at entity load time. Query the DB to confirm all values are either `null` or a JSON array of strings.
- [ ] **Test DDX publish end-to-end**: Publish a lakehouse to DDX and verify the workspace row in `fabric_workspace_nsql` retains all its JSONB fields (especially `capacityAssignmentProgress`) and that `ddxPublishedLakeHouseDetails` is correctly updated with the new lakehouse ID without duplicates.
- [ ] **Note: `getById` side-effect save is still present**: The controller's validation call (`fabricWorkspaceService.getById()` at line 74 of `DdxOnboardingController`) still triggers the destructive save cycle. This PR only fixes the DDX onboarding service path — the broader `getById` issue remains.

### Notes
- The `workspaceData != null` guard means the workspace save is now skipped if the entity has null JSONB data, whereas previously it would save a VO-reconstructed entity regardless. This is intentional — saving an entity with null data would be harmful.

Link to Devin session: https://mercedes-benz.devinenterprise.com/sessions/36e01d60b4a145258bba1ab7c8b63425
<!-- devin-review-badge-begin -->

---

<a href="https://mercedes-benz.devinenterprise.com/review/mercedes-benz/dna/pull/4970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
