### PR TITLE
Release: hotfix: fix role ID/name confusion in callRoleCreate - strip spaces from ID, use ID for getRole lookup

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -659,7 +659,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		adminRoleRequestDto.setDescription(permissionName +" role for workspace " + workspaceName);
 		adminRoleRequestDto.setDynamic(false);
 		adminRoleRequestDto.setGlobalCentralAvailable(true);
-		adminRoleRequestDto.setId(workspaceName + "_" +  permissionName);
+		adminRoleRequestDto.setId((workspaceName + "_" +  permissionName).replace(" ", ""));
 		adminRoleRequestDto.setJobTitle(false);
 		adminRoleRequestDto.setMarketAvailabilities(new ArrayList<>());
 		adminRoleRequestDto.setName(workspaceName + "_" +  permissionName);
@@ -683,7 +683,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		createRoleVO.setState(ConstantsUtility.PENDING_STATE);
 		try {
 			log.info("Calling identity management system to add role {} for workspace {} ", workspaceName + "_" + permissionName, workspaceName);
-			CreateRoleResponseDto getResponse = identityClient.getRole(createRequestDto.getName());
+			CreateRoleResponseDto getResponse = identityClient.getRole(createRequestDto.getId());
 			if(getResponse!=null && getResponse.getId()!=null) {
 				createRoleVO.setId(getResponse.getId());
 				createRoleVO.setLink(identityRoleUrl+workspaceName + "_" +  permissionName);

--- a/packages/fabric-backend/lib/src/main/resources/application.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-fabric-workspace-service
-    version: 1.5.2
+    version: 1.5.3
   profile:
     active: production
 

--- a/packages/fabric-backend/lib/src/main/resources/application.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-fabric-workspace-service
-    version: 1.5.3
+    version: 1.5.4
   profile:
     active: production
 


### PR DESCRIPTION
## Summary

Fixes role creation failure for workspaces with spaces in their name. Two bugs in `BaseFabricWorkspaceService`:

1. **Role ID contained spaces** — `prepareRoleCreateRequestDto` built the ID as `workspaceName + "_" + permissionName`. For workspaces with spaces in the name, this produced an ID with spaces, which fails the roleId regex `^[A-Z0-9]+[A-Z0-9\._-]{1,200}` (spaces not allowed). **Fix**: strip spaces from the ID.

2. **`getRole` called with role name instead of role ID** — `callRoleCreate` passed `createRequestDto.getName()` to `identityClient.getRole()`, but `getRole()` hits `GET /roles/{roleId}` and expects the ID. This caused a 404 on every lookup, forcing unnecessary create attempts. **Fix**: use `createRequestDto.getId()`.

## Review & Testing Checklist for Human

- [ ] **Verify space-stripping produces valid IDs** — confirm that workspaces with spaces produce correctly formatted role IDs without spaces
- [ ] **Test end-to-end role creation for a workspace with spaces in its name** — verify the API accepts the role and the `getRole` lookup works on subsequent calls
- [ ] **Verify no downstream references break** — `createRoleVO.setName()` and log messages still use `workspaceName + "_" + permissionName` (with original spaces). Confirm these internal/display values do not get passed to the identity API elsewhere

### Notes
- The role `name` field (line 665) is unchanged in this PR — it still replaces underscores with spaces. The separate PR #4969 on `hotfix/alice-role-creation-fix` addresses the name regex validation.
- `prepareGenericRoleCreateRequestDto` and `callGenericRoleCreate` are not affected — the generic flow does not have the same `getRole` pre-check and the Alice Role Request UI already validates that user input has no spaces.