### PR TITLE
fix: workspace-project association not persisting projectId correctly

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/adaProjects/BaseADAProjectsService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/adaProjects/BaseADAProjectsService.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -134,9 +135,18 @@ public class BaseADAProjectsService extends BaseCommonService<ADAProjectDetailsV
 	public GenericMessage createWorkspaceProjectAssociation(FabricWorkspaceVO workspace, String projectId) {
 		
 		try {
-			workspace.setProjectId(projectId);
-			FabricWorkspaceNsql entity = fabricWorkspaceAssembler.toEntity(workspace);
-			fabricWorkspaceRepo.save(entity);
+			Optional<FabricWorkspaceNsql> existingEntityOpt = fabricWorkspaceRepo.findById(workspace.getId());
+			if (existingEntityOpt.isPresent()) {
+				FabricWorkspaceNsql existingEntity = existingEntityOpt.get();
+				existingEntity.getData().setProjectId(projectId);
+				fabricWorkspaceRepo.save(existingEntity);
+				log.info("Successfully associated workspace {} with project {}", workspace.getId(), projectId);
+			} else {
+				log.error("Workspace entity not found in DB for id {}", workspace.getId());
+				GenericMessage message = new GenericMessage("ERROR");
+				message.setErrors(List.of(new MessageDescription("Workspace entity not found for id: " + workspace.getId())));
+				return message;
+			}
 			return new GenericMessage("SUCCESS");
 		} catch (Exception e) {
 			log.error("Error creating workspace-project association", e);


### PR DESCRIPTION
Reads the existing workspace entity directly from the database via `findById` and sets `projectId` on its JSONB data object, instead of converting the VO to a new detached entity which caused `project_id` to be overwritten as `null`.

Link to Devin session: https://mercedes-benz.devinenterprise.com/sessions/3cb24dcb9a13490696f8d57c4603fa79