### PR TITLE
Fix epoch 0 timestamp on FAILED deployments

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -126,11 +126,13 @@ public class DeploymentStatusMonitorJob {
                         .orElse(null);
                 }
                 
+                // Set timestamp for both DEPLOYED and FAILED
+                deployment.setLastDeployedOn(new Date());
+                
                 if ("DEPLOYED".equals(argoStatus)) {
                     if (deployment.getLastDeployedBy() == null) {
                         deployment.setLastDeployedBy(workspace.getData().getWorkspaceOwner());
                     }
-                    deployment.setLastDeployedOn(new Date());
                     
                     if (latestAudit != null) {
                         if (deployment.getLastDeployedBranch() == null && latestAudit.getBranch() != null) {
@@ -146,9 +148,7 @@ public class DeploymentStatusMonitorJob {
                 }
                 if (latestAudit != null) {
                     latestAudit.setDeploymentStatus(argoStatus);
-                    if ("DEPLOYED".equals(argoStatus)) {
-                        latestAudit.setDeployedOn(new Date());
-                    }
+                    latestAudit.setDeployedOn(new Date());
                     log.info("Updated audit log status to {} for deployment at {}", argoStatus, latestAudit.getTriggeredOn());
                 }
 
@@ -189,9 +189,7 @@ public class DeploymentStatusMonitorJob {
                 DeploymentAudit audit = auditLogs.get(i);
                 if ("DEPLOYING".equalsIgnoreCase(audit.getDeploymentStatus())) {
                     audit.setDeploymentStatus(argoStatus);
-                    if ("DEPLOYED".equals(argoStatus)) {
-                        audit.setDeployedOn(new Date());
-                    }
+                    audit.setDeployedOn(new Date());
                     log.info("Updated build deploy audit log status to {} for {}-{}", argoStatus, projectName, environment);
                     break;
                 }


### PR DESCRIPTION
## Summary

When a deployment fails, the UI shows "Deployment to staging failed on 1/1/1970, 05:30:00" because `lastDeployedOn` and `deployedOn` are only set when the status is `DEPLOYED`, never when it's `FAILED`. A null date renders as epoch 0 in the frontend.

**Fix:** Move `setLastDeployedOn(new Date())` and `setDeployedOn(new Date())` outside the `DEPLOYED`-only guard so they are set for **both** DEPLOYED and FAILED terminal statuses. Three locations in `DeploymentStatusMonitorJob.java` are updated:

1. `checkAndUpdateDeployment()` — `deployment.setLastDeployedOn()` moved before the `DEPLOYED` branch
2. `checkAndUpdateDeployment()` — `latestAudit.setDeployedOn()` guard removed
3. `updateBuildDeployAuditLog()` — `audit.setDeployedOn()` guard removed

## Review & Testing Checklist for Human

- [ ] **Verify no code reads `lastDeployedOn` assuming it means "last *successful* deployment"** — this field now also gets set on FAILED. Search for usages of `getLastDeployedOn()` and `getDeployedOn()` in the codebase (frontend and backend) to confirm the timestamp is used as "when did this deployment attempt finish" rather than "when was it last successfully deployed"
- [ ] **Test a failing deployment** — trigger a deployment that will fail (e.g., invalid image tag) and verify the timestamp shows the actual failure time, not 1/1/1970
- [ ] **Test a successful deployment** — confirm DEPLOYED still shows the correct timestamp (regression check)

### Notes
- This was originally part of PR #4976 but was pushed after that PR was already merged, so it needs a separate PR.
- The DEPLOYED-only fields (`lastDeployedBy`, `lastDeployedBranch`, `lastDeployedVersion`, `gitjobRunID`) remain guarded — only the timestamp is now shared across both terminal statuses.