### PR TITLE
fix: block private recipes for git.i repos, allow for GHE

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseRecipeService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseRecipeService.java
@@ -110,7 +110,23 @@ public class BaseRecipeService implements RecipeService{
 	
 	@Value("${codeServer.git.pat}")
 	private String gitIPat;
+
+	@Value("${codeServer.git.baseuri}")
+	private String gitBaseUri;
     
+	private boolean isGitIRepo(String repoUrl) {
+		if (repoUrl == null || gitBaseUri == null) {
+			return false;
+		}
+		try {
+			String host = new URI(gitBaseUri).getHost();
+			return host != null && repoUrl.contains(host);
+		} catch (Exception e) {
+			log.warn("Failed to parse gitBaseUri: {}", gitBaseUri, e);
+			return false;
+		}
+	}
+
 	@Override
 	@Transactional
 	public List<RecipeVO> getAllRecipes(int offset, int limit,String id) {
@@ -124,7 +140,13 @@ public RecipeVO createRecipe(RecipeVO recipeRequestVO) {
 
 	SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS+00:00");
 	String repoUrl = recipeRequestVO.getRepodetails();
-	
+
+	if (Boolean.FALSE.equals(recipeRequestVO.isIsPublic())
+			&& isGitIRepo(repoUrl)) {
+		throw new RuntimeException(
+				"Private recipes are not allowed for git.i repositories. Please set recipe visibility to Public.");
+	}
+
 	if (Boolean.TRUE.equals(recipeRequestVO.isIsPublic())
 			&& repoUrl != null
 			&& repoUrl.contains("ghe.com")) {
@@ -172,7 +194,13 @@ public RecipeVO updateRecipe(RecipeVO recipeRequestVO) {
 	SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS+00:00");
 
 	String repoUrl = recipeRequestVO.getRepodetails();
-	
+
+	if (Boolean.FALSE.equals(recipeRequestVO.isIsPublic())
+			&& isGitIRepo(repoUrl)) {
+		throw new RuntimeException(
+				"Private recipes are not allowed for git.i repositories. Please set recipe visibility to Public.");
+	}
+
 	if (Boolean.TRUE.equals(recipeRequestVO.isIsPublic())
 			&& repoUrl != null
 			&& repoUrl.contains("ghe.com")) {
@@ -383,6 +411,14 @@ public GenericMessage validateGitHubUrl(String gitHubUrl) {
 			
 			status = gitClient.validateGitUserWithPid(
 					gitUrl, repoName, applicationName, configuredPid, ghePat);
+		} else if (isGitIRepo(gitHubUrl)) {
+			log.info("git.i repo detected – private recipes not allowed");
+
+			MessageDescription gitIWarning = new MessageDescription();
+			gitIWarning.setMessage("GIT_I_REPO_DETECTED");
+			responseMessage.addWarnings(gitIWarning);
+
+			return responseMessage;
 		} else {
 			log.info("Non-GHE repo detected – skipping PID validation");
 			return responseMessage;

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.9.6
+    version: 1.9.7
   profile:
     active: production
 

--- a/packages/code-space-mfe/package.json
+++ b/packages/code-space-mfe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-space-mfe",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "private": true,
   "scripts": {
     "start": "env-cmd -f .env webpack server --config config/webpack.config.js",

--- a/packages/code-space-mfe/src/components/codeSpaceRecipe/CodeSpaceRecipe.js
+++ b/packages/code-space-mfe/src/components/codeSpaceRecipe/CodeSpaceRecipe.js
@@ -40,6 +40,7 @@ const CodeSpaceRecipe = (props) => {
   const [gitRepoLoc, setGitRepoLoc] = useState('');
   const [deployPath, setDeployPath] = useState('');
   const [isGheRepo, setIsGheRepo] = useState(false);
+  const [isGitIRepo, setIsGitIRepo] = useState(false);
   
   const [diskSpace, setDiskSpace] = useState('');
   const [minCpu, setMinCpu] = useState('0.5');
@@ -168,6 +169,12 @@ const CodeSpaceRecipe = (props) => {
     }
   }, [isGheRepo]);
 
+  useEffect(() => {
+    if (isGitIRepo && !isPublic) {
+      setIsPublic(true);
+    }
+  }, [isGitIRepo]);
+
   const onRecipeNameChange = (e) => {
     const value = e.currentTarget.value;
     setRecipeName(value);
@@ -185,9 +192,18 @@ const CodeSpaceRecipe = (props) => {
   const isGhe = githubUrlVal.toLowerCase().includes('ghe');
   setIsGheRepo(isGhe);
 
+  const gitIHost = Envs.CODE_SPACE_GIT_PAT_APP_URL ? new URL(Envs.CODE_SPACE_GIT_PAT_APP_URL).host : '';
+  const isGitI = gitIHost && githubUrlVal.includes(gitIHost);
+  setIsGitIRepo(isGitI);
+
   if (isGhe && isPublic) {
     setIsPublic(false);
     Notification.show('GHE repositories must use Private visibility.', 'alert');
+  }
+
+  if (isGitI && !isPublic) {
+    setIsPublic(true);
+    Notification.show('git.i repositories must use Public visibility.', 'alert');
   }
 
   const errorText = githubUrlVal.length
@@ -272,6 +288,10 @@ const CodeSpaceRecipe = (props) => {
     Notification.show('GHE repositories cannot be set to Public visibility. Please use Private.', 'alert');
     return;
   }
+  if (currentValue === 'false' && isGitIRepo) {
+    Notification.show('git.i repositories cannot be set to Private visibility. Please use Public.', 'alert');
+    return;
+  }
   if (currentValue === 'true') {
     setIsPublic(true);
     setNotificationMsg(true);
@@ -305,7 +325,11 @@ const CodeSpaceRecipe = (props) => {
         if (response?.data.success === 'SUCCESS') {
           if (isGheRepo) {
             setIsPublic(false);
-          }    
+          }
+          if (response?.data?.warnings?.some(w => w.message === 'GIT_I_REPO_DETECTED')) {
+            setIsGitIRepo(true);
+            setIsPublic(true);
+          }
           setEnableCreate(true);
         } else {
           setEnableCreate(false);
@@ -578,15 +602,16 @@ const CodeSpaceRecipe = (props) => {
                                 name="isPublic"
                                 checked={isPublic === false}
                                 onChange={onIsPublicChange}
+                                disabled={isGitIRepo || edit}
                               />
                             </span>
                             <span className="label">Private</span>
                           </label>
                         </div>
-                        {isGheRepo && (
+                        {isGitIRepo && (
                           <p className={Styles.warning}>
                             <i className="icon mbc-icon alert circle" />
-                            <span>GHE repositories must use Private visibility for security compliance.</span>
+                            <span>git.i repositories must use Public visibility. Private recipes are not allowed.</span>
                           </p>
                         )}
                       </div>


### PR DESCRIPTION


**Backend (`BaseRecipeService.java`):**
- Adds `isGitIRepo()` helper that extracts the hostname from `gitBaseUri` via `URI.getHost()` and checks `repoUrl.contains(host)`
- Blocks private recipe creation in both `createRecipe()` and `updateRecipe()` — throws `RuntimeException` when `isPublic=false` and repo is git.i
- Returns a `GIT_I_REPO_DETECTED` warning from `validateGitHubUrl()` so the frontend can detect git.i repos during URL validation

**Frontend (`CodeSpaceRecipe.js`):**
- Detects git.i repos by parsing `Envs.CODE_SPACE_GIT_PAT_APP_URL` host and matching against the entered URL
- Forces `isPublic=true` and disables the "Private" radio button for git.i repos
- Replaces the old GHE visibility warning with a git.i-specific warning
- Handles `GIT_I_REPO_DETECTED` backend warning in the verify response
