### PR TITLE
fix: validate projectId exists in adaprojects table before workspace association

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/adaProjects/BaseADAProjectsService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/adaProjects/BaseADAProjectsService.java
@@ -135,6 +135,15 @@ public class BaseADAProjectsService extends BaseCommonService<ADAProjectDetailsV
 	public GenericMessage createWorkspaceProjectAssociation(FabricWorkspaceVO workspace, String projectId) {
 		
 		try {
+			ADAProjectsNsql adaProject = customRepo.findbyUniqueLiteral("projectID", projectId);
+			if (adaProject == null || adaProject.getData() == null || adaProject.getData().getProjectID() == null) {
+				log.error("ADA Project with projectID {} not found in adaprojects table", projectId);
+				GenericMessage message = new GenericMessage("ERROR");
+				message.setErrors(List.of(new MessageDescription("ADA Project with projectID " + projectId + " not found in adaprojects table")));
+				return message;
+			}
+			log.info("Validated projectID {} exists in adaprojects table", projectId);
+
 			Optional<FabricWorkspaceNsql> existingEntityOpt = fabricWorkspaceRepo.findById(workspace.getId());
 			if (existingEntityOpt.isPresent()) {
 				FabricWorkspaceNsql existingEntity = existingEntityOpt.get();


### PR DESCRIPTION
## Summary

Adds a service-layer validation in `createWorkspaceProjectAssociation` that checks whether the given `projectId` actually exists in the `adaprojects` table (via `ADAProjectsNsql` / `ADAProjectDetails.projectID`) **before** associating it with the workspace. If the project is not found, the method returns an error immediately instead of proceeding with the association.

This is a defense-in-depth check — the controller already validates the project exists (line 302 of `ADAProjectsController`), but the service method previously trusted the caller and would associate any arbitrary string as `projectId` without verification.

## Review & Testing Checklist for Human

- [ ] **Verify the HTTP status returned on validation failure is acceptable.** When this new check fails, `createWorkspaceProjectAssociation` returns `GenericMessage("ERROR")`, and the controller maps that to HTTP 500 (line 324). A "project not found" scenario arguably warrants a 404 instead. Decide whether the controller should inspect the error message or whether the service should signal "NOT_FOUND" differently.
- [ ] **Confirm the duplicate DB query is acceptable.** The controller already calls `getByUniqueliteral("projectID", ...)` before invoking `createWorkspaceProjectAssociation`. This adds a second identical query to the same transaction. If this is called at high volume, the extra round-trip may matter — but for a workspace association API this is likely fine.
- [ ] **Test end-to-end:** Call the association API with a valid workspace ID but a non-existent `projectId` and verify you get a clear error response (not a silent success). Then call with valid IDs and confirm the association persists correctly.
