### PR TITLE
fix: make fabric owner onboarding async to prevent readiness probe failure

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/config/SchedulerConfig.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/config/SchedulerConfig.java
@@ -33,12 +33,14 @@ import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import javax.sql.DataSource;
 
 @Configuration
 @EnableScheduling
+@EnableAsync
 @EnableSchedulerLock(defaultLockAtMostFor = "30m")
 public class SchedulerConfig {
     @Bean

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/WorkspaceBackgroundJobsService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/WorkspaceBackgroundJobsService.java
@@ -7,8 +7,11 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import javax.annotation.PostConstruct;
 import javax.transaction.Transactional;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -61,7 +64,8 @@ public class WorkspaceBackgroundJobsService {
 	private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 	private SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS+00:00");
 	
-	@PostConstruct
+	@Async
+	@EventListener(ApplicationReadyEvent.class)
 	public void initForEnablingExistingOwnersToFabricRole() {
 		if(enableOwnersOnboardingToFabricRoleOnStartup!=null && enableOwnersOnboardingToFabricRoleOnStartup.equalsIgnoreCase("true")) {
 			FabricWorkspacesCollectionVO collection = fabricService.getAllLov(0,0);


### PR DESCRIPTION
## Summary

The `@PostConstruct` method `initForEnablingExistingOwnersToFabricRole` in `WorkspaceBackgroundJobsService` runs synchronously during Spring bean initialization, blocking the application context from fully starting. This prevents actuator health endpoints (`/actuator/health/liveness`, `/actuator/health/readiness`) from becoming available before Kubernetes probe timeouts expire, causing the pod to crash-loop.

This PR replaces `@PostConstruct` with `@Async` + `@EventListener(ApplicationReadyEvent.class)` so that:
1. The application context finishes startup and health endpoints become available immediately.
2. The owner onboarding runs **after** full startup, on a separate thread managed by Spring's async executor.

`@EnableAsync` is added to `SchedulerConfig` to activate Spring's async method execution support.

## Review & Testing Checklist for Human

- [ ] **Verify in a K8s environment** that readiness/liveness probes now pass consistently on pod startup (the core bug this fixes).
- [ ] **Verify owner onboarding still executes** — confirm logs show the onboarding loop running after startup when `fabricWorkspaces.startup.onboardOwnersToFabricOperationsRole=true`. Since `@Async` runs on a different thread, exceptions won't propagate to the main thread; check that the existing per-workspace try/catch logging is sufficient for observability.
- [ ] **Confirm `@Async` proxy behavior** — `@Async` only works when invoked through the Spring proxy (not via self-invocation). This method is triggered by the event listener, not called internally, so it should be fine — but verify no other code path calls this method directly on `this`.
- [ ] **Thread pool defaults** — `@EnableAsync` without a custom executor uses `SimpleAsyncTaskExecutor` (unbounded, no thread reuse). This is acceptable for a one-shot startup task, but confirm it doesn't interfere with the existing `@Scheduled` tasks or ShedLock behavior in `WorkspaceBackgroundJobsService`.

**Recommended test plan:** Deploy to a staging K8s cluster with the `fabricWorkspaces.startup.workspaceprovisioning=true` flag enabled. Observe that the pod passes readiness probes within the configured timeout, and that owner onboarding log lines appear shortly after the "Started Application" log.

### Notes
- No logic changes to the onboarding method itself — only the invocation mechanism changed.
- The `@ConditionalOnProperty` guard on the class ensures the event listener only fires when workspace provisioning is enabled.