### PR TITLE
fix: allow GHE public repos and block all git.i repo creation

### DIFF
--- a/packages/code-space-mfe/src/components/codeSpaceRecipe/CodeSpaceRecipe.js
+++ b/packages/code-space-mfe/src/components/codeSpaceRecipe/CodeSpaceRecipe.js
@@ -163,11 +163,6 @@ const CodeSpaceRecipe = (props) => {
       });
   }, []);
 
-  useEffect(() => {
-    if (isGheRepo && isPublic) {
-      setIsPublic(false);
-    }
-  }, [isGheRepo]);
 
   useEffect(() => {
     if (isGitIRepo && !isPublic) {
@@ -195,11 +190,6 @@ const CodeSpaceRecipe = (props) => {
   const gitIHost = Envs.CODE_SPACE_GIT_PAT_APP_URL ? new URL(Envs.CODE_SPACE_GIT_PAT_APP_URL).host : '';
   const isGitI = gitIHost && githubUrlVal.includes(gitIHost);
   setIsGitIRepo(isGitI);
-
-  if (isGhe && isPublic) {
-    setIsPublic(false);
-    Notification.show('GHE repositories must use Private visibility.', 'alert');
-  }
 
   if (isGitI) {
     setIsPublic(true);
@@ -284,10 +274,6 @@ const CodeSpaceRecipe = (props) => {
   const onIsPublicChange = (e) => {
   const currentValue = e.currentTarget.value;
   
-  if (currentValue === 'true' && isGheRepo) {
-    Notification.show('GHE repositories cannot be set to Public visibility. Please use Private.', 'alert');
-    return;
-  }
   if (currentValue === 'false' && isGitIRepo) {
     Notification.show('Only repos from GHE is allowed.', 'alert');
     return;
@@ -323,9 +309,6 @@ const CodeSpaceRecipe = (props) => {
       .then((response) => {
         ProgressIndicator.hide();
         if (response?.data.success === 'SUCCESS') {
-          if (isGheRepo) {
-            setIsPublic(false);
-          }
           if (response?.data?.warnings?.some(w => w.message === 'GIT_I_REPO_DETECTED')) {
             setIsGitIRepo(true);
             setIsPublic(true);

--- a/packages/code-space-mfe/src/components/codeSpaceRecipe/CodeSpaceRecipe.js
+++ b/packages/code-space-mfe/src/components/codeSpaceRecipe/CodeSpaceRecipe.js
@@ -201,7 +201,7 @@ const CodeSpaceRecipe = (props) => {
     Notification.show('GHE repositories must use Private visibility.', 'alert');
   }
 
-  if (isGitI && !isPublic) {
+  if (isGitI) {
     setIsPublic(true);
     Notification.show('Only repos from GHE is allowed.', 'alert');
   }


### PR DESCRIPTION
## Summary

Two frontend behavior changes in the recipe creation form (`CodeSpaceRecipe.js`):

1. Allow GHE repos to be Public** — Removes all logic that forced GHE repositories to Private visibility:
 
2. Block all git.i repo creation unconditionally