### PR TITLE
Add UiLiciousClient to fabric-backend with service principal name and integrate after CDC push

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/UiLiciousClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/UiLiciousClient.java
@@ -1,0 +1,243 @@
+package com.daimler.data.application.client;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class UiLiciousClient {
+
+    private final RestTemplate restTemplate;
+
+    private static final int POLL_MAX_ATTEMPTS = 30;
+    private static final long POLL_INTERVAL_MS = 2000L;
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${uilicious.email}")
+    private String email;
+
+    @Value("${uilicious.password}")
+    private String password;
+
+    @Value("${uilicious.accessKey}")
+    private String accessKey;
+
+    @Value("${uilicious.browser:firefox}")
+    private String browser;
+
+    @Value("${uilicious.width:1280}")
+    private String width;
+
+    @Value("${uilicious.height:800}")
+    private String height;
+
+    @Value("${uilicious.filePath}")
+    private String filePath;
+
+    @Value("${uilicious.projectID}")
+    private String projectID;
+
+    @Value("${uilicious.baseURL}")
+    private String baseURL;
+
+    @Value("${uilicious.servicePrincipalName}")
+    private String defaultServicePrincipalName;
+
+    @Autowired
+    public UiLiciousClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public String addServicePrincipalToLakehouse(String workspaceId, String lakehouseId,
+            String workspaceName, String lakehouseName, String servicePrincipalName) {
+
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put("email", email);
+        dataMap.put("password", password);
+        dataMap.put("WorkspaceName", workspaceName);
+        dataMap.put("WorkspaceID", workspaceId);
+        dataMap.put("Lakehouse", lakehouseName);
+        dataMap.put("LakehouseID", lakehouseId);
+
+        String effectiveServicePrincipalName = (servicePrincipalName != null && !servicePrincipalName.trim().isEmpty())
+                ? servicePrincipalName
+                : this.defaultServicePrincipalName;
+        dataMap.put("servicePrincipal", effectiveServicePrincipalName);
+
+        String data;
+        try {
+            data = objectMapper.writeValueAsString(dataMap);
+        } catch (Exception e) {
+            log.error("Error serializing data to JSON: {}", e.getMessage());
+            return null;
+        }
+
+        log.info("UiLicious request for workspaceId: {}, lakehouseId: {}, servicePrincipal: {}",
+                workspaceId, lakehouseId, effectiveServicePrincipalName);
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("projectID", projectID);
+        requestBody.put("filePath", filePath);
+        requestBody.put("data", data);
+        requestBody.put("browser", browser);
+        requestBody.put("width", width);
+        requestBody.put("height", height);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("accessKey", accessKey);
+
+        JsonNode response = callUiLiciousApi(baseURL + "start", JsonNode.class, requestBody, HttpMethod.POST, headers);
+        if (response == null || response.get("result") == null || response.get("result").get("testRunIDs") == null) {
+            log.warn("UiLicious start response did not contain testRunIDs for workspaceId: {} and lakehouseId: {}",
+                    workspaceId, lakehouseId);
+            return null;
+        }
+
+        JsonNode testRunIDsJson = response.get("result").get("testRunIDs");
+
+        List<String> testRunIDsList = objectMapper.convertValue(
+                testRunIDsJson,
+                new TypeReference<List<String>>() {
+                });
+
+        if (testRunIDsList.isEmpty()) {
+            log.warn("No test run ID returned from UiLicious API for workspaceId: {} and lakehouseId: {}",
+                    workspaceId, lakehouseId);
+            return null;
+        }
+
+        return testRunIDsList.get(0);
+    }
+
+    public void triggerTestRun(String projectID, String filePath, String data, String browser,
+            String width, String height, String accessKey) {
+        if (projectID == null || projectID.trim().isEmpty()) {
+            throw new IllegalArgumentException("projectID is required");
+        }
+        if (filePath == null || filePath.trim().isEmpty()) {
+            throw new IllegalArgumentException("filePath is required");
+        }
+        if (data == null) {
+            throw new IllegalArgumentException("data is required");
+        }
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("projectID", projectID);
+        requestBody.put("filePath", filePath);
+        requestBody.put("data", data);
+        requestBody.put("browser", browser != null ? browser : this.browser);
+        requestBody.put("width", width != null ? width : this.width);
+        requestBody.put("height", height != null ? height : this.height);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (accessKey != null && !accessKey.trim().isEmpty()) {
+            headers.set("accessKey", accessKey);
+        } else {
+            headers.set("accessKey", this.accessKey);
+        }
+
+        try {
+            callUiLiciousApi(baseURL + "start", JsonNode.class, requestBody, HttpMethod.POST, headers);
+            log.info("UiLicious test run triggered successfully for projectID: {}, filePath: {}", projectID, filePath);
+        } catch (Exception e) {
+            log.error("Error triggering UiLicious test run for projectID {}, filePath {}: {}",
+                    projectID, filePath, e.getMessage());
+            throw new RuntimeException("Error triggering UiLicious test run", e);
+        }
+    }
+
+    private JsonNode pollUntilFinalStatus(String testRunId, HttpHeaders headers) {
+        Map<String, Object> statusRequest = new HashMap<>();
+        statusRequest.put("id", testRunId);
+        JsonNode lastResponse = null;
+
+        for (int attempt = 1; attempt <= POLL_MAX_ATTEMPTS; attempt++) {
+            lastResponse = callUiLiciousApi(baseURL + "get", JsonNode.class, statusRequest, HttpMethod.POST, headers);
+            String status = extractRunStatus(lastResponse);
+            log.info("UiLicious poll attempt {} for testRunId {} returned status {}", attempt, testRunId, status);
+
+            if (isTerminalStatus(status)) {
+                return lastResponse;
+            }
+
+            try {
+                Thread.sleep(POLL_INTERVAL_MS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                log.warn("UiLicious polling interrupted for testRunId {}", testRunId);
+            }
+        }
+
+        return lastResponse;
+    }
+
+    private String extractRunStatus(JsonNode response) {
+        if (response == null) {
+            return "";
+        }
+        String nestedStatus = response.path("result").path("result").path("status").asText("");
+        if (nestedStatus != null && !nestedStatus.isEmpty()) {
+            return nestedStatus.toLowerCase();
+        }
+        String topLevelStatus = response.path("result").path("status").asText("");
+        return topLevelStatus == null ? "" : topLevelStatus.toLowerCase();
+    }
+
+    private boolean isTerminalStatus(String status) {
+        if (status == null) {
+            return false;
+        }
+        return "success".equals(status) || "failed".equals(status) || "error".equals(status)
+                || "aborted".equals(status) || "stopped".equals(status) || "cancelled".equals(status);
+    }
+
+    private <T> T callUiLiciousApi(String url, Class<T> responseType, Map<String, Object> requestBody,
+            HttpMethod method, HttpHeaders headers) {
+        try {
+            String jsonBody = objectMapper.writeValueAsString(requestBody);
+
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            HttpEntity<String> requestEntity = new HttpEntity<>(jsonBody, headers);
+
+            ResponseEntity<T> response = restTemplate.exchange(
+                    url,
+                    method,
+                    requestEntity,
+                    responseType);
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return response.getBody();
+            } else {
+                log.warn("Received non-OK response from UiLicious API: {}", response.getStatusCode());
+                return null;
+            }
+        } catch (Exception e) {
+            log.error("Error calling UiLicious API at {}: {}", url, e.getMessage());
+            throw new RuntimeException("Error calling UiLicious API", e);
+        }
+    }
+
+}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseDdxOnboardingService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseDdxOnboardingService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 // import com.databricks.sdk.service.sql.StatementResponse;
 // import com.databricks.sdk.WorkspaceClient;
 import com.daimler.data.application.client.FabricWorkspaceClient;
+import com.daimler.data.application.client.UiLiciousClient;
 import com.daimler.data.assembler.FabricWorkspaceAssembler;
 import com.daimler.data.assembler.DdxDataProductsDetailsAssembler;
 import com.daimler.data.controller.exceptions.GenericMessage;
@@ -67,6 +68,9 @@ public class BaseDdxOnboardingService implements DdxOnboardingService {
 
     @Autowired
     private FabricWorkspaceClient fabricWorkspaceClient;
+
+    @Autowired
+    private UiLiciousClient uiLiciousClient;
 
     @Autowired
     private AzureTokenService azureTokenService;
@@ -398,9 +402,24 @@ public class BaseDdxOnboardingService implements DdxOnboardingService {
                 return DdxOnboardingResultDto.builder().responseMessage(responseMessage).ddxResponse(ddxResponse).build();
             }
 
-            // 11. Success Response
+            // 11. Trigger UiLicious test run after successful CDC push
+            log.info("Triggering UiLicious service principal addition for workspace: {} and lakehouse: {}", workspaceId, lakehouseId);
+            try {
+                String testRunId = uiLiciousClient.addServicePrincipalToLakehouse(
+                        workspaceId, lakehouseId, workspaceName, fabricDatabaseName, null);
+                if (testRunId != null) {
+                    log.info("UiLicious test run triggered successfully with testRunId: {} for workspace: {} and lakehouse: {}",
+                            testRunId, workspaceId, lakehouseId);
+                } else {
+                    log.warn("UiLicious test run returned null testRunId for workspace: {} and lakehouse: {}", workspaceId, lakehouseId);
+                }
+            } catch (Exception e) {
+                log.error("Failed to trigger UiLicious test run for workspace: {} and lakehouse: {}", workspaceId, lakehouseId, e);
+            }
+
+            // 12. Success Response
             responseMessage.setSuccess("SUCCESS");
-            log.info("✅ Successfully onboarded product: {} to DDX for workspace: {}. DataProductId: {}, DofUrl: {}",
+            log.info("Successfully onboarded product: {} to DDX for workspace: {}. DataProductId: {}, DofUrl: {}",
                 publishDdxRequest.getDataProductName(), workspaceId, onboardingResponse.getDataProductId(), onboardingResponse.getDofUrl());
 
         } catch (IllegalArgumentException e) {

--- a/packages/fabric-backend/lib/src/main/resources/application.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application.yml
@@ -161,6 +161,18 @@ ddxIntegration:
     scope: ${DDX_OAUTH_SCOPE:XXXX}
     tenantId: ${DDX_OAUTH_TENANT_ID:XXXX}
 
+uilicious:
+  email: ${UILICIOUS_EMAIL:XXXX}
+  password: ${UILICIOUS_PASSWORD:XXXX}
+  accessKey: ${UILICIOUS_ACCESS_KEY:XXXX}
+  browser: ${UILICIOUS_BROWSER:firefox}
+  width: ${UILICIOUS_WIDTH:1280}
+  height: ${UILICIOUS_HEIGHT:800}
+  filePath: ${UILICIOUS_FILE_PATH:XXXX}
+  projectID: ${UILICIOUS_PROJECT_ID:XXXX}
+  baseURL: ${UILICIOUS_BASE_URL:XXXX}
+  servicePrincipalName: ${UILICIOUS_SERVICE_PRINCIPAL_NAME:XXXX}
+
 databricksIntegration:
   url:
     base: ${DATABRICKS_BASE_URL:XXXX}


### PR DESCRIPTION
## Summary

Adds a new `UiLiciousClient` to the `fabric-backend` package and integrates it into the DDX onboarding flow. After the CDC push (DDX product onboarding) completes successfully in `BaseDdxOnboardingService.onboardToDdx()`, the client triggers a UiLicious test run that adds a **service principal** to the lakehouse — replacing the previous groups-based approach.

**Key changes:**
- **`UiLiciousClient.java`** (new): HTTP client that calls the UiLicious API to trigger a test run with workspace/lakehouse details and a service principal name. All secrets/config are injected via `@Value` from environment variables.
- **`BaseDdxOnboardingService.java`**: Injects `UiLiciousClient` and calls `addServicePrincipalToLakehouse()` as step 11, after DDX lakehouse details are updated. The call is wrapped in try-catch so UiLicious failures do **not** fail the onboarding.
- **`application.yml`**: Adds `uilicious.*` config block with env var placeholders for all required properties.

## Review & Testing Checklist for Human

- [ ] **Verify `RestTemplate` bean is appropriate**: The client injects the plain `restTemplate` bean. `FabricWorkspaceClient` uses `proxyRestTemplate` for external calls. If UiLicious is behind a corporate proxy, the plain `restTemplate` may not reach it — check whether `proxyRestTemplate` should be used instead.
- [ ] **Confirm `null` for servicePrincipalName is intentional**: In `BaseDdxOnboardingService` line 409, `null` is always passed as the service principal name, which means the config default (`UILICIOUS_SERVICE_PRINCIPAL_NAME`) is always used. Verify this is the desired behavior vs. deriving it from the request context.
- [ ] **Synchronous call inside `@Transactional` method**: The UiLicious API call runs synchronously within the transactional `onboardToDdx()`. If the API is slow or unreachable, it will add latency to the DDX onboarding response (though it won't cause failure). Consider whether this should be async.
- [ ] **Dead code**: `pollUntilFinalStatus()` and `triggerTestRun()` are defined but unused in this PR. Confirm whether they are needed for future use or should be removed.
- [ ] **Set all `UILICIOUS_*` environment variables** before deploying — the app will fail to start without them since required properties have no real defaults.

**Recommended test plan:** Deploy to a dev environment with all `UILICIOUS_*` env vars configured. Trigger a DDX publish/onboard and verify (1) the onboarding completes successfully, (2) UiLicious test run is triggered (check logs for `testRunId`), and (3) the service principal appears in the lakehouse.

### Notes
- The Gradle build compiles successfully with only pre-existing warnings (no new errors introduced).
- `email` and `password` are sent inside the UiLicious `data` payload by design (used by the UiLicious test script for authentication). These values come from env vars, not hardcoded.