### PR TITLE
fix: enable Public radio button for GHE repos

### DIFF
--- a/packages/code-space-mfe/src/components/codeSpaceRecipe/CodeSpaceRecipe.js
+++ b/packages/code-space-mfe/src/components/codeSpaceRecipe/CodeSpaceRecipe.js
@@ -571,7 +571,7 @@ const CodeSpaceRecipe = (props) => {
                                 name="isPublic"
                                 checked={isPublic === true}
                                 onChange={onIsPublicChange}
-                                disabled={isGheRepo || edit}
+                                disabled={edit}
                               />
                             </span>
                             <span className="label">Public</span>


### PR DESCRIPTION
## Summary

Removes `isGheRepo` from the `disabled` prop on the Public radio button in the recipe creation form (`CodeSpaceRecipe.js`, line 574). Previously, the Public radio button was HTML-disabled whenever a GHE repo URL was detected, preventing users from selecting Public visibility for GHE recipes.
