### PR TITLE
Fix CDC error handling: distinguish user-not-found from connection errors

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/OpenMetadataClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/OpenMetadataClient.java
@@ -45,8 +45,11 @@ public class OpenMetadataClient {
         try {
             return apiClient.buildClient(UsersApi.class)
                     .getUserByFQN(username, null, null);
-        } catch (Exception e) {
+        } catch (FeignException.NotFound e) {
             throw new EntityNotFoundException("User", username);
+        } catch (Exception e) {
+            log.error("Failed to look up user in CDC: {} - {}", username, e.getMessage());
+            throw new OpenMetadataClientException("Failed to look up user in CDC: " + username + " - " + e.getMessage(), e);
         }
     }
 

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricCatalogManagementController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricCatalogManagementController.java
@@ -26,6 +26,7 @@ import com.daimler.data.application.client.OpenMetadataClient;
 import com.daimler.data.controller.exceptions.DDXGroupsResponseMessage;
 import com.daimler.data.controller.exceptions.EntityNotFoundException;
 import com.daimler.data.controller.exceptions.GenericMessage;
+import com.daimler.data.controller.exceptions.OpenMetadataClientException;
 import com.daimler.data.controller.exceptions.MessageDescription;
 import com.daimler.data.db.entities.FabricCatalogMetadataNsql;
 import com.daimler.data.db.json.catalogManangement.FabricCatalogMetadata;
@@ -145,6 +146,18 @@ public class FabricCatalogManagementController implements FabricCatalogManagemen
 			responseVO.setResponses(failedResponse);
 			log.error("User:{} didnt logged into cdc {} ", userStore.getUserInfo().getId(), e.getMessage());
 			return new ResponseEntity<>(responseVO, HttpStatus.BAD_REQUEST);
+        } catch (OpenMetadataClientException e) {
+            GenericMessage failedResponse = new GenericMessage();
+			List<MessageDescription> messages = new ArrayList<>();
+			MessageDescription message = new MessageDescription();
+			message.setMessage("Failed to publish fabric workspace catalog : unable to connect to cdc");
+			messages.add(message);
+			failedResponse.addErrors(message);
+			failedResponse.setSuccess("FAILED");
+            responseVO.setData(null);
+			responseVO.setResponses(failedResponse);
+			log.error("CDC connection error while publishing catalog for user:{} - {}", userStore.getUserInfo().getId(), e.getMessage());
+			return new ResponseEntity<>(responseVO, HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             GenericMessage failedResponse = new GenericMessage();
 			List<MessageDescription> messages = new ArrayList<>();
@@ -275,6 +288,18 @@ public class FabricCatalogManagementController implements FabricCatalogManagemen
 			responseVO.setResponses(failedResponse);
 			log.error("User:{} didnt logged into cdc {} ", userStore.getUserInfo().getId(), e.getMessage());
 			return new ResponseEntity<>(responseVO, HttpStatus.BAD_REQUEST);
+        } catch (OpenMetadataClientException e) {
+            GenericMessage failedResponse = new GenericMessage();
+			List<MessageDescription> messages = new ArrayList<>();
+			MessageDescription message = new MessageDescription();
+			message.setMessage("Failed to update fabric workspace catalog : unable to connect to cdc");
+			messages.add(message);
+			failedResponse.addErrors(message);
+			failedResponse.setSuccess("FAILED");
+            responseVO.setData(null);
+			responseVO.setResponses(failedResponse);
+			log.error("CDC connection error while updating catalog for user:{} - {}", userStore.getUserInfo().getId(), e.getMessage());
+			return new ResponseEntity<>(responseVO, HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             GenericMessage failedResponse = new GenericMessage();
 			List<MessageDescription> messages = new ArrayList<>();


### PR DESCRIPTION
## Summary

`OpenMetadataClient.getUserByFqn()` previously caught **all** exceptions and threw `EntityNotFoundException`, which the controller mapped to the message `"user didn't log in to cdc"`. This masked real errors like proxy failures, connection timeouts, and DNS resolution issues — all of which are likely occurring because the new global proxy config in this branch routes CDC traffic through the proxy.

This PR splits the catch block:
- **`FeignException.NotFound`** (HTTP 404) → still throws `EntityNotFoundException` → `"user didn't log in to cdc"` (genuine case)
- **All other exceptions** → throws `OpenMetadataClientException` → `"unable to connect to cdc"` (connectivity/proxy issue)

The new `OpenMetadataClientException` catch is added to both `publishCatalogRequest` and `updatePublishedCatalogRequest` in the controller.

**Note:** This improves error reporting but does not fix the underlying proxy issue. The OpenMetadata server hostname likely needs to be added to `PROXY_NO_PROXY_HOSTS` in the test environment.

## Review & Testing Checklist for Human

- [ ] Verify `FeignException.NotFound` is the correct Feign exception subclass for HTTP 404 in this project's Feign version (it's used elsewhere in the same file for `Conflict`/`BadRequest`, so likely correct)
- [ ] Confirm `OpenMetadataClientException` does **not** extend `EntityNotFoundException` — if it did, the catch ordering would silently misroute exceptions
- [ ] Test with a user that genuinely hasn't logged into CDC — should still return `"user didn't log in to cdc"` (400)
- [ ] Test with CDC unreachable (e.g., wrong proxy config) — should now return `"unable to connect to cdc"` (500) instead of the misleading login message
- [ ] Ensure the OpenMetadata server is added to `PROXY_NO_PROXY_HOSTS` in the test environment deployment config to fix the actual connectivity issue

### Notes
- The `FeignException` import was already present in `OpenMetadataClient.java` (line 22) and the same pattern (`FeignException.Conflict`, `FeignException.BadRequest`) is used in other methods in the same class.
- No unit tests are included — this is a small error-handling change, but manual verification of both code paths (404 vs connection error) is recommended.