### PR TITLE
refactor: replace Fabric API calls with DB lookup for workspace/lakehouse validation

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricCatalogManagementController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricCatalogManagementController.java
@@ -39,6 +39,7 @@ import com.daimler.data.dto.fabricCatalogManagement.LegalEntitiesResponseVO;
 import com.daimler.data.dto.fabricCatalogManagement.UpdateDDXGroupsRequestVO;
 import com.daimler.data.dto.fabricCatalogManagement.GroupStatusResponseVO;
 import com.daimler.data.dto.fabricWorkspace.CreatedByVO;
+import com.daimler.data.dto.fabricWorkspace.FabricLakehouseVO;
 import com.daimler.data.dto.fabricWorkspace.FabricWorkspaceVO;
 import com.daimler.data.service.catalogManagement.BaseFabricCatalogManagementService;
 import com.daimler.data.service.catalogManagement.FabricCatalogManagementService;
@@ -337,18 +338,11 @@ public class FabricCatalogManagementController implements FabricCatalogManagemen
         String lakehouseName = null;
         List<String> validGroupsList = new ArrayList<>();
         
-        // Validate workspace exists
+        // Validate workspace exists using fabric_workspace_nsql table
         try {
-            com.daimler.data.dto.fabric.WorkspacesCollectionDto workspaces = fabricWorkspaceClient.getAllWorkspacesDetails();
-            List<com.daimler.data.dto.fabric.WorkspaceDetailDto> matchingWorkspaceList = new ArrayList<>();
-            if (workspaces != null && workspaces.getValue() != null) {
-                matchingWorkspaceList = workspaces.getValue().stream()
-                    .filter(w -> w != null && workspaceId.equals(w.getId())).toList();
-            }
-            
-            if (matchingWorkspaceList.isEmpty()) {
-                String errorMsg = "Workspace not found";
-                log.error("Workspace {} not found or error: {}", workspaceId, errorMsg);
+            FabricWorkspaceVO existingWorkspace = fabricWorkspaceService.getById(workspaceId);
+            if (existingWorkspace == null || !workspaceId.equalsIgnoreCase(existingWorkspace.getId())) {
+                log.error("Workspace {} not found in database", workspaceId);
                 MessageDescription error = new MessageDescription();
                 error.setMessage("Workspace not found: " + workspaceId);
                 errors.add(error);
@@ -356,29 +350,18 @@ public class FabricCatalogManagementController implements FabricCatalogManagemen
                 responseMessage.setWarnings(warnings);
                 responseMessage.setSuccess("FAILED");
                 return new ResponseEntity<>(responseMessage, HttpStatus.NOT_FOUND);
-            } else {
-                workspaceName = matchingWorkspaceList.get(0).getDisplayName();
             }
-        } catch (Exception e) {
-            log.error("Error validating workspace {}: {}", workspaceId, e.getMessage());
-            MessageDescription error = new MessageDescription();
-            error.setMessage("Error validating workspace: " + e.getMessage());
-            errors.add(error);
-            responseMessage.setErrors(errors);
-            responseMessage.setWarnings(warnings);
-            responseMessage.setSuccess("FAILED");
-            return new ResponseEntity<>(responseMessage, HttpStatus.NOT_FOUND);
-        }
+            workspaceName = existingWorkspace.getName();
 
-        // Validate lakehouse exists
-        try {
-            com.daimler.data.dto.fabric.LakehouseCollectionDto lakehouses = fabricWorkspaceClient.listLakehouses(workspaceId);
-            List<com.daimler.data.dto.fabric.LakehouseDto> matchingLakehouseList = new ArrayList<>();
-            if (lakehouses != null && lakehouses.getValue() != null) {
-                matchingLakehouseList = lakehouses.getValue().stream()
-                    .filter(lh -> lh != null && lakehouseId.equals(lh.getId())).toList();
+            // Validate lakehouse exists using lakehouses from workspace VO
+            List<FabricLakehouseVO> lakehouses = existingWorkspace.getLakehouses();
+            FabricLakehouseVO matchingLakehouse = null;
+            if (lakehouses != null && !lakehouses.isEmpty()) {
+                matchingLakehouse = lakehouses.stream()
+                    .filter(lh -> lh != null && lakehouseId.equals(lh.getId()))
+                    .findFirst().orElse(null);
             }
-            if (matchingLakehouseList.isEmpty()) {
+            if (matchingLakehouse == null) {
                 log.error("Lakehouse {} not found in workspace {}", lakehouseId, workspaceId);
                 MessageDescription error = new MessageDescription();
                 error.setMessage("Lakehouse not found: " + lakehouseId + " in workspace: " + workspaceId);
@@ -387,13 +370,12 @@ public class FabricCatalogManagementController implements FabricCatalogManagemen
                 responseMessage.setWarnings(warnings);
                 responseMessage.setSuccess("FAILED");
                 return new ResponseEntity<>(responseMessage, HttpStatus.NOT_FOUND);
-            } else {
-                lakehouseName = matchingLakehouseList.get(0).getDisplayName();
             }
+            lakehouseName = matchingLakehouse.getName();
         } catch (Exception e) {
-            log.error("Error validating lakehouse {} in workspace {}: {}", lakehouseId, workspaceId, e.getMessage());
+            log.error("Error validating workspace {} or lakehouse {}: {}", workspaceId, lakehouseId, e.getMessage());
             MessageDescription error = new MessageDescription();
-            error.setMessage("Error validating lakehouse: " + e.getMessage());
+            error.setMessage("Error validating workspace/lakehouse: " + e.getMessage());
             errors.add(error);
             responseMessage.setErrors(errors);
             responseMessage.setWarnings(warnings);
@@ -618,39 +600,27 @@ public class FabricCatalogManagementController implements FabricCatalogManagemen
         String lakehouseName = null;
 
         try {
-            com.daimler.data.dto.fabric.WorkspacesCollectionDto workspaces = fabricWorkspaceClient.getAllWorkspacesDetails();
-            List<com.daimler.data.dto.fabric.WorkspaceDetailDto> matchingWorkspaceList = new ArrayList<>();
-            if (workspaces != null && workspaces.getValue() != null) {
-                matchingWorkspaceList = workspaces.getValue().stream()
-                    .filter(w -> w != null && workspaceId.equals(w.getId())).toList();
-            }
-            if (matchingWorkspaceList.isEmpty()) {
+            FabricWorkspaceVO existingWorkspace = fabricWorkspaceService.getById(workspaceId);
+            if (existingWorkspace == null || !workspaceId.equalsIgnoreCase(existingWorkspace.getId())) {
                 return new ResponseEntity<>(BaseFabricCatalogManagementService.buildGroupStatusListResponse(updateDDXGroupsRequest.getGroups(), ConstantsUtility.GROUPS_FAILED_CONSTANT), HttpStatus.NOT_FOUND);
-            } else {
-                workspaceName = matchingWorkspaceList.get(0).getDisplayName();
             }
-        } catch (Exception e) {
-            log.error("Error validating workspace {}: {}", workspaceId, e.getMessage());
-            return new ResponseEntity<>(BaseFabricCatalogManagementService.buildGroupStatusListResponse(updateDDXGroupsRequest.getGroups(), ConstantsUtility.GROUPS_FAILED_CONSTANT), HttpStatus.NOT_FOUND);
-        }
+            workspaceName = existingWorkspace.getName();
 
-        try {
-            com.daimler.data.dto.fabric.LakehouseCollectionDto lakehouses = fabricWorkspaceClient.listLakehouses(workspaceId);
-            List<com.daimler.data.dto.fabric.LakehouseDto> matchingLakehouseList = new ArrayList<>();
-            if (lakehouses != null && lakehouses.getValue() != null) {
-                matchingLakehouseList = lakehouses.getValue().stream()
-                    .filter(lh -> lh != null && lakehouseId.equals(lh.getId())).toList();
+            // Validate lakehouse from workspace VO
+            List<FabricLakehouseVO> lakehouses = existingWorkspace.getLakehouses();
+            FabricLakehouseVO matchingLakehouse = null;
+            if (lakehouses != null && !lakehouses.isEmpty()) {
+                matchingLakehouse = lakehouses.stream()
+                    .filter(lh -> lh != null && lakehouseId.equals(lh.getId()))
+                    .findFirst().orElse(null);
             }
-            if (matchingLakehouseList.isEmpty()) {
+            if (matchingLakehouse == null) {
                 log.error("Lakehouse {} not found in workspace {}", lakehouseId, workspaceId);
-                MessageDescription error = new MessageDescription();
                 return new ResponseEntity<>(BaseFabricCatalogManagementService.buildGroupStatusListResponse(updateDDXGroupsRequest.getGroups(), ConstantsUtility.GROUPS_FAILED_CONSTANT), HttpStatus.NOT_FOUND);
-            } else {
-                lakehouseName = matchingLakehouseList.get(0).getDisplayName();
             }
+            lakehouseName = matchingLakehouse.getName();
         } catch (Exception e) {
-            log.error("Error validating lakehouse {} in workspace {}: {}", lakehouseId, workspaceId, e.getMessage());
-            MessageDescription error = new MessageDescription();
+            log.error("Error validating workspace {} or lakehouse {}: {}", workspaceId, lakehouseId, e.getMessage());
             return new ResponseEntity<>(BaseFabricCatalogManagementService.buildGroupStatusListResponse(updateDDXGroupsRequest.getGroups(), ConstantsUtility.GROUPS_FAILED_CONSTANT), HttpStatus.NOT_FOUND);
         }
 


### PR DESCRIPTION
## Summary

Replaces two expensive Fabric API calls with a single database lookup in `FabricCatalogManagementController.java`. This affects two methods:

- **`updateGroupsFromDDX`**: Removed separate calls to `fabricWorkspaceClient.getAllWorkspacesDetails()` (which fetches ALL workspaces from the Fabric API) and `fabricWorkspaceClient.listLakehouses(workspaceId)`. Replaced with a single `fabricWorkspaceService.getById(workspaceId)` call that reads from the `fabric_workspace_nsql` DB table. Lakehouse validation now uses the lakehouses list already populated on the returned `FabricWorkspaceVO`.

- **`getGroupsAssignmentStatus`**: Same consolidation applied — two Fabric API calls replaced with one `getById()` DB lookup.

- Added import for `FabricLakehouseVO`.

Net effect: eliminates the expensive `getAllWorkspacesDetails()` call and consolidates workspace + lakehouse validation into a single `getById()` call (~30 lines removed).

## Review & Testing Checklist for Human

- [ ] **Verify `getName()` vs `getDisplayName()` equivalence**: The old code used `WorkspaceDetailDto.getDisplayName()` and `LakehouseDto.getDisplayName()` from the Fabric API DTOs. The new code uses `FabricWorkspaceVO.getName()` and `FabricLakehouseVO.getName()`. Confirm these return semantically equivalent values — downstream methods (`addWorkspaceGropusToLakehouse`, `getGroupsAssignmentStatus`) depend on correct names being passed.
- [ ] **Verify `getById()` populates the lakehouses list**: The new code assumes `existingWorkspace.getLakehouses()` is non-null and populated when `fabricWorkspaceService.getById()` is called. If the service does not eagerly load or refresh lakehouses, validation will always fail. Check the service implementation.
- [ ] **Run integration tests** covering the DDX group update endpoint (`updateGroupsFromDDX`) and group status endpoint (`getGroupsAssignmentStatus`) with valid and invalid workspace/lakehouse IDs.
- [ ] **Build verification**: No build or test suite was run during development due to environment constraints. Please run the full build locally.

### Notes
- This is a refactor-only change. No business logic changes — only the source of workspace/lakehouse data has changed (Fabric API → DB table).
- The `FabricWorkspaceVO` and `fabricWorkspaceService` were already used elsewhere in the codebase; this change brings these two methods in line with that pattern.

Link to Devin session: https://mercedes-benz.devinenterprise.com/sessions/fd3d305c6d4c4f4d85bd5a0cd3fce7f4