### PR TITLE
fix: replace all lossy VO-Entity round-trips with direct entity update

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/assembler/FabricWorkspaceAssembler.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/assembler/FabricWorkspaceAssembler.java
@@ -2,10 +2,10 @@ package com.daimler.data.assembler;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 
@@ -14,6 +14,7 @@ import com.daimler.data.db.entities.FabricWorkspaceNsql;
 import com.daimler.data.db.json.AuthoriserRoleDeatils;
 import com.daimler.data.db.json.Capacity;
 import com.daimler.data.db.json.CdcPublishedLakeHouseDetails;
+import com.daimler.data.db.json.DdxProduct;
 import com.daimler.data.db.json.EntitlementDetails;
 import com.daimler.data.db.json.FabricWorkspace;
 import com.daimler.data.db.json.FabricWorkspaceStatus;
@@ -28,6 +29,7 @@ import com.daimler.data.dto.fabric.LakehouseS3ShortcutDto;
 import com.daimler.data.dto.fabricWorkspace.CapacityVO;
 import com.daimler.data.dto.fabricWorkspace.CdcPublishedLakeHouseDetailsVO;
 import com.daimler.data.dto.fabricWorkspace.CreatedByVO;
+import com.daimler.data.dto.fabricWorkspace.DdxPublishedLakeHouseDetailsVO;
 import com.daimler.data.dto.fabricWorkspace.CustomGroupNameCollectionVO;
 import com.daimler.data.dto.fabricWorkspace.DnaRolesVO;
 import com.daimler.data.dto.fabricWorkspace.EntitlementDetailsVO;
@@ -48,6 +50,9 @@ import com.daimler.data.db.json.CustomGroupNameCollection;
 
 @Component
 public class FabricWorkspaceAssembler implements GenericAssembler<FabricWorkspaceVO, FabricWorkspaceNsql> {
+
+	@Autowired
+	private DdxDataProductsDetailsAssembler ddxAssembler;
 	
 	public FabricLakehouseVO toLakehouseVOFromDto(LakehouseDto lakehouseDto) {
 		FabricLakehouseVO vo = new FabricLakehouseVO();
@@ -169,7 +174,10 @@ public class FabricWorkspaceAssembler implements GenericAssembler<FabricWorkspac
 					vo.setCdcPublishedLakeHouseDetails(cdcPublishedLakeHouseDetails);
 				}
 				if (data.getDdxPublishedLakeHouseDetails() != null) {
-					vo.setDdxPublishedLakeHouseDetails(new ArrayList<>(data.getDdxPublishedLakeHouseDetails()));
+					List<DdxPublishedLakeHouseDetailsVO> ddxVOs = data.getDdxPublishedLakeHouseDetails().stream()
+						.map(ddxAssembler::toVo)
+						.collect(Collectors.toList());
+					vo.setDdxPublishedLakeHouseDetails(ddxVOs);
 				}
 			}
 		}
@@ -402,23 +410,12 @@ public class FabricWorkspaceAssembler implements GenericAssembler<FabricWorkspac
 				cdcLakehouseDetails.setIsLakeHousesPublishedToCdc(vo.getCdcPublishedLakeHouseDetails().isIsLakeHousesPublishedToCdc());
 				data.setCdcPublishedLakeHouseDetails(cdcLakehouseDetails);
 			}
-			// Extract lakehouse IDs from the VO's ddxPublishedLakeHouseDetails.
-			// The list may contain plain Strings (IDs) or enriched Maps with "lakeHouseId" field.
-			List<Object> ddxDetails = vo.getDdxPublishedLakeHouseDetails();
-			if (ddxDetails != null) {
-				List<String> lakehouseIds = new ArrayList<>();
-				for (Object item : ddxDetails) {
-					if (item instanceof String) {
-						lakehouseIds.add((String) item);
-					} else if (item instanceof Map) {
-						Map<?, ?> map = (Map<?, ?>) item;
-						Object idVal = map.get("lakeHouseId");
-						if (idVal != null) {
-							lakehouseIds.add(String.valueOf(idVal));
-						}
-					}
-				}
-				data.setDdxPublishedLakeHouseDetails(lakehouseIds);
+			if (vo.getDdxPublishedLakeHouseDetails() != null) {
+				List<DdxProduct> ddxProducts = vo.getDdxPublishedLakeHouseDetails().stream()
+					.filter(item -> item instanceof DdxPublishedLakeHouseDetailsVO)
+					.map(item -> ddxAssembler.toProduct((DdxPublishedLakeHouseDetailsVO) item))
+					.collect(Collectors.toList());
+				data.setDdxPublishedLakeHouseDetails(ddxProducts);
 			}
 			entity.setData(data);
 		}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/FabricWorkspace.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/FabricWorkspace.java
@@ -55,5 +55,5 @@ public class FabricWorkspace implements Serializable{
 	private String subscription;
 	private Date lastModifiedOn;
 	private CdcPublishedLakeHouseDetails cdcPublishedLakeHouseDetails;
-	private List<String> ddxPublishedLakeHouseDetails;
+	private List<DdxProduct> ddxPublishedLakeHouseDetails;
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/catalogManagement/BaseFabricCatalogManagementService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/catalogManagement/BaseFabricCatalogManagementService.java
@@ -12,8 +12,10 @@ import com.daimler.data.controller.exceptions.*;
 import com.daimler.data.db.entities.FabricCatalogMetadataNsql;
 import com.daimler.data.db.entities.FabricWorkspaceNsql;
 import com.daimler.data.db.entities.DdxDataProductsDetailsNsql;
+import com.daimler.data.db.json.CdcPublishedLakeHouseDetails;
 import com.daimler.data.db.json.DdxDataProductsDetail;
 import com.daimler.data.db.json.DdxProduct;
+import com.daimler.data.db.json.FabricWorkspace;
 import com.daimler.data.db.json.Fabric2FabricDetail;
 import com.daimler.data.db.json.GroupNameDetail;
 import com.daimler.data.db.json.GroupNameList;
@@ -596,17 +598,26 @@ public class BaseFabricCatalogManagementService extends BaseCommonService<Fabric
 
     private void updateLakeHouseDetails(FabricWorkspaceVO workspace, FabricCatalogMetadataVO metadata) {
         try {
-            CdcPublishedLakeHouseDetailsVO details = Optional.ofNullable(workspace.getCdcPublishedLakeHouseDetails())
-                .orElse(new CdcPublishedLakeHouseDetailsVO());
-                
-            details.setIsLakeHousesPublishedToCdc(true);
-            details.setPublishedLakeHouseNames(
-                metadata.getDatabases().stream()
-                    .map(DatabaseMetadataVO::getDbId)
-                    .collect(Collectors.toList()));
-            
-            workspace.setCdcPublishedLakeHouseDetails(details);
-            jpaRepo.save(assembler.toEntity(workspace));
+            List<String> publishedNames = metadata.getDatabases().stream()
+                .map(DatabaseMetadataVO::getDbId)
+                .collect(Collectors.toList());
+
+            Optional<FabricWorkspaceNsql> entityOpt = jpaRepo.findById(workspace.getId());
+            if (entityOpt.isPresent()) {
+                FabricWorkspaceNsql entity = entityOpt.get();
+                FabricWorkspace data = entity.getData();
+                if (data != null) {
+                    CdcPublishedLakeHouseDetails cdcDetails = data.getCdcPublishedLakeHouseDetails();
+                    if (cdcDetails == null) {
+                        cdcDetails = new CdcPublishedLakeHouseDetails();
+                    }
+                    cdcDetails.setIsLakeHousesPublishedToCdc(true);
+                    cdcDetails.setPublishedLakeHouseNames(publishedNames);
+                    data.setCdcPublishedLakeHouseDetails(cdcDetails);
+                    entity.setData(data);
+                    jpaRepo.save(entity);
+                }
+            }
         } catch (Exception e) {
             log.error("Failed to update lake house details: {}", e.getMessage());
             throw new OpenMetadataClientException("Failed to update lake house details: " + e.getMessage(), e);

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseDdxOnboardingService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseDdxOnboardingService.java
@@ -501,14 +501,17 @@ public class BaseDdxOnboardingService implements DdxOnboardingService {
             // Update the workspace's ddxPublishedLakeHouseDetails list directly
             // on the managed entity — no VO round-trip needed.
             if (workspaceData != null) {
-                List<String> detailIds = workspaceData.getDdxPublishedLakeHouseDetails();
-                if (detailIds == null) {
-                    detailIds = new ArrayList<>();
+                List<DdxProduct> existingProducts = workspaceData.getDdxPublishedLakeHouseDetails();
+                if (existingProducts == null) {
+                    existingProducts = new ArrayList<>();
                 }
-                if (!detailIds.contains(lakehouseId)) {
-                    detailIds.add(lakehouseId);
+                String productName = onboardingResponse.getDataProductName();
+                boolean alreadyExists = existingProducts.stream()
+                    .anyMatch(p -> productName != null && productName.equals(p.getProductName()));
+                if (!alreadyExists) {
+                    existingProducts.add(product);
                 }
-                workspaceData.setDdxPublishedLakeHouseDetails(detailIds);
+                workspaceData.setDdxPublishedLakeHouseDetails(existingProducts);
                 workspaceEntity.setData(workspaceData);
                 jpaRepo.save(workspaceEntity);
             }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -44,6 +44,10 @@ import com.daimler.data.db.json.ADAProjectDetails;
 import com.daimler.data.db.json.DdxDataProductsDetail;
 import com.daimler.data.db.json.DdxProduct;
 import com.daimler.data.db.json.AuthoriserRoleDeatils;
+import com.daimler.data.db.json.CdcPublishedLakeHouseDetails;
+import com.daimler.data.db.json.FabricWorkspace;
+import com.daimler.data.db.json.FabricWorkspaceStatus;
+import com.daimler.data.db.json.Lakehouse;
 import com.daimler.data.db.json.UserDetails;
 import com.daimler.data.db.repo.ddxDataProductsDetails.DdxDataProductsDetailsRepository;
 import com.daimler.data.db.repo.fabric.FabricWorkspaceCustomRepository;
@@ -423,11 +427,31 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 					lakehouseVOs = value.stream().map(n -> assembler.toLakehouseVOFromDto(n)).collect(Collectors.toList());
 					voFromDb.setLakehouses(lakehouseVOs);
 				}
-				FabricWorkspaceNsql updatedEntity = assembler.toEntity(voFromDb);
-				log.info("Successfully updated latest displayName and description from Fabric to Database for project id {}", id);
-				jpaRepo.save(updatedEntity);
+				Optional<FabricWorkspaceNsql> entityOpt = jpaRepo.findById(id);
+				if(entityOpt.isPresent()) {
+					FabricWorkspaceNsql entity = entityOpt.get();
+					FabricWorkspace data = entity.getData();
+					if(data != null && lakehousesCollection!=null && lakehousesCollection.getValue()!=null && !lakehousesCollection.getValue().isEmpty()) {
+						List<Lakehouse> lakehouses = lakehousesCollection.getValue().stream().map(n -> {
+							Lakehouse lh = new Lakehouse();
+							lh.setId(n.getId());
+							lh.setName(n.getDisplayName());
+							lh.setDescription(n.getDescription());
+							if(n.getDisplayName()!=null && n.getDisplayName().toLowerCase().contains("dev")) {
+								lh.setSensitivityLabel("Internal");
+							}else {
+								lh.setSensitivityLabel("Confidential");
+							}
+							return lh;
+						}).collect(Collectors.toList());
+						data.setLakehouses(lakehouses);
+						entity.setData(data);
+						jpaRepo.save(entity);
+					}
+				}
+				log.info("Successfully updated lakehouses from Fabric to Database for project id {}", id);
 			}catch(Exception e) {
-				log.error("Failed to update latest displayName and description from Fabric to Database for project id {}, with error {} . Will be updated in next fetch", id, e.getMessage());
+				log.error("Failed to update lakehouses from Fabric to Database for project id {}, with error {} . Will be updated in next fetch", id, e.getMessage());
 			}
 //		}
 		// Enrich ddxPublishedLakeHouseDetails with full product data from ddx_dataProducts_details_nsql
@@ -436,39 +460,14 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 	}
 
 	/**
-	 * Replaces the lakehouse ID strings in ddxPublishedLakeHouseDetails with
-	 * enriched objects containing lakeHouseId and dataProducts from the
-	 * ddx_dataProducts_details_nsql table.
+	 * The ddxPublishedLakeHouseDetails are already fully typed DdxPublishedLakeHouseDetailsVO
+	 * objects after the assembler conversion, so no extra enrichment is needed.
+	 * This method is kept as a no-op placeholder for forward compatibility.
 	 */
 	private void enrichDdxPublishedLakeHouseDetails(FabricWorkspaceVO vo) {
-		if (vo == null || vo.getDdxPublishedLakeHouseDetails() == null || vo.getDdxPublishedLakeHouseDetails().isEmpty()) {
-			return;
-		}
-		try {
-			List<Object> enrichedList = new ArrayList<>();
-			for (Object item : vo.getDdxPublishedLakeHouseDetails()) {
-				String lakehouseId = (item instanceof String) ? (String) item : String.valueOf(item);
-				Optional<DdxDataProductsDetailsNsql> detailOpt = ddxDataProductsDetailsRepo.findById(lakehouseId);
-				Map<String, Object> lakehouseEntry = new LinkedHashMap<>();
-				lakehouseEntry.put("lakeHouseId", lakehouseId);
-				if (detailOpt.isPresent()) {
-					DdxDataProductsDetail data = detailOpt.get().getData();
-					if (data != null && data.getDdxProducts() != null) {
-						lakehouseEntry.put("dataProducts", data.getDdxProducts().stream()
-							.map(ddxDataProductsDetailsAssembler::toVo)
-							.collect(Collectors.toList()));
-					} else {
-						lakehouseEntry.put("dataProducts", new ArrayList<>());
-					}
-				} else {
-					lakehouseEntry.put("dataProducts", new ArrayList<>());
-				}
-				enrichedList.add(lakehouseEntry);
-			}
-			vo.setDdxPublishedLakeHouseDetails(enrichedList);
-		} catch (Exception e) {
-			log.error("Failed to enrich ddxPublishedLakeHouseDetails for workspace {}: {}", vo.getId(), e.getMessage(), e);
-		}
+		// No-op: ddxPublishedLakeHouseDetails are now stored as typed DdxProduct
+		// objects in the entity and converted to DdxPublishedLakeHouseDetailsVO
+		// by the assembler. No additional enrichment needed.
 	}
 
 	@Override
@@ -1629,10 +1628,21 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 					}
 				}
 			}
-			existingWorkspace.getStatus().setState(ConstantsUtility.DELETED_STATE);
-			existingWorkspace.setLastModifiedOn(new Date());
-			existingWorkspace.setDeletedOn(new Date());
-			jpaRepo.save(assembler.toEntity(existingWorkspace));
+				existingWorkspace.getStatus().setState(ConstantsUtility.DELETED_STATE);
+				existingWorkspace.setLastModifiedOn(new Date());
+				existingWorkspace.setDeletedOn(new Date());
+				Optional<FabricWorkspaceNsql> deleteEntityOpt = jpaRepo.findById(id);
+				if (deleteEntityOpt.isPresent()) {
+					FabricWorkspaceNsql deleteEntity = deleteEntityOpt.get();
+					FabricWorkspace deleteData = deleteEntity.getData();
+					if (deleteData != null && deleteData.getStatus() != null) {
+						deleteData.getStatus().setState(ConstantsUtility.DELETED_STATE);
+					}
+					deleteData.setLastModifiedOn(new Date());
+					deleteData.setDeletedOn(new Date());
+					deleteEntity.setData(deleteData);
+					jpaRepo.save(deleteEntity);
+				}
 			responseMessage.setSuccess("SUCCESS");
 			responseMessage.setErrors(errors);
 			responseMessage.setWarnings(warnings);
@@ -1660,9 +1670,19 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		}catch(Exception e) {
 			log.error("Failed to update project {} details in MicrosoftFabric, Will be updated in next action.", existingFabricWorkspace.getId());
 		}
-		FabricWorkspaceNsql updatedEntity = assembler.toEntity(existingFabricWorkspace);
 		updateTags(existingFabricWorkspace);
-		jpaRepo.save(updatedEntity);
+		Optional<FabricWorkspaceNsql> updateEntityOpt = jpaRepo.findById(existingFabricWorkspace.getId());
+		if (updateEntityOpt.isPresent()) {
+			FabricWorkspaceNsql updateEntity = updateEntityOpt.get();
+			FabricWorkspace updateData = updateEntity.getData();
+			if (updateData != null) {
+				updateData.setName(existingFabricWorkspace.getName());
+				updateData.setDescription(existingFabricWorkspace.getDescription());
+				updateData.setTags(existingFabricWorkspace.getTags());
+				updateEntity.setData(updateData);
+				jpaRepo.save(updateEntity);
+			}
+		}
 		return existingFabricWorkspace;
 	}
 	
@@ -2336,6 +2356,70 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		return responses;
 	}
 
+
+	@Override
+	@Transactional
+	public void updateWorkspaceDirectly(String workspaceId, FabricWorkspaceStatusVO statusVO, String name, String description) {
+		Optional<FabricWorkspaceNsql> entityOpt = jpaRepo.findById(workspaceId);
+		if (entityOpt.isPresent()) {
+			FabricWorkspaceNsql entity = entityOpt.get();
+			FabricWorkspace data = entity.getData();
+			if (data != null) {
+				if (name != null) {
+					data.setName(name);
+				}
+				if (description != null) {
+					data.setDescription(description);
+				}
+				if (statusVO != null) {
+					FabricWorkspaceStatus status = data.getStatus();
+					if (status == null) {
+						status = new FabricWorkspaceStatus();
+					}
+					status.setState(statusVO.getState());
+					if (statusVO.getEntitlements() != null) {
+						List<com.daimler.data.db.json.EntitlementDetails> entitlements = statusVO.getEntitlements().stream()
+							.map(e -> {
+								com.daimler.data.db.json.EntitlementDetails ed = new com.daimler.data.db.json.EntitlementDetails();
+								org.springframework.beans.BeanUtils.copyProperties(e, ed);
+								return ed;
+							}).collect(Collectors.toList());
+						status.setEntitlements(entitlements);
+					}
+					if (statusVO.getRoles() != null) {
+						List<com.daimler.data.db.json.RoleDetails> roles = statusVO.getRoles().stream()
+							.map(r -> {
+								com.daimler.data.db.json.RoleDetails rd = new com.daimler.data.db.json.RoleDetails();
+								org.springframework.beans.BeanUtils.copyProperties(r, rd);
+								if (r.getEntitlements() != null) {
+									List<com.daimler.data.db.json.EntitlementDetails> roleEnts = r.getEntitlements().stream()
+										.map(re -> {
+											com.daimler.data.db.json.EntitlementDetails red = new com.daimler.data.db.json.EntitlementDetails();
+											org.springframework.beans.BeanUtils.copyProperties(re, red);
+											return red;
+										}).collect(Collectors.toList());
+									rd.setEntitlements(roleEnts);
+								}
+								return rd;
+							}).collect(Collectors.toList());
+						status.setRoles(roles);
+					}
+					if (statusVO.getMicrosoftGroups() != null) {
+						List<com.daimler.data.db.json.GroupDetails> groups = statusVO.getMicrosoftGroups().stream()
+							.map(g -> {
+								com.daimler.data.db.json.GroupDetails gd = new com.daimler.data.db.json.GroupDetails();
+								org.springframework.beans.BeanUtils.copyProperties(g, gd);
+								return gd;
+							}).collect(Collectors.toList());
+						status.setMicrosoftGroups(groups);
+					}
+					data.setStatus(status);
+				}
+				entity.setData(data);
+				jpaRepo.save(entity);
+			}
+		}
+	}
 
 	@Override
 	public ADAProjectDetailsCollectionVO searchProjects(String projectName) {

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/FabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/FabricWorkspaceService.java
@@ -84,4 +84,6 @@ public interface FabricWorkspaceService extends CommonService<FabricWorkspaceVO,
 	GenericMessage transferOwnership(FabricWorkspaceVO existingFabricWorkspace, CreatedByVO currentOwner, CreatedByVO newOwner);
 
 	ADAProjectDetailsCollectionVO searchProjects(String projectName);
+
+	void updateWorkspaceDirectly(String workspaceId, FabricWorkspaceStatusVO statusVO, String name, String description);
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/WorkspaceBackgroundJobsService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/WorkspaceBackgroundJobsService.java
@@ -172,11 +172,8 @@ public class WorkspaceBackgroundJobsService {
 							FabricWorkspaceVO tempWorkspaceVO =  workspaceVO;
 							try {
 								updatedStatus = fabricService.processWorkspaceUserManagement(currentStatus,updatedName, workspaceVO.getCreatedBy().getId(), workspaceVO.getId(),workspaceVO.getCustomGroupName(), isDivisionAllowed, workspaceVO.getCustomGroupNameCollection());
-								tempWorkspaceVO.setStatus(updatedStatus);
-								try {
-									tempWorkspaceVO.setName(updatedName);
-									tempWorkspaceVO.setDescription(updatedDescription);
-									fabricService.create(tempWorkspaceVO);
+									try {
+									fabricService.updateWorkspaceDirectly(workspaceVO.getId(), updatedStatus, updatedName, updatedDescription);
 								}catch(Exception saveException) {
 									log.error("During scheduled job, failed to update the workspace with latest status {} for workspace {} and id {} with exception {}",
 												updatedStatus.getState(), workspaceVO.getName(), workspaceVO.getId(), saveException.getMessage());
@@ -188,11 +185,10 @@ public class WorkspaceBackgroundJobsService {
 						if(workspaceVO!=null && workspaceVO.getStatus()!=null && ConstantsUtility.COMPLETED_STATE.equalsIgnoreCase(workspaceVO.getStatus().getState())){
 							FabricWorkspaceVO tempWorkspaceVO =  workspaceVO;
 							List<GroupDetailsVO> updatedGroupDetails = fabricService.autoProcessGroupsUsers(workspaceVO.getStatus().getMicrosoftGroups(), updatedName, workspaceVO.getCreatedBy().getId(), workspaceVO.getId(), workspaceVO.getCustomGroupName(), workspaceVO.getCustomGroupNameCollection());
-							tempWorkspaceVO.getStatus().setMicrosoftGroups(updatedGroupDetails);
+							FabricWorkspaceStatusVO updatedCompletedStatus = workspaceVO.getStatus();
+							updatedCompletedStatus.setMicrosoftGroups(updatedGroupDetails);
 							try {
-								tempWorkspaceVO.setName(updatedName);
-								tempWorkspaceVO.setDescription(updatedDescription);
-								fabricService.create(tempWorkspaceVO);
+								fabricService.updateWorkspaceDirectly(workspaceVO.getId(), updatedCompletedStatus, updatedName, updatedDescription);
 							}catch(Exception saveException) {
 								log.error("During scheduled job, failed to update the workspace with latest group assignments for workspace {} and id {} with exception {}", workspaceVO.getName(), workspaceVO.getId(), saveException.getMessage());
 							}

--- a/packages/fabric-backend/lib/src/main/resources/api/fabricWorkspaces.yaml
+++ b/packages/fabric-backend/lib/src/main/resources/api/fabricWorkspaces.yaml
@@ -855,8 +855,8 @@ definitions:
       ddxPublishedLakeHouseDetails:
         type: array
         items:
-          type: object
-        description: "List of enriched DDX product details keyed by lakehouseId from ddx_dataProducts_details_nsql table"
+          $ref: "#/definitions/DdxPublishedLakeHouseDetailsVO"
+        description: "List of DDX published lakehouse details with full product information"
 
   FabricWorkspaceStatusVO:
     type: object


### PR DESCRIPTION
Changes

- FabricWorkspace.java: List<String> -> List<DdxProduct> for ddxPublishedLakeHouseDetails
- fabricWorkspaces.yaml: items: type: string -> items: $ref: DdxPublishedLakeHouseDetailsVO
- FabricWorkspaceAssembler: typed DdxProduct <-> DdxPublishedLakeHouseDetailsVO conversion
- BaseFabricWorkspaceService.getById(): direct entity update instead of assembler.toEntity()
- BaseFabricWorkspaceService.delete(): direct entity update
- BaseFabricWorkspaceService.updateFabricProject(): direct entity update
- BaseFabricCatalogManagementService.updateLakeHouseDetails(): direct entity update
- BaseDdxOnboardingService.updateDdxLakeHouseDetails(): store full DdxProduct objects
- WorkspaceBackgroundJobsService: use updateWorkspaceDirectly() instead of create()
- Added updateWorkspaceDirectly() to FabricWorkspaceService interface + implementation
- enrichDdxPublishedLakeHouseDetails() now no-op (data already typed from assembler)