### PR TITLE
Fix empty resources: use helm values YAML instead of --set to properly render resources: {}

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -252,9 +252,11 @@ public class ArgoCdService {
                 memory != null ? memory + "Mi" : "not set",
                 memory != null ? memory + "Mi" : "not set");
         } else {
-            helmParameters.add(createHelmParam("resources", "{}"));
-            log.info("[Resources] No resource overrides to apply, sending resources={}");
+            log.info("[Resources] No resource overrides to apply, will use helm values to set resources: {}");
         }
+        
+        // Track whether we need to set resources via values YAML (for empty map)
+        boolean useValuesForResources = (resources == null || resources.isEmpty());
         
         Map<String, Object> payload = new HashMap<>();
         
@@ -279,6 +281,11 @@ public class ArgoCdService {
         
         Map<String, Object> helm = new HashMap<>();
         helm.put("parameters", helmParameters);
+        if (useValuesForResources) {
+            // Use values YAML string to properly set resources: {} as an empty map
+            // Helm --set resources={} incorrectly renders as a list [""]
+            helm.put("values", "resources: {}");
+        }
         source.put("helm", helm);
         
         spec.put("source", source);


### PR DESCRIPTION
- The `values` field is only set when `resources` is null or empty. When resources have values, only `parameters` are used (no change to existing behavior).
- If both `values` and `parameters` set the same key, Helm gives precedence to `parameters`, so there's no conflict risk.