### PR TITLE
Fix restartArgoApp: correct namespace and improve error logging

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -312,6 +312,14 @@ public class ArgoCdService {
         syncPolicy.put("syncOptions", syncOptions);
         
         spec.put("syncPolicy", syncPolicy);
+        
+        List<Map<String, String>> infoList = new ArrayList<>();
+        Map<String, String> csEnvInfo = new HashMap<>();
+        csEnvInfo.put("name", "cs-env");
+        csEnvInfo.put("value", targetEnv);
+        infoList.add(csEnvInfo);
+        spec.put("info", infoList);
+        
         payload.put("spec", spec);
         
         ObjectMapper mapper = new ObjectMapper();

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -170,66 +170,39 @@ public class ArgoCdService {
     public String restartArgoApp(String token, String workspaceName, String environment) {
         try {
             String appName = workspaceName + "-" + environment;
-            log.info("Restarting ArgoCD application: {}", appName);
-
-            // Step 1: Get resource tree to find the actual Deployment resource name and namespace
-            String treeUrl = argocdCreateUrl + "/" + appName + "/resource-tree";
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBearerAuth(token);
-            headers.setContentType(MediaType.APPLICATION_JSON);
-            HttpEntity<Object> treeEntity = new HttpEntity<>(headers);
-
-            ResponseEntity<String> treeResponse = restTemplate.exchange(treeUrl, HttpMethod.GET, treeEntity, String.class);
+            String namespace = getNamespaceForEnvironment(codeServerEnvRef, environment);
             
-            String deploymentName = null;
-            String deploymentNamespace = null;
-            
-            if (treeResponse.getStatusCode().is2xxSuccessful() && treeResponse.getBody() != null) {
-                ObjectMapper mapper = new ObjectMapper();
-                JsonNode root = mapper.readTree(treeResponse.getBody());
-                JsonNode nodes = root.path("nodes");
-                if (nodes.isArray()) {
-                    for (JsonNode node : nodes) {
-                        String kind = node.path("kind").asText("");
-                        String group = node.path("group").asText("");
-                        if ("Deployment".equalsIgnoreCase(kind) && "apps".equalsIgnoreCase(group)) {
-                            deploymentName = node.path("name").asText("");
-                            deploymentNamespace = node.path("namespace").asText("");
-                            log.info("Found Deployment resource: name={}, namespace={}", deploymentName, deploymentNamespace);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (deploymentName == null || deploymentName.isEmpty()) {
-                log.error("No Deployment resource found in ArgoCD app: {}", appName);
-                return "failed";
-            }
-
-            // Step 2: Call resource actions API with the actual Deployment name
             String url = argocdCreateUrl + "/" + appName + "/resource/actions" +
-                        "?namespace=" + deploymentNamespace +
-                        "&resourceName=" + deploymentName +
+                        "?namespace=" + namespace +
+                        "&resourceName=" + appName +
                         "&version=v1" +
                         "&kind=Deployment" +
                         "&group=apps";
             
-            log.info("Calling restart action on Deployment: {} in namespace: {}", deploymentName, deploymentNamespace);
-
+            log.info("[Restart] Calling ArgoCD restart: appName={}, namespace={}, url={}", appName, namespace, url);
+    
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(token);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+        
             HttpEntity<String> entity = new HttpEntity<>("restart", headers);
         
             ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
         
             if (response != null && response.getStatusCode().is2xxSuccessful()) {
-                log.info("ArgoCD application restarted successfully: {}", appName);
+                log.info("[Restart] ArgoCD application restarted successfully: {}", appName);
                 return "success";
             } else {
-                log.error("Failed to restart ArgoCD app {}: {}", appName, (response != null ? response.getBody() : "no response"));
+                log.error("[Restart] Failed to restart ArgoCD app {}: status={}, body={}", 
+                    appName, (response != null ? response.getStatusCode() : "null"), (response != null ? response.getBody() : "no response"));
                 return "failed";
             }
+        } catch (org.springframework.web.client.HttpClientErrorException e) {
+            log.error("[Restart] ArgoCD HTTP error for {}: status={}, body={}", 
+                workspaceName + "-" + environment, e.getStatusCode(), e.getResponseBodyAsString(), e);
+            return "failed";
         } catch (Exception e) {
-            log.error("Failed to restart ArgoCD application: {}", e.getMessage(), e);            
+            log.error("[Restart] Failed to restart ArgoCD application {}: {}", workspaceName + "-" + environment, e.getMessage(), e);            
             return "failed";
         }
     }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -170,22 +170,53 @@ public class ArgoCdService {
     public String restartArgoApp(String token, String workspaceName, String environment) {
         try {
             String appName = workspaceName + "-" + environment;
-            String namespace = getNamespaceForEnvironment(environment, environment);
+            log.info("Restarting ArgoCD application: {}", appName);
+
+            // Step 1: Get resource tree to find the actual Deployment resource name and namespace
+            String treeUrl = argocdCreateUrl + "/" + appName + "/resource-tree";
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(token);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Object> treeEntity = new HttpEntity<>(headers);
+
+            ResponseEntity<String> treeResponse = restTemplate.exchange(treeUrl, HttpMethod.GET, treeEntity, String.class);
             
-            String resourceName = appName;
+            String deploymentName = null;
+            String deploymentNamespace = null;
+            
+            if (treeResponse.getStatusCode().is2xxSuccessful() && treeResponse.getBody() != null) {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode root = mapper.readTree(treeResponse.getBody());
+                JsonNode nodes = root.path("nodes");
+                if (nodes.isArray()) {
+                    for (JsonNode node : nodes) {
+                        String kind = node.path("kind").asText("");
+                        String group = node.path("group").asText("");
+                        if ("Deployment".equalsIgnoreCase(kind) && "apps".equalsIgnoreCase(group)) {
+                            deploymentName = node.path("name").asText("");
+                            deploymentNamespace = node.path("namespace").asText("");
+                            log.info("Found Deployment resource: name={}, namespace={}", deploymentName, deploymentNamespace);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (deploymentName == null || deploymentName.isEmpty()) {
+                log.error("No Deployment resource found in ArgoCD app: {}", appName);
+                return "failed";
+            }
+
+            // Step 2: Call resource actions API with the actual Deployment name
             String url = argocdCreateUrl + "/" + appName + "/resource/actions" +
-                        "?namespace=" + namespace +
-                        "&resourceName=" + resourceName +
+                        "?namespace=" + deploymentNamespace +
+                        "&resourceName=" + deploymentName +
                         "&version=v1" +
                         "&kind=Deployment" +
                         "&group=apps";
             
-            log.info("Restarting ArgoCD application: {} in namespace: {}", appName, namespace);
-    
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBearerAuth(token);
-            headers.setContentType(MediaType.APPLICATION_JSON);
-        
+            log.info("Calling restart action on Deployment: {} in namespace: {}", deploymentName, deploymentNamespace);
+
             HttpEntity<String> entity = new HttpEntity<>("restart", headers);
         
             ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
@@ -194,11 +225,11 @@ public class ArgoCdService {
                 log.info("ArgoCD application restarted successfully: {}", appName);
                 return "success";
             } else {
-                log.info("Failed to restart: " + (response != null ? response.getBody() : ""));
+                log.error("Failed to restart ArgoCD app {}: {}", appName, (response != null ? response.getBody() : "no response"));
                 return "failed";
             }
         } catch (Exception e) {
-            log.error("Failed to restart ArgoCD application", e);            
+            log.error("Failed to restart ArgoCD application: {}", e.getMessage(), e);            
             return "failed";
         }
     }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -272,6 +272,7 @@ public class ArgoCdService {
             ? argocdNamespacePrefix : clusterEnv;
         labels.put("env", envLabel);
         labels.put("project", "cs-apps");
+        labels.put("cs-env", targetEnv);
         metadata.put("labels", labels);
         payload.put("metadata", metadata);
         


### PR DESCRIPTION
## Summary

Fixes `restartArgoApp()` which was failing after being called (confirmed via logs) by correcting the namespace resolution and adding detailed error logging.

**Namespace fix:** Changed `getNamespaceForEnvironment(environment, environment)` → `getNamespaceForEnvironment(codeServerEnvRef, environment)`. The first parameter is used as a fallback prefix when `argocdNamespacePrefix` is empty. The old code passed the target env (e.g. `"int"`), which could produce `int-dna-cs-apps-int` instead of the correct `dev-dna-cs-apps-int`. This now matches how `buildPayload()` resolves the namespace during deploy.

