### PR TITLE
Fix restart 400, auto-refresh, resources override, sync-fail detection, and repo registration

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -229,13 +229,14 @@ public class DeploymentStatusSseController {
             return dbStatus;
         }
         
-        // When DB says DEPLOYING, trust it — ArgoCD may still show Healthy from the previous deployment
-        // because the new sync hasn't started yet. Only override DB status if ArgoCD shows non-healthy.
+        // When DB says DEPLOYING, check ArgoCD for real-time status
         if ("DEPLOYING".equalsIgnoreCase(dbStatus)) {
             if ("Degraded".equalsIgnoreCase(argoHealth)) {
                 return "FAILED";
             }
-            // ArgoCD still Healthy or Progressing — keep DEPLOYING until scheduler confirms final state
+            if ("Healthy".equalsIgnoreCase(argoHealth) && "Synced".equalsIgnoreCase(argoSync)) {
+                return "DEPLOYED";
+            }
             return "DEPLOYING";
         }
         

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -183,6 +183,7 @@ public class DeploymentStatusSseController {
 
             String argoHealthStatus = "UNAVAILABLE";
             String argoSyncStatus = "UNAVAILABLE";
+            String argoLastSyncPhase = "";
             
             try {
                 String argoAppName = projectName + "-" + environment;
@@ -194,9 +195,11 @@ public class DeploymentStatusSseController {
                     JsonNode rootNode = mapper.readTree(argoResponse.getBody());
                     argoHealthStatus = rootNode.path("status").path("health").path("status").asText("");
                     argoSyncStatus = rootNode.path("status").path("sync").path("status").asText("");
+                    argoLastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
                     
                     data.put("argocdHealthStatus", argoHealthStatus);
                     data.put("argocdSyncStatus", argoSyncStatus);
+                    data.put("argocdLastSyncPhase", argoLastSyncPhase);
                     data.put("argocdAppUrl", argoCdService.getArgocdBaseUrl() + "/applications/" + argoAppName);
                 }
             } catch (Exception e) {
@@ -204,11 +207,11 @@ public class DeploymentStatusSseController {
                 data.put("argocdHealthStatus", "UNAVAILABLE");
             }
 
-            String actualStatus = determineActualStatus(dbStatus, argoHealthStatus, argoSyncStatus);
+            String actualStatus = determineActualStatus(dbStatus, argoHealthStatus, argoLastSyncPhase);
             data.put("currentStatus", actualStatus);
             
-            log.debug("Status for {}-{}: DB={}, ArgoHealth={}, ArgoSync={}, Actual={}", 
-                projectName, environment, dbStatus, argoHealthStatus, argoSyncStatus, actualStatus);
+            log.debug("Status for {}-{}: DB={}, ArgoHealth={}, ArgoSync={}, LastSyncPhase={}, Actual={}", 
+                projectName, environment, dbStatus, argoHealthStatus, argoSyncStatus, argoLastSyncPhase, actualStatus);
 
         } catch (Exception e) {
             log.error("Error fetching deployment status for {}/{}: {}", projectName, environment, e.getMessage());
@@ -219,7 +222,7 @@ public class DeploymentStatusSseController {
         return data;
     }
     
-    private String determineActualStatus(String dbStatus, String argoHealth, String argoSync) {
+    private String determineActualStatus(String dbStatus, String argoHealth, String lastSyncPhase) {
         if ("DEPLOYED".equalsIgnoreCase(dbStatus) || "FAILED".equalsIgnoreCase(dbStatus)) {
             log.debug("Using terminal DB status: {}", dbStatus);
             return dbStatus;
@@ -229,18 +232,26 @@ public class DeploymentStatusSseController {
             return dbStatus;
         }
         
-        // When DB says DEPLOYING, check ArgoCD for real-time status
+        // When DB says DEPLOYING, check ArgoCD health + last sync phase for real-time status
         if ("DEPLOYING".equalsIgnoreCase(dbStatus)) {
             if ("Degraded".equalsIgnoreCase(argoHealth)) {
                 return "FAILED";
             }
-            if ("Healthy".equalsIgnoreCase(argoHealth) && "Synced".equalsIgnoreCase(argoSync)) {
-                return "DEPLOYED";
+            if ("Healthy".equalsIgnoreCase(argoHealth)) {
+                if ("Failed".equalsIgnoreCase(lastSyncPhase) || "Error".equalsIgnoreCase(lastSyncPhase)) {
+                    return "FAILED";
+                }
+                if ("Succeeded".equalsIgnoreCase(lastSyncPhase)) {
+                    return "DEPLOYED";
+                }
             }
             return "DEPLOYING";
         }
         
         if ("Healthy".equalsIgnoreCase(argoHealth)) {
+            if ("Failed".equalsIgnoreCase(lastSyncPhase) || "Error".equalsIgnoreCase(lastSyncPhase)) {
+                return "FAILED";
+            }
             return "DEPLOYED";
         }
         

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -185,7 +185,7 @@ public class ArgoCdService {
             headers.setBearerAuth(token);
             headers.setContentType(MediaType.APPLICATION_JSON);
         
-            HttpEntity<String> entity = new HttpEntity<>("restart", headers);
+            HttpEntity<String> entity = new HttpEntity<>("\"restart\"", headers);
         
             ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
         

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -608,10 +608,16 @@ public class ArgoCdService {
             JsonNode rootNode = mapper.readTree(argoResponse.getBody());
             String healthStatus = rootNode.path("status").path("health").path("status").asText("");
             String syncStatus = rootNode.path("status").path("sync").path("status").asText("");
-            log.info("ArgoCD app {} - Health: {}, Sync: {}", appName, healthStatus, syncStatus);
+            String lastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
+            log.info("ArgoCD app {} - Health: {}, Sync: {}, LastSyncPhase: {}", appName, healthStatus, syncStatus, lastSyncPhase);
             switch (healthStatus.toLowerCase()) {
                 case "healthy":
-                    log.info("Application {} is healthy - DEPLOYED", appName);
+                    // Healthy but last sync failed means the new changes didn't apply
+                    if ("Failed".equalsIgnoreCase(lastSyncPhase) || "Error".equalsIgnoreCase(lastSyncPhase)) {
+                        log.info("Application {} is healthy but last sync {} - FAILED", appName, lastSyncPhase);
+                        return "FAILED";
+                    }
+                    log.info("Application {} is healthy, last sync {} - DEPLOYED", appName, lastSyncPhase);
                     return "DEPLOYED";
                 case "degraded":
                     log.info("Application {} is degraded - FAILED", appName);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -256,11 +256,8 @@ public class ArgoCdService {
                 memory != null ? memory + "Mi" : "not set",
                 memory != null ? memory + "Mi" : "not set");
         } else {
-            log.info("[Resources] No resource overrides to apply, will use helm values to set resources: {}");
+            log.info("[Resources] No resource overrides to apply, chart values.yaml will be used as-is");
         }
-        
-        // Track whether we need to set resources via values YAML (for empty map)
-        boolean useValuesForResources = (resources == null || resources.isEmpty());
         
         Map<String, Object> payload = new HashMap<>();
         
@@ -286,11 +283,6 @@ public class ArgoCdService {
         
         Map<String, Object> helm = new HashMap<>();
         helm.put("parameters", helmParameters);
-        if (useValuesForResources) {
-            // Use values YAML string to properly set resources: {} as an empty map
-            // Helm --set resources={} incorrectly renders as a list [""]
-            helm.put("values", "resources: {}");
-        }
         source.put("helm", helm);
         
         spec.put("source", source);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseRecipeService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseRecipeService.java
@@ -49,6 +49,7 @@ import com.daimler.dna.notifications.common.producer.KafkaProducerService;
 import com.daimler.data.application.auth.UserStore;
 import com.daimler.data.application.auth.UserStore.UserInfo;
 import com.daimler.data.application.client.GitClient;
+import com.daimler.data.service.ArgoCdService;
 import com.daimler.data.dto.solution.ChangeLogVO;
 import com.daimler.data.dto.workspace.CreatedByVO;
 import com.daimler.data.dto.workspace.UserInfoVO;
@@ -98,6 +99,9 @@ public class BaseRecipeService implements RecipeService{
 
 	@Autowired
 	private GitClient gitClient;
+
+	@Autowired
+	private ArgoCdService argoCdService;
 
 	@Value("${codeserver.recipe.software.filename}")
 	private String gitFileName;
@@ -160,6 +164,11 @@ public RecipeVO createRecipe(RecipeVO recipeRequestVO) {
 		}
 	}
 
+	// Register repository with ArgoCD when deployment is enabled
+	if (Boolean.TRUE.equals(recipeRequestVO.isIsDeployEnabled()) && repoUrl != null) {
+		registerRepoWithArgoCD(repoUrl);
+	}
+
 	CodeServerRecipeNsql entity = recipeAssembler.toEntity(recipeRequestVO);
 	CodeServerRecipeNsql savedEntity = saveEntity(isoFormat, entity, new CodeServerRecipeNsql());
 	return recipeAssembler.toVo(savedEntity);
@@ -199,6 +208,11 @@ public RecipeVO updateRecipe(RecipeVO recipeRequestVO) {
 			throw new RuntimeException(
 					"Unable to access GHE repository. Please verify PID access.");
 		}
+	}
+
+	// Register repository with ArgoCD when deployment is enabled
+	if (Boolean.TRUE.equals(recipeRequestVO.isIsDeployEnabled()) && repoUrl != null) {
+		registerRepoWithArgoCD(repoUrl);
 	}
 
 	CodeServerRecipeNsql existing = workspaceCustomRecipeRepo.findByRecipeName(
@@ -340,6 +354,17 @@ public RecipeVO updateRecipe(RecipeVO recipeRequestVO) {
 	}
 
 	
+	private void registerRepoWithArgoCD(String repoUrl) {
+		try {
+			String token = argoCdService.getArgoToken();
+			String repoGitUrl = repoUrl.endsWith(".git") ? repoUrl : repoUrl + ".git";
+			argoCdService.registerRepository(token, repoGitUrl, configuredPid, ghePat);
+			log.info("Repository registered with ArgoCD for deployment: {}", repoGitUrl);
+		} catch (Exception e) {
+			log.error("Failed to register repository with ArgoCD: {}", e.getMessage());
+		}
+	}
+
 	private GenericMessage getMessageDescrption(String message, String statusMsg ) {
 		GenericMessage responseMessage = new GenericMessage();
 		MessageDescription msg = new MessageDescription();


### PR DESCRIPTION
## Summary

Five fixes across `ArgoCdService.java`, `DeploymentStatusSseController.java`, and `BaseRecipeService.java`:

**1. Restart returns 400 Bad Request** (`ArgoCdService.java`)

ArgoCD's resource actions API expects a JSON-encoded body. Spring's `StringHttpMessageConverter` sends the Java string as-is (no Jackson serialization), so `"restart"` was sent as the raw bytes `restart` — causing ArgoCD to reject it with `"invalid character 'r' looking for beginning of value"`. Fixed by wrapping in escaped quotes so the wire body is `"restart"` (valid JSON string).

**2. Deployment auto-refresh stuck in DEPLOYING** (`DeploymentStatusSseController.java`)

The SSE `determineActualStatus()` method unconditionally returned `DEPLOYING` whenever the DB status was `DEPLOYING`, ignoring ArgoCD's real-time state. This meant the SSE stream could never emit `deployment-complete`, leaving the UI stuck until manual refresh. Fixed by checking **app health + last sync phase** (`status.operationState.phase`) to determine the real status:
- Healthy + last sync `Succeeded` → `DEPLOYED`
- Healthy + last sync `Failed`/`Error` → `FAILED`
- Degraded → `FAILED`
- Otherwise → `DEPLOYING`

**3. Remove aggressive `resources: {}` override** (`ArgoCdService.java`)

Previously (PR #5045), when no valid resources were calculated, the backend forced `helm.values = "resources: {}"` which overrode whatever was in the chart's `values.yaml`. This silently masked invalid resource values (e.g. `resources: ' '`) — deployments that should have failed would succeed with no resource constraints. Removed the override so the chart's `values.yaml` is used as-is.

**4. Detect sync failures even when app is Healthy** (`ArgoCdService.java`, `DeploymentStatusSseController.java`)

Previously, `checkArgoAppDeploymentStatus()` only checked `status.health.status`. An app that was `Healthy` (from a previous successful deployment) but whose latest sync failed (e.g. bad `values.yaml` update) was incorrectly reported as `DEPLOYED`. Now reads `status.operationState.phase` and treats `Healthy + sync Failed/Error` as `FAILED`. The same logic is applied in the SSE controller's `determineActualStatus()`.

**5. Register repository with ArgoCD on recipe create/update** (`BaseRecipeService.java`)

When the "Enable deployment through codespace" checkbox (`isDeployEnabled`) is checked during recipe creation or update, the backend now calls ArgoCD's `POST /api/v1/repositories` to register the git repo. Uses the configured PID username and GHE PAT. The call is idempotent — `registerRepository()` already handles `409 Conflict` (repo already registered) gracefully. Registration failure is non-blocking (logged but does not fail the recipe operation).
