### PR TITLE
Release: fix: sanitize role name and roleId to handle special characters

### DIFF
--- a/packages/fabric-backend/lib/build.gradle
+++ b/packages/fabric-backend/lib/build.gradle
@@ -9,7 +9,7 @@
 buildscript {
     ext {
         springBootVersion = "2.7.0"
-        releaseVersion = "1.0.0"
+        releaseVersion = "1.0.1"
     }
     repositories {
 		maven {

--- a/packages/fabric-backend/lib/build.gradle
+++ b/packages/fabric-backend/lib/build.gradle
@@ -9,7 +9,7 @@
 buildscript {
     ext {
         springBootVersion = "2.7.0"
-        releaseVersion = "1.0.1"
+        releaseVersion = "1.0.0"
     }
     repositories {
 		maven {

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -267,6 +267,8 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		}
 		String uppercased = rawId.toUpperCase();
 		String sanitized = uppercased.replaceAll("[^A-Z0-9._-]", "");
+		// Strip leading chars that are not alphanumeric per regex ^[A-Z0-9]+
+		sanitized = sanitized.replaceAll("^[^A-Z0-9]+", "");
 		if (sanitized.isEmpty()) {
 			return sanitized;
 		}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -257,15 +257,9 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 	private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
 
 	/**
-	 * Sanitizes a role name for use as a roleId by removing characters
-	 * not allowed by the identity management system.
-	 * Allowed pattern: ^[A-Z0-9]+[A-Z0-9._-]{1,200}
-	 */
-	/**
 	 * Sanitizes a role name for display by:
 	 * - Replacing underscores with spaces
 	 * - Replacing standalone hyphens (not surrounded by spaces) with spaces
-	 * - Converting all-uppercase text to title case
 	 */
 	private String sanitizeRoleName(String rawName) {
 		if (rawName == null || rawName.isEmpty()) {
@@ -274,10 +268,6 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		String name = rawName.replace("_", " ");
 		// Replace hyphens that are not surrounded by spaces
 		name = name.replaceAll("(?<! )-(?! )", " ");
-		// Convert to title case if the name is all uppercase
-		if (name.equals(name.toUpperCase()) && name.chars().anyMatch(Character::isLetter)) {
-			name = toTitleCase(name);
-		}
 		return name.trim().replaceAll(" +", " ");
 	}
 
@@ -785,7 +775,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		adminRoleRequestDto.setId(sanitizeRoleId((workspaceName + "_" +  permissionName).replace(" ", "")));
 		adminRoleRequestDto.setJobTitle(false);
 		adminRoleRequestDto.setMarketAvailabilities(new ArrayList<>());
-		adminRoleRequestDto.setName(sanitizeRoleName((workspaceName + " " +  permissionName)));
+		adminRoleRequestDto.setName(sanitizeRoleName((workspaceName + " " +  toTitleCase(permissionName))));
 		adminRoleRequestDto.setNeedsAdditionalSelfRequestApproval(false);
 		adminRoleRequestDto.setNeedsCustomScopes(false);
 		adminRoleRequestDto.setNeedsOrgScopes(false);

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -254,7 +254,27 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		super();
 	}
 
-	private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");  
+	private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+
+	/**
+	 * Sanitizes a role name for use as a roleId by removing characters
+	 * not allowed by the identity management system.
+	 * Allowed pattern: ^[A-Z0-9]+[A-Z0-9._-]{1,200}
+	 */
+	private String sanitizeRoleId(String rawId) {
+		if (rawId == null) {
+			return rawId;
+		}
+		String uppercased = rawId.toUpperCase();
+		String sanitized = uppercased.replaceAll("[^A-Z0-9._-]", "");
+		if (sanitized.isEmpty()) {
+			return sanitized;
+		}
+		if (sanitized.length() > 201) {
+			sanitized = sanitized.substring(0, 201);
+		}
+		return sanitized;
+	}
 	
 	@Override
 	@Transactional  
@@ -723,7 +743,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		adminRoleRequestDto.setDescription(permissionName +" role for workspace " + workspaceName);
 		adminRoleRequestDto.setDynamic(false);
 		adminRoleRequestDto.setGlobalCentralAvailable(true);
-		adminRoleRequestDto.setId((workspaceName + "_" +  permissionName).replace(" ", ""));
+		adminRoleRequestDto.setId(sanitizeRoleId((workspaceName + "_" +  permissionName).replace(" ", "")));
 		adminRoleRequestDto.setJobTitle(false);
 		adminRoleRequestDto.setMarketAvailabilities(new ArrayList<>());
 		adminRoleRequestDto.setName((workspaceName + " " +  permissionName).replace("_", " "));
@@ -2130,7 +2150,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		roleRequestDto.setDescription("Generic DNA role");
 		roleRequestDto.setDynamic(isDynamic);
 		roleRequestDto.setGlobalCentralAvailable(true);
-		roleRequestDto.setId(roleName);
+		roleRequestDto.setId(sanitizeRoleId(roleName));
 		roleRequestDto.setJobTitle(false);
 		roleRequestDto.setMarketAvailabilities(new ArrayList<>());
 		roleRequestDto.setName(roleName.replace("_", " "));

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -261,6 +261,43 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 	 * not allowed by the identity management system.
 	 * Allowed pattern: ^[A-Z0-9]+[A-Z0-9._-]{1,200}
 	 */
+	/**
+	 * Sanitizes a role name for display by:
+	 * - Replacing underscores with spaces
+	 * - Replacing standalone hyphens (not surrounded by spaces) with spaces
+	 * - Converting all-uppercase text to title case
+	 */
+	private String sanitizeRoleName(String rawName) {
+		if (rawName == null || rawName.isEmpty()) {
+			return rawName;
+		}
+		String name = rawName.replace("_", " ");
+		// Replace hyphens that are not surrounded by spaces
+		name = name.replaceAll("(?<! )-(?! )", " ");
+		// Convert to title case if the name is all uppercase
+		if (name.equals(name.toUpperCase()) && name.chars().anyMatch(Character::isLetter)) {
+			name = toTitleCase(name);
+		}
+		return name.trim().replaceAll(" +", " ");
+	}
+
+	private String toTitleCase(String input) {
+		StringBuilder result = new StringBuilder();
+		boolean capitalizeNext = true;
+		for (char c : input.toCharArray()) {
+			if (Character.isWhitespace(c)) {
+				result.append(c);
+				capitalizeNext = true;
+			} else if (capitalizeNext) {
+				result.append(Character.toUpperCase(c));
+				capitalizeNext = false;
+			} else {
+				result.append(Character.toLowerCase(c));
+			}
+		}
+		return result.toString();
+	}
+
 	private String sanitizeRoleId(String rawId) {
 		if (rawId == null) {
 			return rawId;
@@ -748,7 +785,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		adminRoleRequestDto.setId(sanitizeRoleId((workspaceName + "_" +  permissionName).replace(" ", "")));
 		adminRoleRequestDto.setJobTitle(false);
 		adminRoleRequestDto.setMarketAvailabilities(new ArrayList<>());
-		adminRoleRequestDto.setName((workspaceName + " " +  permissionName).replace("_", " "));
+		adminRoleRequestDto.setName(sanitizeRoleName((workspaceName + " " +  permissionName)));
 		adminRoleRequestDto.setNeedsAdditionalSelfRequestApproval(false);
 		adminRoleRequestDto.setNeedsCustomScopes(false);
 		adminRoleRequestDto.setNeedsOrgScopes(false);
@@ -2155,7 +2192,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		roleRequestDto.setId(sanitizeRoleId(roleName));
 		roleRequestDto.setJobTitle(false);
 		roleRequestDto.setMarketAvailabilities(new ArrayList<>());
-		roleRequestDto.setName(roleName.replace("_", " "));
+		roleRequestDto.setName(sanitizeRoleName(roleName));
 		roleRequestDto.setNeedsAdditionalSelfRequestApproval(false);
 		roleRequestDto.setNeedsCustomScopes(false);
 		roleRequestDto.setNeedsOrgScopes(false);

--- a/packages/fabric-backend/lib/src/main/resources/application.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-fabric-workspace-service
-    version: 1.5.9
+    version: 1.6.0
   profile:
     active: production
 


### PR DESCRIPTION
## Summary

Role creation via the identity management system fails with a 400 error when the workspace or role name contains special characters (e.g. `[`, `]`, spaces) because these are passed through to the `roleId`, which must match `^[A-Z0-9]+[A-Z0-9._-]{1,200}`.

This PR adds sanitization methods in `BaseFabricWorkspaceService`:

**`sanitizeRoleId`** — cleans the role ID for the identity management API:
- Uppercases the input
- Strips all characters not in `[A-Z0-9._-]`
- Strips leading non-alphanumeric characters (`.`, `_`, `-`) so the roleId starts with `[A-Z0-9]` as required
- Truncates to max 201 characters

**`sanitizeRoleName`** — cleans the display name:
- Replaces underscores (`_`) with spaces
- Replaces standalone hyphens (not surrounded by spaces) with spaces

**`toTitleCase`** — converts an all-caps string to title case (e.g. `ADMIN` → `Admin`). Applied specifically to `permissionName` in workspace role creation so the display name isn't all-uppercase, while preserving the original casing of the workspace name.

These are applied at the two role-creation sites:
- `prepareRoleCreateRequestDto` (workspace-specific roles) — roleId sanitized, permissionName camel-cased in display name
- `prepareGenericRoleCreateRequestDto` (generic roles) — roleId and display name sanitized, but `toTitleCase` is **not** applied here since generic roles receive a full `roleName` without a separate `permissionName`

Also bumps `fabric-backend` application version from `1.5.9` → `1.6.0` in `application.yml`.

## Review & Testing Checklist for Human

- [ ] **Hyphen replacement may be too aggressive**: `sanitizeRoleName` replaces all standalone hyphens (not surrounded by spaces) with spaces. A name like `XTO-EU-124-Conzert [Production] Admin` would display as `XTO EU 124 Conzert [Production] Admin`. Project codes like `XTO-EU-124` may be better left hyphenated — confirm this is the desired behavior.
- [ ] **Special characters retained in display name**: `sanitizeRoleName` does not strip characters like `[` and `]` — only `sanitizeRoleId` does. The display name would retain brackets. Verify this is acceptable.
- [ ] **Generic roles remain unmodified for casing**: `toTitleCase` is only applied to `permissionName` in `prepareRoleCreateRequestDto`. In `prepareGenericRoleCreateRequestDto`, if `roleName` is all-caps it will stay all-caps in the display name. Confirm this is intentional.
- [ ] **Empty string / collision edge cases**: If all characters are stripped from the roleId, an empty string is returned with no error handling. Also, different source names can map to the same roleId (e.g., `Role[A]` and `RoleA` both → `ROLEA`).
- [ ] **End-to-end test**: Create a role with a name containing `[`, `]`, spaces, underscores, hyphens, and mixed case. Confirm both the roleId and display name are correct and the role is created successfully.

### Notes
- No unit tests were added. Consider adding tests for `sanitizeRoleId`, `sanitizeRoleName`, and `toTitleCase` covering edge cases (null, empty result, leading special chars, long strings, mixed-case inputs).
- The change was not build-verified locally (Gradle was not available in the environment). Compilation should be confirmed by CI.