### PR TITLE
Fix resources={}, Kong host, restart monitoring, UI auto-refresh, deploy status, pod annotations

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AuthenticatorClientImpl.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AuthenticatorClientImpl.java
@@ -458,15 +458,16 @@ public class AuthenticatorClientImpl  implements AuthenticatorClient{
 		// request for kong create service	
 		CreateServiceRequestVO createServiceRequestVO = new CreateServiceRequestVO();
 		CreateServiceVO createServiceVO = new CreateServiceVO();
-		if(kongApiForDeploymentURL) {	
-			url = "http://" + serviceName.toLowerCase() + "-" + env;		
+			if(kongApiForDeploymentURL) {	
+			url = "http://" + serviceName.toLowerCase() + "-" + env;
+			String nsSuffix = "int".equalsIgnoreCase(env) ? "-int" : "";
 			if(cloudServiceProvider.equalsIgnoreCase(ConstantsUtility.DHC_CAAS_AWS)){
 				if("dev".equalsIgnoreCase(codeServerEnvRef))
-					url = url + ".dev-dna-cs-apps:80";
+					url = url + ".dev-dna-cs-apps" + nsSuffix + ":80";
 				else if("staging".equalsIgnoreCase(codeServerEnvRef))
-					url = url + ".test-dna-cs-apps:80";
+					url = url + ".test-dna-cs-apps" + nsSuffix + ":80";
 				else
-					url = url + ".prod-dna-cs-apps:80";
+					url = url + ".prod-dna-cs-apps" + nsSuffix + ":80";
 			}else{	    		    
 				url = url +  ".codespaces-apps:80";
 			}

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -269,7 +269,12 @@ public class DeploymentStatusSseController {
             if ("Failed".equalsIgnoreCase(lastSyncPhase) || "Error".equalsIgnoreCase(lastSyncPhase)) {
                 return "FAILED";
             }
-            return "DEPLOYED";
+            // Only DEPLOYED when both Healthy AND last sync Succeeded
+            if ("Succeeded".equalsIgnoreCase(lastSyncPhase)) {
+                return "DEPLOYED";
+            }
+            // Healthy but sync not yet succeeded — still deploying
+            return "DEPLOYING";
         }
         
         if ("Degraded".equalsIgnoreCase(argoHealth)) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -47,6 +47,12 @@ public class DeploymentStatusSseController {
             int maxErrors = 5;
             int maxIterations = 600;
             int iteration = 0;
+            boolean seenInProgress = false;
+            // Minimum iterations before accepting terminal status from ArgoCD.
+            // This prevents false "DEPLOYED" when re-deploying an already-deployed app,
+            // because ArgoCD still shows the old deployment as Healthy+Succeeded
+            // before the new sync starts.
+            int minIterationsBeforeTerminal = 5; // ~15 seconds at 3s interval
             
             try {
                 while (iteration < maxIterations) {
@@ -59,14 +65,25 @@ public class DeploymentStatusSseController {
                                 .data(objectMapper.writeValueAsString(statusData)));
 
                         String status = (String) statusData.get("currentStatus");
-                        log.debug("SSE iteration {}: status={} for {}/{}", iteration, status, projectName, environment);
+                        log.debug("SSE iteration {}: status={} seenInProgress={} for {}/{}", iteration, status, seenInProgress, projectName, environment);
+                        
+                        // Track if we've seen an in-progress state (proves new sync has started)
+                        if ("DEPLOYING".equals(status)) {
+                            seenInProgress = true;
+                        }
                         
                         if ("DEPLOYED".equals(status) || "FAILED".equals(status)) {
-                            log.info("Deployment finished with status: {} after {} iterations", status, iteration);
-                            emitter.send(SseEmitter.event()
-                                    .name("deployment-complete")
-                                    .data(objectMapper.writeValueAsString(statusData)));
-                            break;
+                            // Only accept terminal status if we've seen the deployment actually start,
+                            // or enough time has passed to rule out stale ArgoCD state
+                            if (seenInProgress || iteration >= minIterationsBeforeTerminal) {
+                                log.info("Deployment finished with status: {} after {} iterations (seenInProgress={})", status, iteration, seenInProgress);
+                                emitter.send(SseEmitter.event()
+                                        .name("deployment-complete")
+                                        .data(objectMapper.writeValueAsString(statusData)));
+                                break;
+                            } else {
+                                log.info("SSE iteration {}: ignoring early terminal status {} (waiting for new sync to start)", iteration, status);
+                            }
                         }
                         
                         if ("ERROR".equals(status) || "NOT_FOUND".equals(status)) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -220,7 +220,7 @@ public class ArgoCdService {
         String vaultInjectorRootPath = "/" + projectName + "/" + targetEnv + "/api";
         String vaultInjectorRootPathNonApi = "/" + projectName + "/" + targetEnv + "/";
         
-        List<Map<String, String>> helmParameters = new ArrayList<>();
+        List<Map<String, Object>> helmParameters = new ArrayList<>();
         
         helmParameters.add(createHelmParam("namespace", namespace));
         helmParameters.add(createHelmParam("fullnameOverride", appName));
@@ -234,6 +234,7 @@ public class ArgoCdService {
         helmParameters.add(createHelmParam("vaultInjector.root_path_non_api", vaultInjectorRootPathNonApi));
         helmParameters.add(createHelmParam("vaultInjector.authpath", vaultAuthPath));
         helmParameters.add(createHelmParam("vaultInjector.namespace", "/"));
+        helmParameters.add(createHelmParamForceString("podAnnotations.prometheus\\.io/scrape", "true"));
         
         if (resources != null && resources.isEmpty()) {
             // resources: {} in values.yaml — send explicit empty override
@@ -324,10 +325,18 @@ public class ArgoCdService {
         return finalJson;
     }
     
-    private Map<String, String> createHelmParam(String name, String value) {
-        Map<String, String> param = new HashMap<>();
+    private Map<String, Object> createHelmParam(String name, String value) {
+        Map<String, Object> param = new HashMap<>();
         param.put("name", name);
         param.put("value", value);
+        return param;
+    }
+
+    private Map<String, Object> createHelmParamForceString(String name, String value) {
+        Map<String, Object> param = new HashMap<>();
+        param.put("name", name);
+        param.put("value", value);
+        param.put("forceString", true);
         return param;
     }
     

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -235,26 +235,37 @@ public class ArgoCdService {
         helmParameters.add(createHelmParam("vaultInjector.authpath", vaultAuthPath));
         helmParameters.add(createHelmParam("vaultInjector.namespace", "/"));
         
-        if (resources != null && !resources.isEmpty()) {
+        if (resources != null && resources.isEmpty()) {
+            // resources: {} in values.yaml — send explicit empty override
+            helmParameters.add(createHelmParam("resources", "{}"));
+            log.info("[Resources] Sending -> resources: {} (explicit empty from values.yaml)");
+        } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
+            String limitsCpu = resources.get("limitsCpu");
+            String limitsMemory = resources.get("limitsMemory");
             if (cpu != null) {
                 helmParameters.add(createHelmParam("resources.requests.cpu", cpu + "m"));
                 log.info("[Resources] Sending -> resources.requests.cpu: {}", cpu + "m");
             }
             if (memory != null) {
                 helmParameters.add(createHelmParam("resources.requests.memory", memory + "Mi"));
-                helmParameters.add(createHelmParam("resources.limits.memory", memory + "Mi"));
-                log.info("[Resources] Sending -> resources.requests.memory: {}, resources.limits.memory: {}", memory + "Mi", memory + "Mi");
+                log.info("[Resources] Sending -> resources.requests.memory: {}", memory + "Mi");
             }
-            // Explicitly remove limits.cpu by setting to "null" string
-            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
-            log.info("[Resources] Sending -> resources.limits.cpu: null (override to suppress chart default)");
+            if (limitsMemory != null) {
+                helmParameters.add(createHelmParam("resources.limits.memory", limitsMemory + "Mi"));
+                log.info("[Resources] Sending -> resources.limits.memory: {}", limitsMemory + "Mi");
+            }
+            if (limitsCpu != null) {
+                helmParameters.add(createHelmParam("resources.limits.cpu", limitsCpu + "m"));
+                log.info("[Resources] Sending -> resources.limits.cpu: {}", limitsCpu + "m");
+            }
             log.info("[Resources] Final resources being sent to ArgoCD: " +
-                "requests.cpu={}, requests.memory={}, limits.memory={} (same as requests.memory), limits.cpu=null (removed)",
+                "requests.cpu={}, requests.memory={}, limits.memory={}, limits.cpu={}",
                 cpu != null ? cpu + "m" : "not set",
                 memory != null ? memory + "Mi" : "not set",
-                memory != null ? memory + "Mi" : "not set");
+                limitsMemory != null ? limitsMemory + "Mi" : "not set",
+                limitsCpu != null ? limitsCpu + "m" : "not set");
         } else {
             log.info("[Resources] No resource overrides to apply, chart values.yaml will be used as-is");
         }
@@ -410,6 +421,12 @@ public class ArgoCdService {
         Map<String, Object> resourcesSection = (Map<String, Object>) resourcesObj;
         log.info("[Resources] Raw resources from values.yaml: {}", resourcesSection);
         
+        // If resources is explicitly empty {}, return empty map to signal "resources: {}" override
+        if (resourcesSection.isEmpty()) {
+            log.info("[Resources] resources is explicitly empty {}, will send resources={} override");
+            return new HashMap<>();
+        }
+        
         if (!resourcesSection.containsKey("requests")) {
             log.info("[Resources] No 'requests' section found in resources. Available keys: {}", resourcesSection.keySet());
             return null;
@@ -442,6 +459,33 @@ public class ArgoCdService {
                 convertedResources.put("memory", convertedMemory);
             }
         }
+        
+        // Parse limits section if present
+        if (resourcesSection.containsKey("limits")) {
+            Object limitsObj = resourcesSection.get("limits");
+            if (limitsObj instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> limits = (Map<String, Object>) limitsObj;
+                log.info("[Resources] Raw limits from values.yaml: {}", limits);
+                if (limits.containsKey("cpu")) {
+                    String limitsCpuValue = String.valueOf(limits.get("cpu"));
+                    String convertedLimitsCpu = convertCpu(limitsCpuValue);
+                    log.info("[Resources] Limits CPU: raw='{}' -> converted='{}'", limitsCpuValue, convertedLimitsCpu);
+                    if (convertedLimitsCpu != null) {
+                        convertedResources.put("limitsCpu", convertedLimitsCpu);
+                    }
+                }
+                if (limits.containsKey("memory")) {
+                    String limitsMemoryValue = String.valueOf(limits.get("memory"));
+                    String convertedLimitsMemory = convertMemory(limitsMemoryValue);
+                    log.info("[Resources] Limits Memory: raw='{}' -> converted='{}'", limitsMemoryValue, convertedLimitsMemory);
+                    if (convertedLimitsMemory != null) {
+                        convertedResources.put("limitsMemory", convertedLimitsMemory);
+                    }
+                }
+            }
+        }
+        
         log.info("[Resources] Final calculated resources: {}", convertedResources);
         return convertedResources.isEmpty() ? null : convertedResources;
     } catch (Exception e) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -242,30 +242,23 @@ public class ArgoCdService {
         } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
-            String limitsCpu = resources.get("limitsCpu");
-            String limitsMemory = resources.get("limitsMemory");
             if (cpu != null) {
                 helmParameters.add(createHelmParam("resources.requests.cpu", cpu + "m"));
                 log.info("[Resources] Sending -> resources.requests.cpu: {}", cpu + "m");
             }
             if (memory != null) {
                 helmParameters.add(createHelmParam("resources.requests.memory", memory + "Mi"));
-                log.info("[Resources] Sending -> resources.requests.memory: {}", memory + "Mi");
+                helmParameters.add(createHelmParam("resources.limits.memory", memory + "Mi"));
+                log.info("[Resources] Sending -> resources.requests.memory: {}, resources.limits.memory: {}", memory + "Mi", memory + "Mi");
             }
-            if (limitsMemory != null) {
-                helmParameters.add(createHelmParam("resources.limits.memory", limitsMemory + "Mi"));
-                log.info("[Resources] Sending -> resources.limits.memory: {}", limitsMemory + "Mi");
-            }
-            if (limitsCpu != null) {
-                helmParameters.add(createHelmParam("resources.limits.cpu", limitsCpu + "m"));
-                log.info("[Resources] Sending -> resources.limits.cpu: {}", limitsCpu + "m");
-            }
+            // Explicitly remove limits.cpu by setting to "null" string
+            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
+            log.info("[Resources] Sending -> resources.limits.cpu: null (override to suppress chart default)");
             log.info("[Resources] Final resources being sent to ArgoCD: " +
-                "requests.cpu={}, requests.memory={}, limits.memory={}, limits.cpu={}",
+                "requests.cpu={}, requests.memory={}, limits.memory={} (same as requests.memory), limits.cpu=null (removed)",
                 cpu != null ? cpu + "m" : "not set",
                 memory != null ? memory + "Mi" : "not set",
-                limitsMemory != null ? limitsMemory + "Mi" : "not set",
-                limitsCpu != null ? limitsCpu + "m" : "not set");
+                memory != null ? memory + "Mi" : "not set");
         } else {
             log.info("[Resources] No resource overrides to apply, chart values.yaml will be used as-is");
         }
@@ -457,32 +450,6 @@ public class ArgoCdService {
             log.info("[Resources] Memory: raw='{}' -> converted='{}'", memoryValue, convertedMemory);
             if (convertedMemory != null) {
                 convertedResources.put("memory", convertedMemory);
-            }
-        }
-        
-        // Parse limits section if present
-        if (resourcesSection.containsKey("limits")) {
-            Object limitsObj = resourcesSection.get("limits");
-            if (limitsObj instanceof Map) {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> limits = (Map<String, Object>) limitsObj;
-                log.info("[Resources] Raw limits from values.yaml: {}", limits);
-                if (limits.containsKey("cpu")) {
-                    String limitsCpuValue = String.valueOf(limits.get("cpu"));
-                    String convertedLimitsCpu = convertCpu(limitsCpuValue);
-                    log.info("[Resources] Limits CPU: raw='{}' -> converted='{}'", limitsCpuValue, convertedLimitsCpu);
-                    if (convertedLimitsCpu != null) {
-                        convertedResources.put("limitsCpu", convertedLimitsCpu);
-                    }
-                }
-                if (limits.containsKey("memory")) {
-                    String limitsMemoryValue = String.valueOf(limits.get("memory"));
-                    String convertedLimitsMemory = convertMemory(limitsMemoryValue);
-                    log.info("[Resources] Limits Memory: raw='{}' -> converted='{}'", limitsMemoryValue, convertedLimitsMemory);
-                    if (convertedLimitsMemory != null) {
-                        convertedResources.put("limitsMemory", convertedLimitsMemory);
-                    }
-                }
             }
         }
         

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -628,8 +628,14 @@ public class ArgoCdService {
                         log.info("Application {} is healthy but last sync {} - FAILED", appName, lastSyncPhase);
                         return "FAILED";
                     }
-                    log.info("Application {} is healthy, last sync {} - DEPLOYED", appName, lastSyncPhase);
-                    return "DEPLOYED";
+                    // Only mark as DEPLOYED when both Healthy AND last sync Succeeded
+                    if ("Succeeded".equalsIgnoreCase(lastSyncPhase)) {
+                        log.info("Application {} is healthy and last sync succeeded - DEPLOYED", appName);
+                        return "DEPLOYED";
+                    }
+                    // Healthy but sync not yet succeeded (Running, empty, etc.) — still deploying
+                    log.info("Application {} is healthy but last sync phase is {} - DEPLOYING", appName, lastSyncPhase);
+                    return "DEPLOYING";
                 case "degraded":
                     log.info("Application {} is degraded - FAILED", appName);
                     return "FAILED";

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -93,7 +93,8 @@ public class DeploymentStatusMonitorJob {
 
     private boolean shouldCheckDeployment(String status) {
         if (status == null) return false;
-        return "DEPLOYING".equalsIgnoreCase(status) || "FAILED".equalsIgnoreCase(status);
+        return "DEPLOYING".equalsIgnoreCase(status) || "FAILED".equalsIgnoreCase(status)
+                || "RESTART_REQUESTED".equalsIgnoreCase(status);
     }
 
     private boolean checkAndUpdateDeployment(String argoToken, CodeServerWorkspaceNsql workspace, 
@@ -106,16 +107,27 @@ public class DeploymentStatusMonitorJob {
 
             
             boolean needsUpdate = false;
-            if ("DEPLOYED".equals(argoStatus) && !"DEPLOYED".equalsIgnoreCase(currentDbStatus)) {
+            String targetStatus = argoStatus;
+            
+            if ("RESTART_REQUESTED".equalsIgnoreCase(currentDbStatus)) {
+                // For restart: Healthy+Succeeded → RESTARTED, Degraded/Failed → RESTART_FAILED
+                if ("DEPLOYED".equals(argoStatus)) {
+                    targetStatus = "RESTARTED";
+                    needsUpdate = true;
+                } else if ("FAILED".equals(argoStatus)) {
+                    targetStatus = "RESTART_FAILED";
+                    needsUpdate = true;
+                }
+            } else if ("DEPLOYED".equals(argoStatus) && !"DEPLOYED".equalsIgnoreCase(currentDbStatus)) {
                 needsUpdate = true;
             } else if ("FAILED".equals(argoStatus) && "DEPLOYING".equalsIgnoreCase(currentDbStatus)) {
                 needsUpdate = true;
             }
 
             if (needsUpdate) {
-                log.info("Reconciling deployment status for {} from {} to {}", appName, currentDbStatus, argoStatus);
+                log.info("Reconciling deployment status for {} from {} to {}", appName, currentDbStatus, targetStatus);
                 
-                deployment.setLastDeploymentStatus(argoStatus);
+                deployment.setLastDeploymentStatus(targetStatus);
                 
                 DeploymentAudit latestAudit = null;
                 if (deployment.getDeploymentAuditLogs() != null && !deployment.getDeploymentAuditLogs().isEmpty()) {
@@ -126,7 +138,7 @@ public class DeploymentStatusMonitorJob {
                         .orElse(null);
                 }
                 
-                if ("DEPLOYED".equals(argoStatus)) {
+                if ("DEPLOYED".equals(targetStatus) || "RESTARTED".equals(targetStatus)) {
                     if (deployment.getLastDeployedBy() == null) {
                         deployment.setLastDeployedBy(workspace.getData().getWorkspaceOwner());
                     }
@@ -145,17 +157,17 @@ public class DeploymentStatusMonitorJob {
                     }
                 }
                 if (latestAudit != null) {
-                    latestAudit.setDeploymentStatus(argoStatus);
-                    if ("DEPLOYED".equals(argoStatus)) {
+                    latestAudit.setDeploymentStatus(targetStatus);
+                    if ("DEPLOYED".equals(targetStatus) || "RESTARTED".equals(targetStatus)) {
                         latestAudit.setDeployedOn(new Date());
                     }
-                    log.info("Updated audit log status to {} for deployment at {}", argoStatus, latestAudit.getTriggeredOn());
+                    log.info("Updated audit log status to {} for deployment at {}", targetStatus, latestAudit.getTriggeredOn());
                 }
 
-                workspaceCustomRepository.updateDeploymentDetails(projectName, environment, deployment, argoStatus);
+                workspaceCustomRepository.updateDeploymentDetails(projectName, environment, deployment, targetStatus);
                 
                 // Also update deployment audit logs in the build deploy entity (used by frontend)
-                updateBuildDeployAuditLog(projectName, environment, argoStatus);
+                updateBuildDeployAuditLog(projectName, environment, targetStatus);
                 
                 return true;
             }
@@ -184,12 +196,13 @@ public class DeploymentStatusMonitorJob {
             if (auditLogs == null || auditLogs.isEmpty()) {
                 return;
             }
-            // Find the latest DEPLOYING audit log and update its status
+            // Find the latest in-progress audit log and update its status
             for (int i = auditLogs.size() - 1; i >= 0; i--) {
                 DeploymentAudit audit = auditLogs.get(i);
-                if ("DEPLOYING".equalsIgnoreCase(audit.getDeploymentStatus())) {
+                String auditStatus = audit.getDeploymentStatus();
+                if ("DEPLOYING".equalsIgnoreCase(auditStatus) || "RESTART_REQUESTED".equalsIgnoreCase(auditStatus)) {
                     audit.setDeploymentStatus(argoStatus);
-                    if ("DEPLOYED".equals(argoStatus)) {
+                    if ("DEPLOYED".equals(argoStatus) || "RESTARTED".equals(argoStatus)) {
                         audit.setDeployedOn(new Date());
                     }
                     log.info("Updated build deploy audit log status to {} for {}-{}", argoStatus, projectName, environment);

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -53,6 +53,47 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
   const enableReadMe =  Envs.CODESPACE_RECIEPES_ENABLE_README?.split(',')?.includes(codeSpace?.projectDetails?.recipeDetails?.Id) || false;
   const [showMigrateOrStartModal, setShowMigrateOrStartModal] = useState(false);
   const contextMenuRef = useRef(null);
+  const restartPollRef = useRef(null);
+
+  // Auto-poll when restart is in progress to detect status transition
+  useEffect(() => {
+    const status = codeSpace?.projectDetails?.lastBuildOrDeployedStatus;
+    if (status === 'RESTART_REQUESTED') {
+      let attempts = 0;
+      const maxAttempts = 60; // 10s interval × 60 = 10 minutes max
+      restartPollRef.current = setInterval(() => {
+        attempts++;
+        if (attempts >= maxAttempts) {
+          clearInterval(restartPollRef.current);
+          restartPollRef.current = null;
+          return;
+        }
+        CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+          .then((res) => {
+            if (res.data && props.onRefreshCard) {
+              const newStatus = res.data?.projectDetails?.lastBuildOrDeployedStatus;
+              props.onRefreshCard(codeSpace.id, res.data);
+              if (newStatus !== 'RESTART_REQUESTED') {
+                clearInterval(restartPollRef.current);
+                restartPollRef.current = null;
+              }
+            }
+          })
+          .catch(() => {});
+      }, 10000);
+    } else {
+      if (restartPollRef.current) {
+        clearInterval(restartPollRef.current);
+        restartPollRef.current = null;
+      }
+    }
+    return () => {
+      if (restartPollRef.current) {
+        clearInterval(restartPollRef.current);
+        restartPollRef.current = null;
+      }
+    };
+  }, [codeSpace?.projectDetails?.lastBuildOrDeployedStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
    
     useEffect(() => {

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -53,47 +53,62 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
   const enableReadMe =  Envs.CODESPACE_RECIEPES_ENABLE_README?.split(',')?.includes(codeSpace?.projectDetails?.recipeDetails?.Id) || false;
   const [showMigrateOrStartModal, setShowMigrateOrStartModal] = useState(false);
   const contextMenuRef = useRef(null);
-  const restartPollRef = useRef(null);
+  const statusPollRef = useRef(null);
 
-  // Auto-poll when restart is in progress to detect status transition
+  // Auto-poll when any in-progress status is detected (deploy, restart, build)
   useEffect(() => {
-    const status = codeSpace?.projectDetails?.lastBuildOrDeployedStatus;
-    if (status === 'RESTART_REQUESTED') {
+    const topStatus = codeSpace?.projectDetails?.lastBuildOrDeployedStatus;
+    const intStatus = codeSpace?.projectDetails?.intDeploymentDetails?.lastDeploymentStatus;
+    const prodStatus = codeSpace?.projectDetails?.prodDeploymentDetails?.lastDeploymentStatus;
+
+    const inProgressStatuses = ['DEPLOYING', 'DEPLOY_REQUESTED', 'RESTART_REQUESTED', 'BUILD_REQUESTED'];
+    const isInProgress = inProgressStatuses.includes(topStatus) ||
+      inProgressStatuses.includes(intStatus) ||
+      inProgressStatuses.includes(prodStatus);
+
+    if (isInProgress) {
       let attempts = 0;
       const maxAttempts = 60; // 10s interval × 60 = 10 minutes max
-      restartPollRef.current = setInterval(() => {
+      statusPollRef.current = setInterval(() => {
         attempts++;
         if (attempts >= maxAttempts) {
-          clearInterval(restartPollRef.current);
-          restartPollRef.current = null;
+          clearInterval(statusPollRef.current);
+          statusPollRef.current = null;
           return;
         }
         CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
           .then((res) => {
             if (res.data && props.onRefreshCard) {
-              const newStatus = res.data?.projectDetails?.lastBuildOrDeployedStatus;
+              const newTopStatus = res.data?.projectDetails?.lastBuildOrDeployedStatus;
+              const newIntStatus = res.data?.projectDetails?.intDeploymentDetails?.lastDeploymentStatus;
+              const newProdStatus = res.data?.projectDetails?.prodDeploymentDetails?.lastDeploymentStatus;
               props.onRefreshCard(codeSpace.id, res.data);
-              if (newStatus !== 'RESTART_REQUESTED') {
-                clearInterval(restartPollRef.current);
-                restartPollRef.current = null;
+              const stillInProgress = inProgressStatuses.includes(newTopStatus) ||
+                inProgressStatuses.includes(newIntStatus) ||
+                inProgressStatuses.includes(newProdStatus);
+              if (!stillInProgress) {
+                clearInterval(statusPollRef.current);
+                statusPollRef.current = null;
               }
             }
           })
           .catch(() => {});
       }, 10000);
     } else {
-      if (restartPollRef.current) {
-        clearInterval(restartPollRef.current);
-        restartPollRef.current = null;
+      if (statusPollRef.current) {
+        clearInterval(statusPollRef.current);
+        statusPollRef.current = null;
       }
     }
     return () => {
-      if (restartPollRef.current) {
-        clearInterval(restartPollRef.current);
-        restartPollRef.current = null;
+      if (statusPollRef.current) {
+        clearInterval(statusPollRef.current);
+        statusPollRef.current = null;
       }
     };
-  }, [codeSpace?.projectDetails?.lastBuildOrDeployedStatus]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [codeSpace?.projectDetails?.lastBuildOrDeployedStatus,
+      codeSpace?.projectDetails?.intDeploymentDetails?.lastDeploymentStatus,
+      codeSpace?.projectDetails?.prodDeploymentDetails?.lastDeploymentStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
    
     useEffect(() => {


### PR DESCRIPTION
## Summary

Seven fixes in this PR:

### 1. Send explicit `resources={}` when values.yaml has empty resources

Previously, an explicit empty `resources: {}` in `values.yaml` caused `calculateResources()` to return `null` (because the empty map has no `requests` key), so no resource parameter was sent at all. Now:

- **`calculateResources()`** detects an empty `resources` section and returns an empty `HashMap` (instead of `null`) to signal "resources is explicitly empty."
- **`buildPayload()`** checks for this empty map and sends `{"name": "resources", "value": "{}"}` as a Helm parameter override.

No changes were made to how non-empty resources (with actual `requests`/`limits` values) are handled — that logic remains unchanged.

### 2. Fix Kong service host for `int` environment

The Kong service URL now appends `-int` to the namespace suffix when `env` is `"int"`, matching the actual Kubernetes namespace (`dev-dna-cs-apps-int`). For `prod`, no suffix is added (unchanged).

**Before** (int): `http://{service}-int.dev-dna-cs-apps:80` → wrong namespace  
**After** (int): `http://{service}-int.dev-dna-cs-apps-int:80` → correct namespace  
**Prod** (unchanged): `http://{service}-prod.dev-dna-cs-apps:80`

This applies to all three cluster environments (dev, staging/test, prod).

### 3. Fix restart stuck on "Restarting..." — monitor `RESTART_REQUESTED` status (backend)

After a restart, the DB status was set to `RESTART_REQUESTED` but nothing transitioned it to `RESTARTED`. The `DeploymentStatusMonitorJob` only monitored `DEPLOYING` and `FAILED`, so restart status was never reconciled.

**Fix:**
- `shouldCheckDeployment()` now includes `RESTART_REQUESTED`
- When ArgoCD reports healthy + sync succeeded → status transitions to `RESTARTED`
- When ArgoCD reports degraded/failed → status transitions to `RESTART_FAILED`
- Audit log updates also handle `RESTART_REQUESTED` entries (not just `DEPLOYING`)

### 4. Fix UI not auto-refreshing after deploy/restart/build (frontend)

The UI cards had no polling mechanism to detect when the backend status changed after a deploy, restart, or build. The existing SSE stream has a race condition: it detects completion from ArgoCD, but then fetches workspace data from the DB which may still show `DEPLOYING` because the monitor job hasn't updated it yet.

**Fix:** Added a `useEffect` in `CodeSpaceCardItem` that auto-polls `getWorkspaceById` every 10 seconds whenever any in-progress status is detected:
- `DEPLOYING`, `DEPLOY_REQUESTED`, `RESTART_REQUESTED`, `BUILD_REQUESTED`
- Checks top-level status AND per-environment (`intDeploymentDetails`, `prodDeploymentDetails`) statuses
- Polling stops automatically once status transitions to a terminal state or after 10 minutes (60 attempts max)

### 5. Fix false "deployment completed" notification on re-deploy (backend SSE)

When re-deploying a workspace that already had a successful deployment, the SSE stream would immediately see the **old** deployment's `Healthy + Succeeded` ArgoCD state and fire a false `deployment-complete` event before the new sync even started.

**Fix:** Added a guard in `DeploymentStatusSseController.streamDeploymentStatus()`:
- Tracks a `seenInProgress` flag — set to `true` once any `DEPLOYING` status is observed (proving the new sync has started)
- Terminal statuses (`DEPLOYED`/`FAILED`) are only accepted if `seenInProgress` is true OR at least 5 iterations (~15 seconds) have passed
- Early terminal statuses from stale ArgoCD state are logged and skipped

### 6. Fix DEPLOYED status: require both Healthy AND Succeeded sync phase

Previously, `checkArgoAppDeploymentStatus()` in `ArgoCdService` and `determineActualStatus()` in `DeploymentStatusSseController` would return `DEPLOYED` whenever ArgoCD health was `Healthy`, regardless of the last sync phase. This meant an app could be marked as `DEPLOYED` while a sync was still running or when `operationState.phase` was empty.

**Fix:** Both methods now require `Healthy` health **AND** `Succeeded` last sync phase to return `DEPLOYED`. If health is `Healthy` but sync phase is anything other than `Succeeded` or `Failed`/`Error`, the status remains `DEPLOYING`.

### 7. Add `podAnnotations.prometheus.io/scrape` Helm parameter

Added `podAnnotations.prometheus\.io/scrape = "true"` with `forceString: true` to the Helm parameters sent when creating an ArgoCD application. The backslash-escaped dot tells Helm to treat `prometheus.io/scrape` as a single annotation key (rather than a nested path).

This required changing the Helm parameter list type from `List<Map<String, String>>` to `List<Map<String, Object>>` to support the boolean `forceString` field, and adding a `createHelmParamForceString()` helper alongside the existing `createHelmParam()`.