### PR TITLE
Send default resource values when resources: {} instead of empty override

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -236,11 +236,13 @@ public class ArgoCdService {
         helmParameters.add(createHelmParam("vaultInjector.namespace", "/"));
         helmParameters.add(createHelmParamForceString("podAnnotations.prometheus\\.io/scrape", "true"));
         
-        boolean useHelmValuesForEmptyResources = false;
         if (resources != null && resources.isEmpty()) {
-            // resources: {} in values.yaml — use helm.values YAML (not --set) to avoid slice parsing issue
-            useHelmValuesForEmptyResources = true;
-            log.info("[Resources] resources is empty in values.yaml, will use helm.values to send resources: {}");
+            // resources: {} in values.yaml — send default resource values
+            helmParameters.add(createHelmParam("resources.requests.cpu", "200m"));
+            helmParameters.add(createHelmParam("resources.requests.memory", "256Mi"));
+            helmParameters.add(createHelmParam("resources.limits.memory", "1Gi"));
+            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
+            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi, limits.cpu=null");
         } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
@@ -289,9 +291,6 @@ public class ArgoCdService {
         
         Map<String, Object> helm = new HashMap<>();
         helm.put("parameters", helmParameters);
-        if (useHelmValuesForEmptyResources) {
-            helm.put("values", "resources: {}\n");
-        }
         source.put("helm", helm);
         
         spec.put("source", source);


### PR DESCRIPTION
## Summary

When `values.yaml` has `resources: {}`, the previous behavior sent `helm.values = "resources: {}\n"` (an empty override). This caused workspaces to deploy with no resource constraints at all.

**Change:** Instead of sending an empty resources override, send default resource parameters:

| Parameter | Value |
|---|---|
| `resources.requests.cpu` | `200m` |
| `resources.requests.memory` | `256Mi` |
| `resources.limits.memory` | `1Gi` |
| `resources.limits.cpu` | `null` (removed) |

This follows the same pattern as when resources has explicit values:
- Memory (RAM) in both `limits` and `requests`
- CPU only in `requests` (not in `limits`)

The `helm.values` field is no longer used — all resource parameters are now sent via `helm.parameters` consistently.

## Review & Testing Checklist for Human

- [ ] **Deploy a workspace with `resources: {}` in values.yaml** and verify the pod gets `requests.cpu=200m`, `requests.memory=256Mi`, `limits.memory=1Gi`, and no `limits.cpu`.
- [ ] **Deploy a workspace with explicit resources** (e.g., `requests.cpu: 500m, requests.memory: 1024Mi`) and confirm behavior is unchanged — limits.memory should equal requests.memory, limits.cpu should be null.
- [ ] **Deploy a workspace with no resources section** in values.yaml and confirm no resource overrides are applied (chart defaults used as-is).

### Notes
- The `helm.values` field for empty resources has been removed entirely. All resource parameters now go through `helm.parameters` for consistency.
- Default values: CPU 200m (requests only), memory 256Mi (requests) / 1Gi (limits).
