### PR TITLE
Send default resource values when resources: {} and conditionally handle limits.cpu

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -236,11 +236,13 @@ public class ArgoCdService {
         helmParameters.add(createHelmParam("vaultInjector.namespace", "/"));
         helmParameters.add(createHelmParamForceString("podAnnotations.prometheus\\.io/scrape", "true"));
         
-        boolean useHelmValuesForEmptyResources = false;
         if (resources != null && resources.isEmpty()) {
-            // resources: {} in values.yaml — use helm.values YAML (not --set) to avoid slice parsing issue
-            useHelmValuesForEmptyResources = true;
-            log.info("[Resources] resources is empty in values.yaml, will use helm.values to send resources: {}");
+            // resources: {} in values.yaml — send default resource values
+            helmParameters.add(createHelmParam("resources.requests.cpu", "200m"));
+            helmParameters.add(createHelmParam("resources.requests.memory", "256Mi"));
+            helmParameters.add(createHelmParam("resources.limits.memory", "1Gi"));
+            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
+            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi, limits.cpu=null");
         } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
@@ -289,9 +291,6 @@ public class ArgoCdService {
         
         Map<String, Object> helm = new HashMap<>();
         helm.put("parameters", helmParameters);
-        if (useHelmValuesForEmptyResources) {
-            helm.put("values", "resources: {}\n");
-        }
         source.put("helm", helm);
         
         spec.put("source", source);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -237,12 +237,11 @@ public class ArgoCdService {
         helmParameters.add(createHelmParamForceString("podAnnotations.prometheus\\.io/scrape", "true"));
         
         if (resources != null && resources.isEmpty()) {
-            // resources: {} in values.yaml — send default resource values
+            // resources: {} in values.yaml — send default resource values (no limits.cpu)
             helmParameters.add(createHelmParam("resources.requests.cpu", "200m"));
             helmParameters.add(createHelmParam("resources.requests.memory", "256Mi"));
             helmParameters.add(createHelmParam("resources.limits.memory", "1Gi"));
-            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
-            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi, limits.cpu=null");
+            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi");
         } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
@@ -255,14 +254,20 @@ public class ArgoCdService {
                 helmParameters.add(createHelmParam("resources.limits.memory", memory + "Mi"));
                 log.info("[Resources] Sending -> resources.requests.memory: {}, resources.limits.memory: {}", memory + "Mi", memory + "Mi");
             }
-            // Explicitly remove limits.cpu by setting to "null" string
-            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
-            log.info("[Resources] Sending -> resources.limits.cpu: null (override to suppress chart default)");
+            // Only suppress limits.cpu when it was explicitly defined in the yaml
+            boolean hasLimitsCpu = "true".equals(resources.get("hasLimitsCpu"));
+            if (hasLimitsCpu) {
+                helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
+                log.info("[Resources] Sending -> resources.limits.cpu: null (override to suppress chart value)");
+            } else {
+                log.info("[Resources] No limits.cpu in values.yaml, skipping limits.cpu override");
+            }
             log.info("[Resources] Final resources being sent to ArgoCD: " +
-                "requests.cpu={}, requests.memory={}, limits.memory={} (same as requests.memory), limits.cpu=null (removed)",
+                "requests.cpu={}, requests.memory={}, limits.memory={} (same as requests.memory), limits.cpu={}",
                 cpu != null ? cpu + "m" : "not set",
                 memory != null ? memory + "Mi" : "not set",
-                memory != null ? memory + "Mi" : "not set");
+                memory != null ? memory + "Mi" : "not set",
+                hasLimitsCpu ? "null (suppressed)" : "not sent");
         } else {
             log.info("[Resources] No resource overrides to apply, chart values.yaml will be used as-is");
         }
@@ -462,6 +467,17 @@ public class ArgoCdService {
             log.info("[Resources] Memory: raw='{}' -> converted='{}'", memoryValue, convertedMemory);
             if (convertedMemory != null) {
                 convertedResources.put("memory", convertedMemory);
+            }
+        }
+        
+        // Check if limits.cpu exists in yaml — used by buildPayload to decide whether to send limits.cpu=null
+        Object limitsObj = resourcesSection.get("limits");
+        if (limitsObj instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> limits = (Map<String, Object>) limitsObj;
+            if (limits.containsKey("cpu")) {
+                convertedResources.put("hasLimitsCpu", "true");
+                log.info("[Resources] limits.cpu found in values.yaml, will send limits.cpu=null override");
             }
         }
         


### PR DESCRIPTION
## Summary

Changes how resource parameters are sent to ArgoCD based on what's in `values.yaml`:

**Case 1 — `resources: {}` (empty):** Send default resource values instead of the previous `helm.values = "resources: {}\n"` override:
| Parameter | Value |
|---|---|
| `resources.requests.cpu` | `200m` |
| `resources.requests.memory` | `256Mi` |
| `resources.limits.memory` | `1Gi` |

No `resources.limits.cpu` is sent.

**Case 2 — resources with values but NO `limits.cpu` in yaml:**
```yaml
resources:
  limits:
    memory: 1Gi
  requests:
    cpu: 200m
    memory: 256Mi
```
Sends `requests.cpu`, `requests.memory`, `limits.memory` from yaml values. No `limits.cpu` is sent (previously it sent `limits.cpu=null`).

**Case 3 — resources with values INCLUDING `limits.cpu` in yaml:**
```yaml
resources:
  limits:
    cpu: 200m
    memory: 1Gi
  requests:
    cpu: 200m
    memory: 256Mi
```
Sends `requests.cpu`, `requests.memory`, `limits.memory` from yaml values, plus `limits.cpu=null` to explicitly suppress the chart's cpu limit.

### Implementation
- `calculateResources()` now checks whether `limits.cpu` exists in the yaml and signals this via a `hasLimitsCpu` flag in the returned map.
- `buildPayload()` uses this flag to conditionally send `limits.cpu=null` only when the yaml has it (Case 3).
- The `helm.values` field is no longer used for empty resources — all parameters go through `helm.parameters`.

Supersedes #5090.

## Review & Testing Checklist for Human

- [ ] **Case 1**: Deploy with `resources: {}` → verify pod gets `requests.cpu=200m`, `requests.memory=256Mi`, `limits.memory=1Gi`, and NO `limits.cpu`
- [ ] **Case 2**: Deploy with resources that have requests+limits.memory but no limits.cpu → verify no `limits.cpu` override is sent
- [ ] **Case 3**: Deploy with resources that include `limits.cpu` → verify `limits.cpu` is sent as `null` to suppress it
- [ ] **No resources section**: Deploy with no `resources` key in values.yaml → verify chart defaults are used as-is

### Notes
- Default values when resources is empty: CPU 200m (requests only), memory 256Mi (requests) / 1Gi (limits)
- `limits.cpu=null` is now only sent when the yaml explicitly defines `limits.cpu`, to avoid unnecessary overrides
