### PR TITLE
Resource defaults for empty resources, conditional limits.cpu, and deployed refresh button

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -236,11 +236,13 @@ public class ArgoCdService {
         helmParameters.add(createHelmParam("vaultInjector.namespace", "/"));
         helmParameters.add(createHelmParamForceString("podAnnotations.prometheus\\.io/scrape", "true"));
         
-        boolean useHelmValuesForEmptyResources = false;
         if (resources != null && resources.isEmpty()) {
-            // resources: {} in values.yaml — use helm.values YAML (not --set) to avoid slice parsing issue
-            useHelmValuesForEmptyResources = true;
-            log.info("[Resources] resources is empty in values.yaml, will use helm.values to send resources: {}");
+            // resources: {} in values.yaml — send default resource values
+            helmParameters.add(createHelmParam("resources.requests.cpu", "200m"));
+            helmParameters.add(createHelmParam("resources.requests.memory", "256Mi"));
+            helmParameters.add(createHelmParam("resources.limits.memory", "1Gi"));
+            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
+            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi, limits.cpu=null");
         } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
@@ -289,9 +291,6 @@ public class ArgoCdService {
         
         Map<String, Object> helm = new HashMap<>();
         helm.put("parameters", helmParameters);
-        if (useHelmValuesForEmptyResources) {
-            helm.put("values", "resources: {}\n");
-        }
         source.put("helm", helm);
         
         spec.put("source", source);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -237,12 +237,11 @@ public class ArgoCdService {
         helmParameters.add(createHelmParamForceString("podAnnotations.prometheus\\.io/scrape", "true"));
         
         if (resources != null && resources.isEmpty()) {
-            // resources: {} in values.yaml — send default resource values
+            // resources: {} in values.yaml — send default resource values (no limits.cpu)
             helmParameters.add(createHelmParam("resources.requests.cpu", "200m"));
             helmParameters.add(createHelmParam("resources.requests.memory", "256Mi"));
             helmParameters.add(createHelmParam("resources.limits.memory", "1Gi"));
-            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
-            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi, limits.cpu=null");
+            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi");
         } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
@@ -255,14 +254,20 @@ public class ArgoCdService {
                 helmParameters.add(createHelmParam("resources.limits.memory", memory + "Mi"));
                 log.info("[Resources] Sending -> resources.requests.memory: {}, resources.limits.memory: {}", memory + "Mi", memory + "Mi");
             }
-            // Explicitly remove limits.cpu by setting to "null" string
-            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
-            log.info("[Resources] Sending -> resources.limits.cpu: null (override to suppress chart default)");
+            // Only suppress limits.cpu when it was explicitly defined in the yaml
+            boolean hasLimitsCpu = "true".equals(resources.get("hasLimitsCpu"));
+            if (hasLimitsCpu) {
+                helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
+                log.info("[Resources] Sending -> resources.limits.cpu: null (override to suppress chart value)");
+            } else {
+                log.info("[Resources] No limits.cpu in values.yaml, skipping limits.cpu override");
+            }
             log.info("[Resources] Final resources being sent to ArgoCD: " +
-                "requests.cpu={}, requests.memory={}, limits.memory={} (same as requests.memory), limits.cpu=null (removed)",
+                "requests.cpu={}, requests.memory={}, limits.memory={} (same as requests.memory), limits.cpu={}",
                 cpu != null ? cpu + "m" : "not set",
                 memory != null ? memory + "Mi" : "not set",
-                memory != null ? memory + "Mi" : "not set");
+                memory != null ? memory + "Mi" : "not set",
+                hasLimitsCpu ? "null (suppressed)" : "not sent");
         } else {
             log.info("[Resources] No resource overrides to apply, chart values.yaml will be used as-is");
         }
@@ -462,6 +467,17 @@ public class ArgoCdService {
             log.info("[Resources] Memory: raw='{}' -> converted='{}'", memoryValue, convertedMemory);
             if (convertedMemory != null) {
                 convertedResources.put("memory", convertedMemory);
+            }
+        }
+        
+        // Check if limits.cpu exists in yaml — used by buildPayload to decide whether to send limits.cpu=null
+        Object limitsObj = resourcesSection.get("limits");
+        if (limitsObj instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> limits = (Map<String, Object>) limitsObj;
+            if (limits.containsKey("cpu")) {
+                convertedResources.put("hasLimitsCpu", "true");
+                log.info("[Resources] limits.cpu found in values.yaml, will send limits.cpu=null override");
             }
         }
         

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -397,6 +397,66 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
+  const onDeployedRefreshClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    const projectName = codeSpace?.projectDetails?.projectName;
+    const environment = codeSpace?.projectDetails?.lastBuildOrDeployedEnv || 'int';
+    const sse = CodeSpaceApiClient.subscribeToDeploymentStatus(
+      projectName,
+      environment,
+      (data) => {
+        // Status update received — check if failed
+        const status = data?.status;
+        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED') {
+          setIsRefreshing(false);
+          sse.close();
+          // Refresh card data from backend to get updated status
+          CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+            .then((res) => {
+              if (res.data && props.onRefreshCard) {
+                props.onRefreshCard(codeSpace.id, res.data);
+              }
+            })
+            .catch(() => {});
+          Notification.show(`${projectName || 'Workspace'} deployment status: Failed`, 'alert');
+        }
+      },
+      (data) => {
+        // Deployment complete — refresh card
+        setIsRefreshing(false);
+        CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+          .then((res) => {
+            if (res.data && props.onRefreshCard) {
+              props.onRefreshCard(codeSpace.id, res.data);
+            }
+          })
+          .catch(() => {});
+        const status = data?.status;
+        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED') {
+          Notification.show(`${projectName || 'Workspace'} deployment status: Failed`, 'alert');
+        } else {
+          Notification.show(`${projectName || 'Workspace'} status refreshed`);
+        }
+      },
+      () => {
+        // SSE error
+        setIsRefreshing(false);
+        // Fallback: refresh from DB
+        handleRefresh();
+      }
+    );
+    // Auto-close SSE after 15 seconds to avoid hanging connections
+    setTimeout(() => {
+      if (sse && sse.readyState !== 2) {
+        sse.close();
+        setIsRefreshing(false);
+      }
+    }, 15000);
+  };
+
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
@@ -705,7 +765,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'DEPLOYED' && (
-                        <span className={Styles.statusIndicator}>
+                        <span className={classNames(Styles.statusIndicator, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intDeploymentDetails?.gitjobRunID)
@@ -721,6 +781,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                             Deployed
                           </a>
+                          <span 
+                            className={Styles.refreshIcon} 
+                            onClick={onDeployedRefreshClick}
+                            tooltip-data="Check deployment health"
+                          >
+                            <i className={classNames('icon mbc-icon refresh', isRefreshing ? Styles.spinning : '')}></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'APPROVAL_PENDING' && (

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -452,3 +452,12 @@
       margin: 0;
     }
   }
+
+  .spinning {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }


### PR DESCRIPTION
## Summary

Two changes: resource handling improvements in the backend and a refresh icon on the Deployed state in the frontend.

### 1. Resource handling — `ArgoCdService.java`

**Case 1 — `resources: {}` (empty):** Instead of sending `helm.values = "resources: {}\n"`, sends default resource parameters:
| Parameter | Value |
|---|---|
| `resources.requests.cpu` | `200m` |
| `resources.requests.memory` | `256Mi` |
| `resources.limits.memory` | `1Gi` |
No `resources.limits.cpu` is sent.

**Case 2 — resources with values but NO `limits.cpu` in yaml** (e.g. `limits: {memory: 1Gi}, requests: {cpu: 200m, memory: 256Mi}`):
Sends values from yaml. No `limits.cpu` is sent — previously it sent `limits.cpu=null` unconditionally.

**Case 3 — resources with values INCLUDING `limits.cpu` in yaml:**
Sends values from yaml plus `limits.cpu=null` to explicitly suppress the chart's cpu limit.

Implementation: `calculateResources()` now checks for `limits.cpu` in the yaml and sets a `hasLimitsCpu` flag. `buildPayload()` only sends `limits.cpu=null` when this flag is present.

### 2. Refresh icon on Deployed status — `CodeSpaceCardItem.js`

Added a refresh icon (same style as Building/Deploying states) on workspace cards showing "Deployed" status. Clicking it:
1. Opens an SSE connection to `subscribeToDeploymentStatus` to check current app health and last sync status
2. If the SSE reports `FAILED` or `DEPLOYMENT_FAILED`, refreshes the card data from the backend — the UI updates from "Deployed" to "Failed"
3. If the status is still healthy, shows a "status refreshed" notification
4. The icon spins while checking; SSE auto-closes after 15 seconds to prevent hanging connections

Supersedes #5090 and #5091.

## Review & Testing Checklist for Human

- [ ] **Resource Case 1**: Deploy with `resources: {}` in values.yaml → verify pod gets `requests.cpu=200m`, `requests.memory=256Mi`, `limits.memory=1Gi`, and NO `limits.cpu`
- [ ] **Resource Case 2**: Deploy with resources that have requests + limits.memory but no limits.cpu → verify no `limits.cpu` override is sent
- [ ] **Resource Case 3**: Deploy with resources that include `limits.cpu` → verify `limits.cpu=null` is sent to suppress it
- [ ] **Refresh icon visible**: After a successful deployment, verify the refresh icon appears next to "Deployed" text
- [ ] **Refresh detects failure**: Manually break a deployment (e.g. bad config) so ArgoCD reports unhealthy, then click the refresh icon on a card still showing "Deployed" — verify it transitions to "Failed"
- [ ] **Refresh on healthy**: Click refresh on a truly healthy deployment — verify it shows "status refreshed" notification and stays "Deployed"

### Notes
- The refresh icon reuses the existing `.refreshIcon` and `.statusWithRefresh` CSS classes from the Building/Deploying states
- SSE connection has a 15-second timeout to prevent hanging if the server doesn't respond
- On SSE error, falls back to a regular `getWorkspaceById` API call
