### PR TITLE
Resource defaults, conditional limits.cpu, and SSE refresh on Built/Deployed

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -236,11 +236,13 @@ public class ArgoCdService {
         helmParameters.add(createHelmParam("vaultInjector.namespace", "/"));
         helmParameters.add(createHelmParamForceString("podAnnotations.prometheus\\.io/scrape", "true"));
         
-        boolean useHelmValuesForEmptyResources = false;
         if (resources != null && resources.isEmpty()) {
-            // resources: {} in values.yaml — use helm.values YAML (not --set) to avoid slice parsing issue
-            useHelmValuesForEmptyResources = true;
-            log.info("[Resources] resources is empty in values.yaml, will use helm.values to send resources: {}");
+            // resources: {} in values.yaml — send default resource values
+            helmParameters.add(createHelmParam("resources.requests.cpu", "200m"));
+            helmParameters.add(createHelmParam("resources.requests.memory", "256Mi"));
+            helmParameters.add(createHelmParam("resources.limits.memory", "1Gi"));
+            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
+            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi, limits.cpu=null");
         } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
@@ -289,9 +291,6 @@ public class ArgoCdService {
         
         Map<String, Object> helm = new HashMap<>();
         helm.put("parameters", helmParameters);
-        if (useHelmValuesForEmptyResources) {
-            helm.put("values", "resources: {}\n");
-        }
         source.put("helm", helm);
         
         spec.put("source", source);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -237,12 +237,11 @@ public class ArgoCdService {
         helmParameters.add(createHelmParamForceString("podAnnotations.prometheus\\.io/scrape", "true"));
         
         if (resources != null && resources.isEmpty()) {
-            // resources: {} in values.yaml — send default resource values
+            // resources: {} in values.yaml — send default resource values (no limits.cpu)
             helmParameters.add(createHelmParam("resources.requests.cpu", "200m"));
             helmParameters.add(createHelmParam("resources.requests.memory", "256Mi"));
             helmParameters.add(createHelmParam("resources.limits.memory", "1Gi"));
-            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
-            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi, limits.cpu=null");
+            log.info("[Resources] resources is empty in values.yaml, sending defaults: requests.cpu=200m, requests.memory=256Mi, limits.memory=1Gi");
         } else if (resources != null && !resources.isEmpty()) {
             String cpu = resources.get("cpu");
             String memory = resources.get("memory");
@@ -255,14 +254,20 @@ public class ArgoCdService {
                 helmParameters.add(createHelmParam("resources.limits.memory", memory + "Mi"));
                 log.info("[Resources] Sending -> resources.requests.memory: {}, resources.limits.memory: {}", memory + "Mi", memory + "Mi");
             }
-            // Explicitly remove limits.cpu by setting to "null" string
-            helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
-            log.info("[Resources] Sending -> resources.limits.cpu: null (override to suppress chart default)");
+            // Only suppress limits.cpu when it was explicitly defined in the yaml
+            boolean hasLimitsCpu = "true".equals(resources.get("hasLimitsCpu"));
+            if (hasLimitsCpu) {
+                helmParameters.add(createHelmParam("resources.limits.cpu", "null"));
+                log.info("[Resources] Sending -> resources.limits.cpu: null (override to suppress chart value)");
+            } else {
+                log.info("[Resources] No limits.cpu in values.yaml, skipping limits.cpu override");
+            }
             log.info("[Resources] Final resources being sent to ArgoCD: " +
-                "requests.cpu={}, requests.memory={}, limits.memory={} (same as requests.memory), limits.cpu=null (removed)",
+                "requests.cpu={}, requests.memory={}, limits.memory={} (same as requests.memory), limits.cpu={}",
                 cpu != null ? cpu + "m" : "not set",
                 memory != null ? memory + "Mi" : "not set",
-                memory != null ? memory + "Mi" : "not set");
+                memory != null ? memory + "Mi" : "not set",
+                hasLimitsCpu ? "null (suppressed)" : "not sent");
         } else {
             log.info("[Resources] No resource overrides to apply, chart values.yaml will be used as-is");
         }
@@ -462,6 +467,17 @@ public class ArgoCdService {
             log.info("[Resources] Memory: raw='{}' -> converted='{}'", memoryValue, convertedMemory);
             if (convertedMemory != null) {
                 convertedResources.put("memory", convertedMemory);
+            }
+        }
+        
+        // Check if limits.cpu exists in yaml — used by buildPayload to decide whether to send limits.cpu=null
+        Object limitsObj = resourcesSection.get("limits");
+        if (limitsObj instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> limits = (Map<String, Object>) limitsObj;
+            if (limits.containsKey("cpu")) {
+                convertedResources.put("hasLimitsCpu", "true");
+                log.info("[Resources] limits.cpu found in values.yaml, will send limits.cpu=null override");
             }
         }
         

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -397,6 +397,66 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
+  const onDeployedRefreshClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    const projectName = codeSpace?.projectDetails?.projectName;
+    const environment = codeSpace?.projectDetails?.lastBuildOrDeployedEnv || 'int';
+    const sse = CodeSpaceApiClient.subscribeToDeploymentStatus(
+      projectName,
+      environment,
+      (data) => {
+        // Status update received — check if failed
+        const status = data?.status;
+        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED') {
+          setIsRefreshing(false);
+          sse.close();
+          // Refresh card data from backend to get updated status
+          CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+            .then((res) => {
+              if (res.data && props.onRefreshCard) {
+                props.onRefreshCard(codeSpace.id, res.data);
+              }
+            })
+            .catch(() => {});
+          Notification.show(`${projectName || 'Workspace'} deployment status: Failed`, 'alert');
+        }
+      },
+      (data) => {
+        // Deployment complete — refresh card
+        setIsRefreshing(false);
+        CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+          .then((res) => {
+            if (res.data && props.onRefreshCard) {
+              props.onRefreshCard(codeSpace.id, res.data);
+            }
+          })
+          .catch(() => {});
+        const status = data?.status;
+        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED') {
+          Notification.show(`${projectName || 'Workspace'} deployment status: Failed`, 'alert');
+        } else {
+          Notification.show(`${projectName || 'Workspace'} status refreshed`);
+        }
+      },
+      () => {
+        // SSE error
+        setIsRefreshing(false);
+        // Fallback: refresh from DB
+        handleRefresh();
+      }
+    );
+    // Auto-close SSE after 15 seconds to avoid hanging connections
+    setTimeout(() => {
+      if (sse && sse.readyState !== 2) {
+        sse.close();
+        setIsRefreshing(false);
+      }
+    }, 15000);
+  };
+
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
@@ -705,7 +765,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'DEPLOYED' && (
-                        <span className={Styles.statusIndicator}>
+                        <span className={classNames(Styles.statusIndicator, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intDeploymentDetails?.gitjobRunID)
@@ -721,6 +781,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                             Deployed
                           </a>
+                          <span 
+                            className={Styles.refreshIcon} 
+                            onClick={onDeployedRefreshClick}
+                            tooltip-data="Check deployment health"
+                          >
+                            <i className={classNames('icon mbc-icon refresh', isRefreshing ? Styles.spinning : '')}></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'APPROVAL_PENDING' && (

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -744,7 +744,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'BUILD_SUCCESS' && (
-                        <span className={Styles.statusIndicator}>
+                        <span className={classNames(Styles.statusIndicator, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intBuildDetails?.gitjobRunID)
@@ -760,6 +760,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                             Built
                           </a>
+                          <span 
+                            className={Styles.refreshIcon} 
+                            onClick={onDeployedRefreshClick}
+                            tooltip-data="Check deployment health"
+                          >
+                            <i className="icon mbc-icon refresh"></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'DEPLOYED' && (

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -397,6 +397,64 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
+  const onDeployedRefreshClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    const projectName = codeSpace?.projectDetails?.projectName;
+    const environment = codeSpace?.projectDetails?.lastBuildOrDeployedEnv || 'int';
+    const sse = CodeSpaceApiClient.subscribeToDeploymentStatus(
+      projectName,
+      environment,
+      (data) => {
+        const status = data?.status;
+        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED') {
+          setIsRefreshing(false);
+          sse.close();
+          CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+            .then((res) => {
+              if (res.data && props.onRefreshCard) {
+                props.onRefreshCard(codeSpace.id, res.data);
+              }
+            })
+            .catch(() => {});
+          Notification.show(`${projectName || 'Workspace'} deployment status: Failed`, 'alert');
+        } else if (status === 'DEPLOYED') {
+          setIsRefreshing(false);
+          sse.close();
+          Notification.show(`${projectName || 'Workspace'} is healthy`);
+        }
+      },
+      (data) => {
+        setIsRefreshing(false);
+        const status = data?.status;
+        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED') {
+          CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+            .then((res) => {
+              if (res.data && props.onRefreshCard) {
+                props.onRefreshCard(codeSpace.id, res.data);
+              }
+            })
+            .catch(() => {});
+          Notification.show(`${projectName || 'Workspace'} deployment status: Failed`, 'alert');
+        } else {
+          Notification.show(`${projectName || 'Workspace'} is healthy`);
+        }
+      },
+      () => {
+        setIsRefreshing(false);
+        handleRefresh();
+      }
+    );
+    setTimeout(() => {
+      if (sse && sse.readyState !== 2) {
+        sse.close();
+        setIsRefreshing(false);
+      }
+    }, 15000);
+  };
+
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
@@ -723,8 +781,8 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           </a>
                           <span 
                             className={Styles.refreshIcon} 
-                            onClick={onRefreshClick}
-                            tooltip-data="Refresh status"
+                            onClick={onDeployedRefreshClick}
+                            tooltip-data="Check deployment health"
                           >
                             <i className="icon mbc-icon refresh"></i>
                           </span>

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -397,66 +397,6 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
-  const onDeployedRefreshClick = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (isRefreshing) return;
-    setIsRefreshing(true);
-    const projectName = codeSpace?.projectDetails?.projectName;
-    const environment = codeSpace?.projectDetails?.lastBuildOrDeployedEnv || 'int';
-    const sse = CodeSpaceApiClient.subscribeToDeploymentStatus(
-      projectName,
-      environment,
-      (data) => {
-        // Status update received — check if failed
-        const status = data?.status;
-        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED') {
-          setIsRefreshing(false);
-          sse.close();
-          // Refresh card data from backend to get updated status
-          CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
-            .then((res) => {
-              if (res.data && props.onRefreshCard) {
-                props.onRefreshCard(codeSpace.id, res.data);
-              }
-            })
-            .catch(() => {});
-          Notification.show(`${projectName || 'Workspace'} deployment status: Failed`, 'alert');
-        }
-      },
-      (data) => {
-        // Deployment complete — refresh card
-        setIsRefreshing(false);
-        CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
-          .then((res) => {
-            if (res.data && props.onRefreshCard) {
-              props.onRefreshCard(codeSpace.id, res.data);
-            }
-          })
-          .catch(() => {});
-        const status = data?.status;
-        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED') {
-          Notification.show(`${projectName || 'Workspace'} deployment status: Failed`, 'alert');
-        } else {
-          Notification.show(`${projectName || 'Workspace'} status refreshed`);
-        }
-      },
-      () => {
-        // SSE error
-        setIsRefreshing(false);
-        // Fallback: refresh from DB
-        handleRefresh();
-      }
-    );
-    // Auto-close SSE after 15 seconds to avoid hanging connections
-    setTimeout(() => {
-      if (sse && sse.readyState !== 2) {
-        sse.close();
-        setIsRefreshing(false);
-      }
-    }, 15000);
-  };
-
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
@@ -783,10 +723,10 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           </a>
                           <span 
                             className={Styles.refreshIcon} 
-                            onClick={onDeployedRefreshClick}
-                            tooltip-data="Check deployment health"
+                            onClick={onRefreshClick}
+                            tooltip-data="Refresh status"
                           >
-                            <i className={classNames('icon mbc-icon refresh', isRefreshing ? Styles.spinning : '')}></i>
+                            <i className="icon mbc-icon refresh"></i>
                           </span>
                         </span>
                       )}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -453,11 +453,3 @@
     }
   }
 
-  .spinning {
-    animation: spin 1s linear infinite;
-  }
-
-  @keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
-  }

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -452,3 +452,12 @@
       margin: 0;
     }
   }
+
+  .spinning {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }


### PR DESCRIPTION
## Summary

### Backend — `ArgoCdService.java`

Three-case resource handling:
- **Case 1 (`resources: {}`):** Sends defaults: `requests.cpu=200m`, `requests.memory=256Mi`, `limits.memory=1Gi`. No `limits.cpu`.
- **Case 2 (resources with values, no `limits.cpu` in yaml):** Sends yaml values. No `limits.cpu`.
- **Case 3 (resources with values, `limits.cpu` in yaml):** Sends yaml values + `limits.cpu=null` to suppress chart default.

`calculateResources()` detects `limits.cpu` via a `hasLimitsCpu` flag. `buildPayload()` conditionally sends `limits.cpu=null` only when the flag is set.

### Frontend — `CodeSpaceCardItem.js`

Added refresh icon on both **Built** and **Deployed** statuses. Clicking it calls the SSE API (`subscribeToDeploymentStatus`) to check real-time app health and sync from ArgoCD:
- If `FAILED`/`DEPLOYMENT_FAILED` → refreshes card data, UI updates to Failed
- If healthy → shows notification
- On SSE error → falls back to `getWorkspaceById`
- Auto-closes SSE after 15s


## Review & Testing Checklist for Human

- [ ] Deploy with `resources: {}` → verify defaults sent, no `limits.cpu`
- [ ] Deploy with resources without `limits.cpu` → verify no `limits.cpu` override
- [ ] Deploy with resources including `limits.cpu` → verify `limits.cpu=null` sent
- [ ] Verify refresh icon on **Built** cards — click it and confirm SSE health check works
- [ ] Verify refresh icon on **Deployed** cards — click it and confirm SSE health check works
- [ ] Click refresh when ArgoCD reports failure → card should update to Failed

### Notes
- Refresh icon reuses existing `.refreshIcon` and `.statusWithRefresh` CSS classes