### PR TITLE
Wire SSE to all deploy flows, extract shared handler factory

### DIFF
--- a/packages/code-space-mfe/src/components/AllCodeSpaces.js
+++ b/packages/code-space-mfe/src/components/AllCodeSpaces.js
@@ -29,7 +29,7 @@ import AddCodespaceGroupModal from './addCodespaceGroupModal/AddCodespaceGroupMo
 import CodeSpaceGroupCard from './codeSpaceGroupCard/CodeSpaceGroupCard';
 import Spinner from './spinner/Spinner';
 import { SESSION_STORAGE_KEYS } from '../Utility/constants';
-import { useDeploymentStatus } from '../hooks/useDeploymentStatus';
+import { useDeploymentStatus, createDeployHandlers } from '../hooks/useDeploymentStatus';
 
 // export interface IAllCodeSpacesProps {
 //   user: IUserInfo;
@@ -73,44 +73,7 @@ const AllCodeSpaces = (props) => {
 
     const { startListening } = useDeploymentStatus();
 
-    const handleDeploymentStatusUpdate = (codeSpaceId, statusData) => {
-        console.log('Deployment status update for', codeSpaceId, statusData);
-        
-        CodeSpaceApiClient.getWorkspaceById(codeSpaceId)
-            .then((res) => {
-                if (res.data) {
-                    onRefreshSingleCodeSpace(codeSpaceId, res.data);
-                }
-            })
-            .catch((err) => {
-                console.error('Error refreshing codespace:', err);
-            });
-    };
-
-    const handleDeploymentComplete = (codeSpaceId, statusData) => {
-        console.log('Deployment complete for', codeSpaceId, statusData);
-        
-        if (statusData.currentStatus === 'DEPLOYED') {
-            Notification.show(`Deployment completed successfully for ${statusData.projectName}`);
-        } else if (statusData.currentStatus === 'FAILED' || statusData.currentStatus === 'ERROR') {
-            Notification.show(`Deployment failed for ${statusData.projectName}`, 'alert');
-        }
-        
-        CodeSpaceApiClient.getWorkspaceById(codeSpaceId)
-            .then((res) => {
-                if (res.data) {
-                    onRefreshSingleCodeSpace(codeSpaceId, res.data);
-                }
-            })
-            .catch((err) => {
-                console.error('Error refreshing codespace:', err);
-            });
-    };
-
-    const handleDeploymentSSEError = (codeSpaceId, error) => {
-        console.error('SSE connection error for', codeSpaceId, error);
-        Notification.show('Real-time deployment updates disconnected. Please refresh manually.', 'alert');
-    };
+    const getDeployHandlers = (codeSpaceId) => createDeployHandlers(codeSpaceId, onRefreshSingleCodeSpace);
 
     const getCodeSpacesData = () => {
         setLoading(true);
@@ -1192,9 +1155,9 @@ const AllCodeSpaces = (props) => {
                     setCodeDeploying={() => { getCodeSpacesData(); getCodeSpaceGroupsData();}}
                     setIsApiCallTakeTime={setIsApiCallTakeTime}
                     startDeploymentStatusListener={startListening}
-                    onDeploymentStatusUpdate={(data) => handleDeploymentStatusUpdate(onDeployCodeSpace?.id, data)}
-                    onDeploymentComplete={(data) => handleDeploymentComplete(onDeployCodeSpace?.id, data)}
-                    onDeploymentSSEError={(error) => handleDeploymentSSEError(onDeployCodeSpace?.id, error)}
+                    onDeploymentStatusUpdate={() => getDeployHandlers(onDeployCodeSpace?.id).onStatusUpdate()}
+                    onDeploymentComplete={(data) => getDeployHandlers(onDeployCodeSpace?.id).onComplete(data)}
+                    onDeploymentSSEError={() => getDeployHandlers(onDeployCodeSpace?.id).onError()}
                 />
             )}
             {showBuildCodeSpaceModal && (
@@ -1221,9 +1184,9 @@ const AllCodeSpaces = (props) => {
                     setCodeBuilding={() => { getCodeSpacesData(); getCodeSpaceGroupsData();}}
                     setIsApiCallTakeTime={setIsApiCallTakeTime}
                     startDeploymentStatusListener={startListening}
-                    onDeploymentStatusUpdate={(data) => handleDeploymentStatusUpdate(onDeployCodeSpace?.id, data)}
-                    onDeploymentComplete={(data) => handleDeploymentComplete(onDeployCodeSpace?.id, data)}
-                    onDeploymentSSEError={(error) => handleDeploymentSSEError(onDeployCodeSpace?.id, error)}
+                    onDeploymentStatusUpdate={() => getDeployHandlers(onDeployCodeSpace?.id).onStatusUpdate()}
+                    onDeploymentComplete={(data) => getDeployHandlers(onDeployCodeSpace?.id).onComplete(data)}
+                    onDeploymentSSEError={() => getDeployHandlers(onDeployCodeSpace?.id).onError()}
                 />
             )}
             {showDeployApprovalModal && (
@@ -1234,9 +1197,9 @@ const AllCodeSpaces = (props) => {
                       setCodeDeploying={() => {getCodeSpacesData(); getCodeSpaceGroupsData();}}
                       setIsApiCallTakeTime={setIsApiCallTakeTime}
                       startDeploymentStatusListener={startListening}
-                      onDeploymentStatusUpdate={(data) => handleDeploymentStatusUpdate(onDeployCodeSpace?.id, data)}
-                      onDeploymentComplete={(data) => handleDeploymentComplete(onDeployCodeSpace?.id, data)}
-                      onDeploymentSSEError={(error) => handleDeploymentSSEError(onDeployCodeSpace?.id, error)}
+                      onDeploymentStatusUpdate={() => getDeployHandlers(onDeployCodeSpace?.id).onStatusUpdate()}
+                      onDeploymentComplete={(data) => getDeployHandlers(onDeployCodeSpace?.id).onComplete(data)}
+                      onDeploymentSSEError={() => getDeployHandlers(onDeployCodeSpace?.id).onError()}
                     />
             )}
             {isApiCallTakeTime && (

--- a/packages/code-space-mfe/src/components/CodeSpace.js
+++ b/packages/code-space-mfe/src/components/CodeSpace.js
@@ -31,6 +31,7 @@ import DeployModal from './deployModal/DeployModal';
 import { setRippleAnimation } from '../common/modules/uilab/js/src/util';
 import ConfirmModal from 'dna-container/ConfirmModal';
 import BuildModal from './buildModal/buildModal';
+import { useDeploymentStatus, createDeployHandlers } from '../hooks/useDeploymentStatus';
 
 // export interface ICodeSpaceProps {
 //   user: IUserInfo;
@@ -166,6 +167,10 @@ const CodeSpace = (props) => {
   const livelinessIntervalRef = React.useRef();
   const stagingWrapperRef = useRef(null);
   const prodWrapperRef = useRef(null);
+
+  const { startListening } = useDeploymentStatus();
+  const refreshCodeSpace = (csId, data) => setCodeSpaceData({ ...data, running: !!data.intiatedOn });
+  const deployHandlers = createDeployHandlers(codeSpaceData?.id, refreshCodeSpace);
 
   // const [branchValue, setBranchValue] = useState('main');
   // const [deployEnvironment, setDeployEnvironment] = useState('staging');
@@ -1223,6 +1228,10 @@ const CodeSpace = (props) => {
           startDeployLivelinessCheck={enableDeployLivelinessCheck}
           setCodeDeploying={setCodeDeploying}
           setIsApiCallTakeTime={setIsApiCallTakeTime}
+          startDeploymentStatusListener={startListening}
+          onDeploymentStatusUpdate={() => deployHandlers.onStatusUpdate()}
+          onDeploymentComplete={(data) => deployHandlers.onComplete(data)}
+          onDeploymentSSEError={() => deployHandlers.onError()}
         />
       )}
 
@@ -1235,6 +1244,10 @@ const CodeSpace = (props) => {
           setCodeDeploying={setCodeDeploying}
           setCodeBuilding={setCodeBuilding}
           setIsApiCallTakeTime={setIsApiCallTakeTime}
+          startDeploymentStatusListener={startListening}
+          onDeploymentStatusUpdate={() => deployHandlers.onStatusUpdate()}
+          onDeploymentComplete={(data) => deployHandlers.onComplete(data)}
+          onDeploymentSSEError={() => deployHandlers.onError()}
         />
       )}
 

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -20,6 +20,7 @@ import { marked } from 'marked';
 import { Envs } from '../../Utility/envs';
 import Tooltip from '../../common/modules/uilab/js/src/tooltip';
 import ContextMenu from '../contextMenu/ContextMenu';
+import { useDeploymentStatus } from '../../hooks/useDeploymentStatus';
 
 let isTouch = false;
 
@@ -397,6 +398,8 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
+  const { startListening, stopListening } = useDeploymentStatus();
+
   const handleDeploymentStatusResult = (status) => {
     setIsRefreshing(false);
     const isFailed = status === 'FAILED' || status === 'DEPLOYMENT_FAILED';
@@ -423,25 +426,20 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     setIsRefreshing(true);
     const projectName = codeSpace?.projectDetails?.projectName;
     const environment = codeSpace?.projectDetails?.lastBuildOrDeployedEnv || 'int';
-    const sse = CodeSpaceApiClient.subscribeToDeploymentStatus(
+    startListening(
       projectName,
       environment,
       (data) => {
         const status = data?.status;
         if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED' || status === 'DEPLOYED') {
-          sse.close();
+          stopListening();
           handleDeploymentStatusResult(status);
         }
       },
       (data) => handleDeploymentStatusResult(data?.status),
       () => { setIsRefreshing(false); handleRefresh(); }
     );
-    setTimeout(() => {
-      if (sse && sse.readyState !== 2) {
-        sse.close();
-        setIsRefreshing(false);
-      }
-    }, 15000);
+    setTimeout(() => { stopListening(); setIsRefreshing(false); }, 15000);
   };
 
   const projectDetails = codeSpace?.projectDetails;

--- a/packages/code-space-mfe/src/hooks/useDeploymentStatus.js
+++ b/packages/code-space-mfe/src/hooks/useDeploymentStatus.js
@@ -1,5 +1,9 @@
 import { useRef, useCallback } from 'react';
 import { CodeSpaceApiClient } from '../apis/codespace.api';
+// @ts-ignore
+import Notification from '../common/modules/uilab/js/src/notification';
+
+const ENV_MAP = { staging: 'int', int: 'int', production: 'prod', prod: 'prod' };
 
 export const useDeploymentStatus = () => {
   const eventSourceRef = useRef(null);
@@ -8,40 +12,16 @@ export const useDeploymentStatus = () => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
     }
-
-    const envMap = {
-      'staging': 'int',
-      'int': 'int',
-      'production': 'prod',
-      'prod': 'prod'
-    };
-    const mappedEnvironment = envMap[environment.toLowerCase()] || environment;
-
-    // Start new SSE connection
+    const mappedEnv = ENV_MAP[environment.toLowerCase()] || environment;
     eventSourceRef.current = CodeSpaceApiClient.subscribeToDeploymentStatus(
       projectName,
-      mappedEnvironment,
-      (data) => {
-        console.log('Deployment status update:', data);
-        onStatusUpdate && onStatusUpdate(data);
-      },
-      (data) => {
-        console.log('Deployment complete:', data);
-        onComplete && onComplete(data);
-        // Connection will be closed by the API client
-        eventSourceRef.current = null;
-      },
-      (error) => {
-        console.error('Deployment SSE error:', error);
-        onError && onError(error);
-        eventSourceRef.current = null;
-      }
+      mappedEnv,
+      (data) => { onStatusUpdate && onStatusUpdate(data); },
+      (data) => { onComplete && onComplete(data); eventSourceRef.current = null; },
+      (error) => { onError && onError(error); eventSourceRef.current = null; }
     );
   }, []);
 
-  /**
-   * Stop listening to deployment status updates
-   */
   const stopListening = useCallback(() => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -49,8 +29,34 @@ export const useDeploymentStatus = () => {
     }
   }, []);
 
+  return { startListening, stopListening };
+};
+
+/**
+ * Reusable SSE handler factory for deploy flows.
+ * Refreshes card data and shows notifications on status changes.
+ */
+export const createDeployHandlers = (codeSpaceId, refreshCallback) => {
+  const refreshCard = () => {
+    CodeSpaceApiClient.getWorkspaceById(codeSpaceId)
+      .then((res) => { if (res.data && refreshCallback) refreshCallback(codeSpaceId, res.data); })
+      .catch(() => {});
+  };
+
   return {
-    startListening,
-    stopListening
+    onStatusUpdate: () => refreshCard(),
+    onComplete: (data) => {
+      const status = data?.currentStatus || data?.status;
+      const name = data?.projectName || 'Workspace';
+      const isFailed = status === 'FAILED' || status === 'ERROR' || status === 'DEPLOYMENT_FAILED';
+      Notification.show(
+        isFailed ? `Deployment failed for ${name}` : `Deployment completed successfully for ${name}`,
+        isFailed ? 'alert' : undefined
+      );
+      refreshCard();
+    },
+    onError: () => {
+      Notification.show('Real-time deployment updates disconnected. Please refresh manually.', 'alert');
+    }
   };
 };


### PR DESCRIPTION
## Summary

Ensures the SSE deployment status listener is called after **every** deploy action (context menu "Deploy Code", Manage Build deploy icon, deploy approval), and consolidates duplicated handler logic into a shared factory.

### What changed (4 files, net -20 lines)

**`useDeploymentStatus.js`** — Enhanced hook:
- Cleaned up `startListening`/`stopListening` (removed console.log noise)
- Added `createDeployHandlers(codeSpaceId, refreshCallback)` — shared factory that returns `{onStatusUpdate, onComplete, onError}` SSE callbacks with card refresh + notifications

**`AllCodeSpaces.js`** — Reduced duplication:
- Replaced 3 inline handler functions (`handleDeploymentStatusUpdate`, `handleDeploymentComplete`, `handleDeploymentSSEError`) with `getDeployHandlers()` using the shared factory
- All 3 modals (DeployModal, BuildModal, DeployApprovalModal) now use the same pattern

**`CodeSpace.js`** — **Bug fix**: SSE was not wired:
- Added `useDeploymentStatus` hook + `createDeployHandlers`
- `DeployModal` and `BuildModal` now receive `startDeploymentStatusListener` and SSE callbacks
- Previously, deploying from the detail view did NOT start the SSE listener — only the card list view did

**`CodeSpaceCardItem.js`** — Uses hook instead of direct API:
- `onDeployedRefreshClick` now uses `startListening`/`stopListening` from the hook instead of calling `CodeSpaceApiClient.subscribeToDeploymentStatus` directly
- Same behavior, consistent SSE management

### Flow after these changes

1. User clicks "Deploy Code" or deploy rocket icon → `DeployModal.onAcceptCodeDeploy()` calls deploy API
2. On success → `startDeploymentStatusListener` opens SSE stream
3. SSE receives `deployment-status` events → `onStatusUpdate` refreshes card from backend
4. SSE receives `deployment-complete` → `onComplete` shows success/failure notification + refreshes card
5. If status is FAILED → card updates from Deployed to Failed in UI

## Review & Testing Checklist for Human

- [ ] Deploy from card list view (context menu "Deploy Code") → verify SSE starts and card updates on success/failure
- [ ] Deploy from Manage Build (rocket icon) → verify SSE starts and card updates
- [ ] Deploy from workspace detail view (`CodeSpace.js`) → verify SSE now works (previously missing)
- [ ] Click refresh icon on Built/Deployed card → verify SSE health check still works
- [ ] Verify no duplicate notifications (only one notification per deploy completion)

### Notes
- Single commit, 4 files changed, 67 insertions / 87 deletions (net reduction)
- `createDeployHandlers` is a pure function (not a hook) exported from `useDeploymentStatus.js` for reuse in any component