### PR TITLE
Add staging(int) migration popup for existing deployments before cutoff date

### DIFF
--- a/packages/code-space-mfe/src/Utility/envs.js
+++ b/packages/code-space-mfe/src/Utility/envs.js
@@ -57,4 +57,5 @@ const getInjectedEnv = (key) => {
     DNA_APP_ID: getInjectedEnv('DNA_APP_ID') || process.env.DNA_APP_ID,
     DNA_ENTITLEMENT_PREFIX: getInjectedEnv('DNA_ENTITLEMENT_PREFIX') || process.env.DNA_ENTITLEMENT_PREFIX,
     FABRIC_API_BASEURL: getInjectedEnv('FABRIC_API_BASEURL') || process.env.FABRIC_API_BASEURL,
+    CODESPACE_INT_MIGRATION_CUTOFF: getInjectedEnv('CODESPACE_INT_MIGRATION_CUTOFF') || process.env.CODESPACE_INT_MIGRATION_CUTOFF,
   };

--- a/packages/code-space-mfe/src/components/CodeSpace.js
+++ b/packages/code-space-mfe/src/components/CodeSpace.js
@@ -10,7 +10,7 @@ import Tabs from '../common/modules/uilab/js/src/tabs';
 import { Envs } from '../Utility/envs';
 // import { ICodeCollaborator, IUserInfo } from 'globals/types';
 import { history } from '../store';
-import { buildGitUrl, trackEvent, buildGitJobLogViewAWSURL, buildLogViewAWSURL } from '../Utility/utils';
+import { buildGitUrl, trackEvent, buildGitJobLogViewAWSURL, buildLogViewAWSURL, regionalDateAndTimeConversionSolution } from '../Utility/utils';
 import Modal from 'dna-container/Modal';
 import Styles from './CodeSpace.scss';
 import FullScreenModeIcon from 'dna-container/FullScreenModeIcon';
@@ -162,6 +162,8 @@ const CodeSpace = (props) => {
   const [showProdActions, setShowProdActions] = useState(false);
   const [showRestartModal, setShowRestartModal] = useState(false);
   const [env, setEnv] = useState("");
+  const [showIntMigrationModal, setShowIntMigrationModal] = useState(false);
+  const [migrationCopied, setMigrationCopied] = useState(false);
 
   const livelinessIntervalRef = React.useRef();
   const stagingWrapperRef = useRef(null);
@@ -401,6 +403,18 @@ const CodeSpace = (props) => {
 
         setCodeBuilding(res?.data?.projectDetails?.lastBuildOrDeployedStatus === 'BUILD_REQUESTED');
 
+        const migrationCutoff = Envs.CODESPACE_INT_MIGRATION_CUTOFF;
+        const intLastDeployedOn = intDeploymentDetails?.lastDeployedOn;
+        if (migrationCutoff && intLastDeployedOn) {
+          const cutoffDate = new Date(migrationCutoff);
+          const deployedDate = new Date(intLastDeployedOn);
+          const projectName = res.data.projectDetails?.projectName;
+          const storageKey = 'intMigrationDismissed_' + projectName;
+          if (deployedDate < cutoffDate && !localStorage.getItem(storageKey)) {
+            setShowIntMigrationModal(true);
+          }
+        }
+
         Tooltip.defaultSetup();
         Tabs.defaultSetup();
         if (deployingInProgress) {
@@ -446,6 +460,37 @@ const CodeSpace = (props) => {
 
   const toggleProgressMessage = (show) => {
     setIsApiCallTakeTime(show);
+  };
+
+  const handleIntMigrationDismiss = () => {
+    const projectName = projectDetails?.projectName;
+    if (projectName) {
+      localStorage.setItem('intMigrationDismissed_' + projectName, 'true');
+    }
+    setShowIntMigrationModal(false);
+    setMigrationCopied(false);
+  };
+
+  const getMigrationDetails = () => {
+    const projectName = projectDetails?.projectName?.toLowerCase();
+    const clusterEnv = Envs.CODE_SERVER_GIT_ENVREF || '';
+    const intDeploymentDetails = codeSpaceData?.projectDetails?.intDeploymentDetails;
+    const deployedAppUrl = intDeploymentDetails?.deploymentUrl || '';
+    const currentHost = projectName + '-int.' + (Envs.CODESERVER_APP_NAMESPACE || '');
+    const newHost = projectName + '-' + clusterEnv + '-int.prod-dna-cs-apps';
+    return { projectName, deployedAppUrl, currentHost, newHost };
+  };
+
+  const onCopyMigrationDetails = () => {
+    const { projectName, deployedAppUrl, currentHost, newHost } = getMigrationDetails();
+    const text = 'Project Name: ' + projectName + '\n' +
+      'Deployed App URL: ' + deployedAppUrl + '\n' +
+      'Current Host: ' + currentHost + '\n' +
+      'New Host: ' + newHost;
+    navigator.clipboard.writeText(text).then(() => {
+      setMigrationCopied(true);
+      setTimeout(() => setMigrationCopied(false), 2000);
+    });
   };
 
   const onNewCodeSpaceModalCancel = () => {
@@ -1265,6 +1310,64 @@ const CodeSpace = (props) => {
       {!serverStarted && (
         <ProgressWithMessage message={`Starting...${serverProgress}%`} />
       )}
+
+      {showIntMigrationModal && (() => {
+        const { projectName, deployedAppUrl, currentHost, newHost } = getMigrationDetails();
+        const intDeploymentDetails = codeSpaceData?.projectDetails?.intDeploymentDetails;
+        const lastDeployedOn = regionalDateAndTimeConversionSolution(intDeploymentDetails?.lastDeployedOn);
+        return (
+          <ConfirmModal
+            title={'Staging Environment Migration Notice'}
+            acceptButtonTitle="OK, I understand"
+            showAcceptButton={true}
+            showCancelButton={false}
+            modalWidth="50%"
+            show={showIntMigrationModal}
+            content={
+              <div>
+                <p>
+                  Your workspace <strong>{projectName}</strong> has an existing staging(int) deployment
+                  (last deployed on <strong>{lastDeployedOn}</strong>) since the last staging deployed
+                  app (<a href={deployedAppUrl} target="_blank" rel="noopener noreferrer">{deployedAppUrl}</a>) needs
+                  to be migrated to a new namespace and we need your support.
+                </p>
+                <p>
+                  Please send the below information to the{' '}
+                  <a href={Envs.CODESPACE_TEAMS_LINK} target="_blank" rel="noopener noreferrer">DnA Team</a>{' '}
+                  before proceeding with the Staging Deployment.
+                </p>
+                <div style={{ background: '#1e1e1e', padding: '12px 16px', borderRadius: '4px', position: 'relative', marginBottom: '16px' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+                    <strong>Namespace Migration Details</strong>
+                    <button
+                      className="btn btn-secondary"
+                      style={{ padding: '4px 12px', fontSize: '12px' }}
+                      onClick={onCopyMigrationDetails}
+                    >
+                      {migrationCopied ? 'Copied!' : 'Copy'}
+                    </button>
+                  </div>
+                  <div style={{ fontFamily: 'monospace', fontSize: '13px', lineHeight: '1.6' }}>
+                    <div>Project Name: {projectName}</div>
+                    <div>Deployed App URL: {deployedAppUrl}</div>
+                    <div>Current Host: {currentHost}</div>
+                    <div>New Host: {newHost}</div>
+                  </div>
+                </div>
+                <p>
+                  <strong>Note:</strong> This notification will only be displayed once.
+                  Please save the details and contact link below for future reference.
+                </p>
+                <p>
+                  <a href={Envs.CODESPACE_TEAMS_LINK} target="_blank" rel="noopener noreferrer">Contact Codespace Team</a>
+                </p>
+              </div>
+            }
+            onCancel={handleIntMigrationDismiss}
+            onAccept={handleIntMigrationDismiss}
+          />
+        );
+      })()}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Adds a one-time popup modal in the workspace detail page (`CodeSpace.js`) to notify users with existing staging(int) deployments about namespace migration.

**Changes:**
- `envs.js`: Added `CODESPACE_INT_MIGRATION_CUTOFF` env var for the cutoff date/time from Vault
- `CodeSpace.js`: 
  - On workspace load, checks if `intDeploymentDetails.lastDeployedOn` is before the `CODESPACE_INT_MIGRATION_CUTOFF` date
  - If yes and not previously dismissed → shows a `ConfirmModal` with migration details
  - Modal displays: project name, deployed app URL, current host, new host (format: `{projectName}-{clusterEnv}-int.prod-dna-cs-apps`)
  - Copy button copies all 4 migration detail fields to clipboard
  - "OK, I understand" dismisses and saves to `localStorage` so it never shows again for that workspace
  - Contact Codespace Team link uses existing `CODESPACE_TEAMS_LINK` env var

**No new files, no new CSS, no styling changes.** Uses existing `ConfirmModal` from `dna-container` and existing `btn btn-secondary` class for the copy button.

## Review & Testing Checklist for Human

- [ ] Set `CODESPACE_INT_MIGRATION_CUTOFF` in Vault (e.g. "March 21, 2026 3:40 PM") and verify the popup appears for workspaces with `lastDeployedOn` before that date
- [ ] Verify the popup does NOT appear for workspaces deployed after the cutoff date
- [ ] Click "OK, I understand" → reload the page → confirm the popup does not reappear (check `localStorage` key `intMigrationDismissed_{projectName}`)
- [ ] Test the Copy button copies correct details (Project Name, Deployed App URL, Current Host, New Host)
- [ ] Verify the new host format is correct: `{projectName}-{CODE_SERVER_GIT_ENVREF}-int.prod-dna-cs-apps`

### Notes

- The cutoff date format should be parseable by JavaScript's `new Date()` (e.g. "March 21, 2026 3:40 PM", or ISO format "2026-03-21T15:40:00")
- Current host is constructed as `{projectName}-int.{CODESERVER_APP_NAMESPACE}`
- Only 2 files changed, 105 lines added
