### PR TITLE
Add staging(int) migration popup on deploy actions for existing deployments

### DIFF
--- a/packages/code-space-mfe/src/Utility/envs.js
+++ b/packages/code-space-mfe/src/Utility/envs.js
@@ -57,4 +57,5 @@ const getInjectedEnv = (key) => {
     DNA_APP_ID: getInjectedEnv('DNA_APP_ID') || process.env.DNA_APP_ID,
     DNA_ENTITLEMENT_PREFIX: getInjectedEnv('DNA_ENTITLEMENT_PREFIX') || process.env.DNA_ENTITLEMENT_PREFIX,
     FABRIC_API_BASEURL: getInjectedEnv('FABRIC_API_BASEURL') || process.env.FABRIC_API_BASEURL,
+    CODESPACE_INT_MIGRATION_CUTOFF: getInjectedEnv('CODESPACE_INT_MIGRATION_CUTOFF') || process.env.CODESPACE_INT_MIGRATION_CUTOFF,
   };

--- a/packages/code-space-mfe/src/components/CodeSpace.js
+++ b/packages/code-space-mfe/src/components/CodeSpace.js
@@ -10,7 +10,7 @@ import Tabs from '../common/modules/uilab/js/src/tabs';
 import { Envs } from '../Utility/envs';
 // import { ICodeCollaborator, IUserInfo } from 'globals/types';
 import { history } from '../store';
-import { buildGitUrl, trackEvent, buildGitJobLogViewAWSURL, buildLogViewAWSURL, regionalDateAndTimeConversionSolution } from '../Utility/utils';
+import { buildGitUrl, trackEvent, buildGitJobLogViewAWSURL, buildLogViewAWSURL } from '../Utility/utils';
 import Modal from 'dna-container/Modal';
 import Styles from './CodeSpace.scss';
 import FullScreenModeIcon from 'dna-container/FullScreenModeIcon';
@@ -162,8 +162,7 @@ const CodeSpace = (props) => {
   const [showProdActions, setShowProdActions] = useState(false);
   const [showRestartModal, setShowRestartModal] = useState(false);
   const [env, setEnv] = useState("");
-  const [showIntMigrationModal, setShowIntMigrationModal] = useState(false);
-  const [migrationCopied, setMigrationCopied] = useState(false);
+
 
   const livelinessIntervalRef = React.useRef();
   const stagingWrapperRef = useRef(null);
@@ -403,18 +402,6 @@ const CodeSpace = (props) => {
 
         setCodeBuilding(res?.data?.projectDetails?.lastBuildOrDeployedStatus === 'BUILD_REQUESTED');
 
-        const migrationCutoff = Envs.CODESPACE_INT_MIGRATION_CUTOFF;
-        const intLastDeployedOn = intDeploymentDetails?.lastDeployedOn;
-        if (migrationCutoff && intLastDeployedOn) {
-          const cutoffDate = new Date(migrationCutoff);
-          const deployedDate = new Date(intLastDeployedOn);
-          const projectName = res.data.projectDetails?.projectName;
-          const storageKey = 'intMigrationDismissed_' + projectName;
-          if (deployedDate < cutoffDate && !localStorage.getItem(storageKey)) {
-            setShowIntMigrationModal(true);
-          }
-        }
-
         Tooltip.defaultSetup();
         Tabs.defaultSetup();
         if (deployingInProgress) {
@@ -460,37 +447,6 @@ const CodeSpace = (props) => {
 
   const toggleProgressMessage = (show) => {
     setIsApiCallTakeTime(show);
-  };
-
-  const handleIntMigrationDismiss = () => {
-    const projectName = projectDetails?.projectName;
-    if (projectName) {
-      localStorage.setItem('intMigrationDismissed_' + projectName, 'true');
-    }
-    setShowIntMigrationModal(false);
-    setMigrationCopied(false);
-  };
-
-  const getMigrationDetails = () => {
-    const projectName = projectDetails?.projectName?.toLowerCase();
-    const clusterEnv = Envs.CODE_SERVER_GIT_ENVREF || '';
-    const intDeploymentDetails = codeSpaceData?.projectDetails?.intDeploymentDetails;
-    const deployedAppUrl = intDeploymentDetails?.deploymentUrl || '';
-    const currentHost = projectName + '-int.' + (Envs.CODESERVER_APP_NAMESPACE || '');
-    const newHost = projectName + '-' + clusterEnv + '-int.prod-dna-cs-apps';
-    return { projectName, deployedAppUrl, currentHost, newHost };
-  };
-
-  const onCopyMigrationDetails = () => {
-    const { projectName, deployedAppUrl, currentHost, newHost } = getMigrationDetails();
-    const text = 'Project Name: ' + projectName + '\n' +
-      'Deployed App URL: ' + deployedAppUrl + '\n' +
-      'Current Host: ' + currentHost + '\n' +
-      'New Host: ' + newHost;
-    navigator.clipboard.writeText(text).then(() => {
-      setMigrationCopied(true);
-      setTimeout(() => setMigrationCopied(false), 2000);
-    });
   };
 
   const onNewCodeSpaceModalCancel = () => {
@@ -1310,64 +1266,6 @@ const CodeSpace = (props) => {
       {!serverStarted && (
         <ProgressWithMessage message={`Starting...${serverProgress}%`} />
       )}
-
-      {showIntMigrationModal && (() => {
-        const { projectName, deployedAppUrl, currentHost, newHost } = getMigrationDetails();
-        const intDeploymentDetails = codeSpaceData?.projectDetails?.intDeploymentDetails;
-        const lastDeployedOn = regionalDateAndTimeConversionSolution(intDeploymentDetails?.lastDeployedOn);
-        return (
-          <ConfirmModal
-            title={'Staging Environment Migration Notice'}
-            acceptButtonTitle="OK, I understand"
-            showAcceptButton={true}
-            showCancelButton={false}
-            modalWidth="50%"
-            show={showIntMigrationModal}
-            content={
-              <div>
-                <p>
-                  Your workspace <strong>{projectName}</strong> has an existing staging(int) deployment
-                  (last deployed on <strong>{lastDeployedOn}</strong>) since the last staging deployed
-                  app (<a href={deployedAppUrl} target="_blank" rel="noopener noreferrer">{deployedAppUrl}</a>) needs
-                  to be migrated to a new namespace and we need your support.
-                </p>
-                <p>
-                  Please send the below information to the{' '}
-                  <a href={Envs.CODESPACE_TEAMS_LINK} target="_blank" rel="noopener noreferrer">DnA Team</a>{' '}
-                  before proceeding with the Staging Deployment.
-                </p>
-                <div style={{ background: '#1e1e1e', padding: '12px 16px', borderRadius: '4px', position: 'relative', marginBottom: '16px' }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
-                    <strong>Namespace Migration Details</strong>
-                    <button
-                      className="btn btn-secondary"
-                      style={{ padding: '4px 12px', fontSize: '12px' }}
-                      onClick={onCopyMigrationDetails}
-                    >
-                      {migrationCopied ? 'Copied!' : 'Copy'}
-                    </button>
-                  </div>
-                  <div style={{ fontFamily: 'monospace', fontSize: '13px', lineHeight: '1.6' }}>
-                    <div>Project Name: {projectName}</div>
-                    <div>Deployed App URL: {deployedAppUrl}</div>
-                    <div>Current Host: {currentHost}</div>
-                    <div>New Host: {newHost}</div>
-                  </div>
-                </div>
-                <p>
-                  <strong>Note:</strong> This notification will only be displayed once.
-                  Please save the details and contact link below for future reference.
-                </p>
-                <p>
-                  <a href={Envs.CODESPACE_TEAMS_LINK} target="_blank" rel="noopener noreferrer">Contact Codespace Team</a>
-                </p>
-              </div>
-            }
-            onCancel={handleIntMigrationDismiss}
-            onAccept={handleIntMigrationDismiss}
-          />
-        );
-      })()}
     </div>
   );
 };

--- a/packages/code-space-mfe/src/components/CodeSpace.js
+++ b/packages/code-space-mfe/src/components/CodeSpace.js
@@ -10,7 +10,7 @@ import Tabs from '../common/modules/uilab/js/src/tabs';
 import { Envs } from '../Utility/envs';
 // import { ICodeCollaborator, IUserInfo } from 'globals/types';
 import { history } from '../store';
-import { buildGitUrl, trackEvent, buildGitJobLogViewAWSURL, buildLogViewAWSURL } from '../Utility/utils';
+import { buildGitUrl, trackEvent, buildGitJobLogViewAWSURL, buildLogViewAWSURL, regionalDateAndTimeConversionSolution } from '../Utility/utils';
 import Modal from 'dna-container/Modal';
 import Styles from './CodeSpace.scss';
 import FullScreenModeIcon from 'dna-container/FullScreenModeIcon';
@@ -162,6 +162,8 @@ const CodeSpace = (props) => {
   const [showProdActions, setShowProdActions] = useState(false);
   const [showRestartModal, setShowRestartModal] = useState(false);
   const [env, setEnv] = useState("");
+  const [showIntMigrationModal, setShowIntMigrationModal] = useState(false);
+  const [migrationCopied, setMigrationCopied] = useState(false);
 
   const livelinessIntervalRef = React.useRef();
   const stagingWrapperRef = useRef(null);
@@ -401,6 +403,18 @@ const CodeSpace = (props) => {
 
         setCodeBuilding(res?.data?.projectDetails?.lastBuildOrDeployedStatus === 'BUILD_REQUESTED');
 
+        const migrationCutoff = Envs.CODESPACE_INT_MIGRATION_CUTOFF;
+        const intLastDeployedOn = intDeploymentDetails?.lastDeployedOn;
+        if (migrationCutoff && intLastDeployedOn) {
+          const cutoffDate = new Date(migrationCutoff);
+          const deployedDate = new Date(intLastDeployedOn);
+          const projectName = res.data.projectDetails?.projectName;
+          const storageKey = 'intMigrationDismissed_' + projectName;
+          if (deployedDate < cutoffDate && !localStorage.getItem(storageKey)) {
+            setShowIntMigrationModal(true);
+          }
+        }
+
         Tooltip.defaultSetup();
         Tabs.defaultSetup();
         if (deployingInProgress) {
@@ -446,6 +460,37 @@ const CodeSpace = (props) => {
 
   const toggleProgressMessage = (show) => {
     setIsApiCallTakeTime(show);
+  };
+
+  const handleIntMigrationDismiss = () => {
+    const projectName = projectDetails?.projectName;
+    if (projectName) {
+      localStorage.setItem('intMigrationDismissed_' + projectName, 'true');
+    }
+    setShowIntMigrationModal(false);
+    setMigrationCopied(false);
+  };
+
+  const getMigrationDetails = () => {
+    const projectName = projectDetails?.projectName?.toLowerCase();
+    const clusterEnv = Envs.CODE_SERVER_GIT_ENVREF || '';
+    const intDeploymentDetails = codeSpaceData?.projectDetails?.intDeploymentDetails;
+    const deployedAppUrl = intDeploymentDetails?.deploymentUrl || '';
+    const currentHost = projectName + '-int.' + (Envs.CODESERVER_APP_NAMESPACE || '');
+    const newHost = projectName + '-' + clusterEnv + '-int.prod-dna-cs-apps';
+    return { projectName, deployedAppUrl, currentHost, newHost };
+  };
+
+  const onCopyMigrationDetails = () => {
+    const { projectName, deployedAppUrl, currentHost, newHost } = getMigrationDetails();
+    const text = 'Project Name: ' + projectName + '\n' +
+      'Deployed App URL: ' + deployedAppUrl + '\n' +
+      'Current Host: ' + currentHost + '\n' +
+      'New Host: ' + newHost;
+    navigator.clipboard.writeText(text).then(() => {
+      setMigrationCopied(true);
+      setTimeout(() => setMigrationCopied(false), 2000);
+    });
   };
 
   const onNewCodeSpaceModalCancel = () => {
@@ -1265,6 +1310,64 @@ const CodeSpace = (props) => {
       {!serverStarted && (
         <ProgressWithMessage message={`Starting...${serverProgress}%`} />
       )}
+
+      {showIntMigrationModal && (() => {
+        const { projectName, deployedAppUrl, currentHost, newHost } = getMigrationDetails();
+        const intDeploymentDetails = codeSpaceData?.projectDetails?.intDeploymentDetails;
+        const lastDeployedOn = regionalDateAndTimeConversionSolution(intDeploymentDetails?.lastDeployedOn);
+        return (
+          <ConfirmModal
+            title={'Staging Environment Migration Notice'}
+            acceptButtonTitle="OK, I understand"
+            showAcceptButton={true}
+            showCancelButton={false}
+            modalWidth="50%"
+            show={showIntMigrationModal}
+            content={
+              <div>
+                <p>
+                  Your workspace <strong>{projectName}</strong> has an existing staging(int) deployment
+                  (last deployed on <strong>{lastDeployedOn}</strong>) since the last staging deployed
+                  app (<a href={deployedAppUrl} target="_blank" rel="noopener noreferrer">{deployedAppUrl}</a>) needs
+                  to be migrated to a new namespace and we need your support.
+                </p>
+                <p>
+                  Please send the below information to the{' '}
+                  <a href={Envs.CODESPACE_TEAMS_LINK} target="_blank" rel="noopener noreferrer">DnA Team</a>{' '}
+                  before proceeding with the Staging Deployment.
+                </p>
+                <div style={{ background: '#1e1e1e', padding: '12px 16px', borderRadius: '4px', position: 'relative', marginBottom: '16px' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+                    <strong>Namespace Migration Details</strong>
+                    <button
+                      className="btn btn-secondary"
+                      style={{ padding: '4px 12px', fontSize: '12px' }}
+                      onClick={onCopyMigrationDetails}
+                    >
+                      {migrationCopied ? 'Copied!' : 'Copy'}
+                    </button>
+                  </div>
+                  <div style={{ fontFamily: 'monospace', fontSize: '13px', lineHeight: '1.6' }}>
+                    <div>Project Name: {projectName}</div>
+                    <div>Deployed App URL: {deployedAppUrl}</div>
+                    <div>Current Host: {currentHost}</div>
+                    <div>New Host: {newHost}</div>
+                  </div>
+                </div>
+                <p>
+                  <strong>Note:</strong> This notification will only be displayed once.
+                  Please save the details and contact link below for future reference.
+                </p>
+                <p>
+                  <a href={Envs.CODESPACE_TEAMS_LINK} target="_blank" rel="noopener noreferrer">Contact Codespace Team</a>
+                </p>
+              </div>
+            }
+            onCancel={handleIntMigrationDismiss}
+            onAccept={handleIntMigrationDismiss}
+          />
+        );
+      })()}
     </div>
   );
 };

--- a/packages/code-space-mfe/src/components/buildModal/buildModal.js
+++ b/packages/code-space-mfe/src/components/buildModal/buildModal.js
@@ -16,6 +16,7 @@ import Tags from 'dna-container/Tags';
 import Tooltip from '../../common/modules/uilab/js/src/tooltip';
 import Pagination from 'dna-container/Pagination';
 import DeployModal from '../deployModal/DeployModal';
+import IntMigrationModal, { needsIntMigration } from '../intMigrationModal/IntMigrationModal';
 
 const BuildModal = (props) => {
   const [branches, setBranches] = useState([]);
@@ -36,6 +37,7 @@ const BuildModal = (props) => {
   const [showDeployCodeSpaceModal, setShowDeployCodeSpaceModal] = useState(false);
   const [buildDetails, setBuildDetails] = useState('');
   const [retainBuildImage, setRetainBuildImage] = useState(false);
+  const [showIntMigrationModal, setShowIntMigrationModal] = useState(false);
 
   const projectDetails = props.codeSpaceData?.projectDetails;
   // const intDeploymentMigrated = props.codeSpaceData?.projectDetails?.intDeploymentDetails?.deploymentUrl?.includes(Envs.CODESPACE_AWS_POPUP_URL);
@@ -466,7 +468,11 @@ const BuildModal = (props) => {
                                     onClick={() => {
                                       item.environment = buildEnvironment;
                                       setBuildDetails(item);
-                                      setShowDeployCodeSpaceModal(true);
+                                      if (buildEnvironment === 'staging' && needsIntMigration(props.codeSpaceData)) {
+                                        setShowIntMigrationModal(true);
+                                      } else {
+                                        setShowDeployCodeSpaceModal(true);
+                                      }
                                     }}
                                   >
                                     <i className="icon mbc-icon deploy" />
@@ -517,6 +523,16 @@ const BuildModal = (props) => {
               startWithFive={true}
             />
           ) : null}
+          {showIntMigrationModal && (
+            <IntMigrationModal
+              show={showIntMigrationModal}
+              codeSpaceData={props.codeSpaceData}
+              onDismiss={() => {
+                setShowIntMigrationModal(false);
+                setShowDeployCodeSpaceModal(true);
+              }}
+            />
+          )}
           {showDeployCodeSpaceModal && (
             <DeployModal
               userInfo={props.userInfo}

--- a/packages/code-space-mfe/src/components/deployModal/DeployModal.js
+++ b/packages/code-space-mfe/src/components/deployModal/DeployModal.js
@@ -12,6 +12,7 @@ import Modal from 'dna-container/Modal';
 import { trackEvent, regionalDateAndTimeConversionSolution, buildGitRepoUrl } from '../../Utility/utils';
 import Tags from 'dna-container/Tags';
 import Tooltip from '../../common/modules/uilab/js/src/tooltip';
+import IntMigrationModal, { needsIntMigration } from '../intMigrationModal/IntMigrationModal';
 
 const DeployModal = (props) => {
   const [branches, setBranches] = useState([]);
@@ -21,6 +22,7 @@ const DeployModal = (props) => {
   const [acceptContinueCodingOnDeployment, setAcceptContinueCodingOnDeployment] = useState(true);
   const projectDetails = props.codeSpaceData?.projectDetails;
   const [retainBuildImage, setRetainBuildImage] = useState(false);
+  const [showIntMigrationModal, setShowIntMigrationModal] = useState(false);
 
   //details from build
   const version = props?.buildDetails?.version || '';
@@ -99,6 +101,11 @@ const DeployModal = (props) => {
       }
     }
     if (formValid) {
+      const isStaging = version?.length ? buildEnvironment === 'staging' : deployEnvironment === 'staging';
+      if (isStaging && needsIntMigration(props.codeSpaceData)) {
+        setShowIntMigrationModal(true);
+        return;
+      }
       const deployRequest = {
         targetEnvironment: version?.length
           ? buildEnvironment === 'staging'
@@ -276,6 +283,13 @@ const DeployModal = (props) => {
         scrollableBox={true}
         onCancel={() => props.setShowCodeDeployModal(false)}
       />
+      {showIntMigrationModal && (
+        <IntMigrationModal
+          show={showIntMigrationModal}
+          codeSpaceData={props.codeSpaceData}
+          onDismiss={() => setShowIntMigrationModal(false)}
+        />
+      )}
     </>
   );
 };

--- a/packages/code-space-mfe/src/components/intMigrationModal/IntMigrationModal.js
+++ b/packages/code-space-mfe/src/components/intMigrationModal/IntMigrationModal.js
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import ConfirmModal from 'dna-container/ConfirmModal';
+import { Envs } from '../../Utility/envs';
+import { regionalDateAndTimeConversionSolution } from '../../Utility/utils';
+
+const IntMigrationModal = ({ show, codeSpaceData, onDismiss }) => {
+  const [copied, setCopied] = useState(false);
+
+  const projectDetails = codeSpaceData?.projectDetails;
+  const projectName = projectDetails?.projectName?.toLowerCase();
+  const clusterEnv = Envs.CODE_SERVER_GIT_ENVREF || '';
+  const intDeploymentDetails = projectDetails?.intDeploymentDetails;
+  const deployedAppUrl = intDeploymentDetails?.deploymentUrl || '';
+  const currentHost = projectName + '-int.' + (Envs.CODESERVER_APP_NAMESPACE || '');
+  const newHost = projectName + '-' + clusterEnv + '-int.prod-dna-cs-apps';
+  const lastDeployedOn = regionalDateAndTimeConversionSolution(intDeploymentDetails?.lastDeployedOn);
+
+  const onCopy = () => {
+    const text = 'Project Name: ' + projectName + '\n' +
+      'Deployed App URL: ' + deployedAppUrl + '\n' +
+      'Current Host: ' + currentHost + '\n' +
+      'New Host: ' + newHost;
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const handleDismiss = () => {
+    if (projectName) {
+      localStorage.setItem('intMigrationDismissed_' + projectName, 'true');
+    }
+    setCopied(false);
+    onDismiss();
+  };
+
+  return (
+    <ConfirmModal
+      title={'Staging Environment Migration Notice'}
+      acceptButtonTitle="OK, I understand"
+      showAcceptButton={true}
+      showCancelButton={false}
+      modalWidth="50%"
+      show={show}
+      content={
+        <div>
+          <p>
+            Your workspace <strong>{projectName}</strong> has an existing staging(int) deployment
+            (last deployed on <strong>{lastDeployedOn}</strong>) since the last staging deployed
+            app (<a href={deployedAppUrl} target="_blank" rel="noopener noreferrer">{deployedAppUrl}</a>) needs
+            to be migrated to a new namespace and we need your support.
+          </p>
+          <p>
+            Please send the below information to the{' '}
+            <a href={Envs.CODESPACE_TEAMS_LINK} target="_blank" rel="noopener noreferrer">DnA Team</a>{' '}
+            before proceeding with the Staging Deployment.
+          </p>
+          <div style={{ background: '#1e1e1e', padding: '12px 16px', borderRadius: '4px', position: 'relative', marginBottom: '16px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+              <strong>Namespace Migration Details</strong>
+              <button
+                className="btn btn-secondary"
+                style={{ padding: '4px 12px', fontSize: '12px' }}
+                onClick={onCopy}
+              >
+                {copied ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+            <div style={{ fontFamily: 'monospace', fontSize: '13px', lineHeight: '1.6' }}>
+              <div>Project Name: {projectName}</div>
+              <div>Deployed App URL: {deployedAppUrl}</div>
+              <div>Current Host: {currentHost}</div>
+              <div>New Host: {newHost}</div>
+            </div>
+          </div>
+          <p>
+            <strong>Note:</strong> This notification will only be displayed once.
+            Please save the details and contact link below for future reference.
+          </p>
+          <p>
+            <a href={Envs.CODESPACE_TEAMS_LINK} target="_blank" rel="noopener noreferrer">Contact Codespace Team</a>
+          </p>
+        </div>
+      }
+      onCancel={handleDismiss}
+      onAccept={handleDismiss}
+    />
+  );
+};
+
+export const needsIntMigration = (codeSpaceData) => {
+  const intDeploymentDetails = codeSpaceData?.projectDetails?.intDeploymentDetails;
+  const lastDeployedOn = intDeploymentDetails?.lastDeployedOn;
+  const migrationCutoff = Envs.CODESPACE_INT_MIGRATION_CUTOFF;
+  const projectName = codeSpaceData?.projectDetails?.projectName;
+
+  if (!migrationCutoff || !lastDeployedOn || !projectName) return false;
+
+  const cutoffDate = new Date(migrationCutoff);
+  const deployedDate = new Date(lastDeployedOn);
+  const storageKey = 'intMigrationDismissed_' + projectName;
+
+  return deployedDate < cutoffDate && !localStorage.getItem(storageKey);
+};
+
+export default IntMigrationModal;


### PR DESCRIPTION
## Summary

Adds a one-time migration popup modal that intercepts staging (int) deploy actions for workspaces with existing deployments before a configurable cutoff date.

**Trigger points (per workspace card):**
1. **Manage Build → rocket icon click** (Build and Deploy) — when build environment is staging
2. **Deploy Code → Deploy button click** — when staging is selected

**What happens:**
- Checks `intDeploymentDetails.lastDeployedOn` against `CODESPACE_INT_MIGRATION_CUTOFF` (from Vault)
- If deployed before cutoff and not previously dismissed → shows migration popup
- Popup includes namespace migration details with a **Copy** button (Project Name, Deployed App URL, Current Host, New Host)
- New host format: `{projectName}-{clusterEnv}-int.prod-dna-cs-apps`
- Contact link uses `CODESPACE_TEAMS_LINK` env var
- "OK, I understand" saves to `localStorage` (`intMigrationDismissed_{projectName}`) — popup never shows again for that workspace
- For rocket icon: after dismissal, the DeployModal opens normally
- For Deploy button: after dismissal, user can click Deploy again (popup won't re-appear)

