### PR TITLE
Re-add refresh icon on Built and Deployed statuses with SSE health check

### DIFF
--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -397,6 +397,53 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
+  const handleDeploymentStatusResult = (status) => {
+    setIsRefreshing(false);
+    const isFailed = status === 'FAILED' || status === 'DEPLOYMENT_FAILED';
+    if (isFailed) {
+      CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+        .then((res) => {
+          if (res.data && props.onRefreshCard) {
+            props.onRefreshCard(codeSpace.id, res.data);
+          }
+        })
+        .catch(() => {});
+    }
+    const name = codeSpace?.projectDetails?.projectName || 'Workspace';
+    Notification.show(
+      isFailed ? `${name} deployment status: Failed` : `${name} is healthy`,
+      isFailed ? 'alert' : undefined
+    );
+  };
+
+  const onDeployedRefreshClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    const projectName = codeSpace?.projectDetails?.projectName;
+    const environment = codeSpace?.projectDetails?.lastBuildOrDeployedEnv || 'int';
+    const sse = CodeSpaceApiClient.subscribeToDeploymentStatus(
+      projectName,
+      environment,
+      (data) => {
+        const status = data?.status;
+        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED' || status === 'DEPLOYED') {
+          sse.close();
+          handleDeploymentStatusResult(status);
+        }
+      },
+      (data) => handleDeploymentStatusResult(data?.status),
+      () => { setIsRefreshing(false); handleRefresh(); }
+    );
+    setTimeout(() => {
+      if (sse && sse.readyState !== 2) {
+        sse.close();
+        setIsRefreshing(false);
+      }
+    }, 15000);
+  };
+
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
@@ -686,7 +733,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'BUILD_SUCCESS' && (
-                        <span className={Styles.statusIndicator}>
+                        <span className={classNames(Styles.statusIndicator, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intBuildDetails?.gitjobRunID)
@@ -702,10 +749,17 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                             Built
                           </a>
+                          <span 
+                            className={Styles.refreshIcon} 
+                            onClick={onDeployedRefreshClick}
+                            tooltip-data="Check deployment health"
+                          >
+                            <i className="icon mbc-icon refresh"></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'DEPLOYED' && (
-                        <span className={Styles.statusIndicator}>
+                        <span className={classNames(Styles.statusIndicator, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intDeploymentDetails?.gitjobRunID)
@@ -721,6 +775,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                             Deployed
                           </a>
+                          <span 
+                            className={Styles.refreshIcon} 
+                            onClick={onDeployedRefreshClick}
+                            tooltip-data="Check deployment health"
+                          >
+                            <i className="icon mbc-icon refresh"></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'APPROVAL_PENDING' && (


### PR DESCRIPTION
## Summary


**What it does:**
- Adds a refresh icon (🔄) next to "Built" and "Deployed" status labels on workspace cards
- On click: calls the existing SSE API (`subscribeToDeploymentStatus`) to check real-time ArgoCD app health and sync status
- If the SSE reports FAILED or DEPLOYMENT_FAILED → refreshes the card data from the API and updates the card status to Failed in the UI
- If healthy → shows a notification "{workspace} is healthy"
- SSE auto-closes after 15 seconds; falls back to `getWorkspaceById` on SSE error
- Uses existing `statusWithRefresh` and `refreshIcon` CSS classes (already in CodeSpaceCardItem.scss)

**Status updates from deploy actions:**
Both deploy flows (Deploy Code modal and Build and Deploy rocket icon) already update card status via the existing SSE infrastructure (`startDeploymentStatusListener` + `handleDeploymentStatusUpdate` callbacks in AllCodeSpaces.js) and the auto-poll mechanism in CodeSpaceCardItem.js.