### PR TITLE
Re-add refresh icon on Built/Deployed with SSE health check and error message display

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -213,11 +213,15 @@ public class DeploymentStatusSseController {
                     argoHealthStatus = rootNode.path("status").path("health").path("status").asText("");
                     argoSyncStatus = rootNode.path("status").path("sync").path("status").asText("");
                     argoLastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
+                    String argoOperationMessage = rootNode.path("status").path("operationState").path("message").asText("");
                     
                     data.put("argocdHealthStatus", argoHealthStatus);
                     data.put("argocdSyncStatus", argoSyncStatus);
                     data.put("argocdLastSyncPhase", argoLastSyncPhase);
                     data.put("argocdAppUrl", argoCdService.getArgocdBaseUrl() + "/applications/" + argoAppName);
+                    if (argoOperationMessage != null && !argoOperationMessage.isEmpty()) {
+                        data.put("argocdOperationMessage", argoOperationMessage);
+                    }
                 }
             } catch (Exception e) {
                 log.debug("Could not fetch ArgoCD status: {}", e.getMessage());

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -397,6 +397,53 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
+  const handleDeploymentStatusResult = (status) => {
+    setIsRefreshing(false);
+    const isFailed = status === 'FAILED' || status === 'DEPLOYMENT_FAILED';
+    if (isFailed) {
+      CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
+        .then((res) => {
+          if (res.data && props.onRefreshCard) {
+            props.onRefreshCard(codeSpace.id, res.data);
+          }
+        })
+        .catch(() => {});
+    }
+    const name = codeSpace?.projectDetails?.projectName || 'Workspace';
+    Notification.show(
+      isFailed ? `${name} deployment status: Failed` : `${name} is healthy`,
+      isFailed ? 'alert' : undefined
+    );
+  };
+
+  const onDeployedRefreshClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    const projectName = codeSpace?.projectDetails?.projectName;
+    const environment = codeSpace?.projectDetails?.lastBuildOrDeployedEnv || 'int';
+    const sse = CodeSpaceApiClient.subscribeToDeploymentStatus(
+      projectName,
+      environment,
+      (data) => {
+        const status = data?.status;
+        if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED' || status === 'DEPLOYED') {
+          sse.close();
+          handleDeploymentStatusResult(status);
+        }
+      },
+      (data) => handleDeploymentStatusResult(data?.status),
+      () => { setIsRefreshing(false); handleRefresh(); }
+    );
+    setTimeout(() => {
+      if (sse && sse.readyState !== 2) {
+        sse.close();
+        setIsRefreshing(false);
+      }
+    }, 15000);
+  };
+
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
@@ -686,7 +733,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'BUILD_SUCCESS' && (
-                        <span className={Styles.statusIndicator}>
+                        <span className={classNames(Styles.statusIndicator, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intBuildDetails?.gitjobRunID)
@@ -702,10 +749,17 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                             Built
                           </a>
+                          <span 
+                            className={Styles.refreshIcon} 
+                            onClick={onDeployedRefreshClick}
+                            tooltip-data="Check deployment health"
+                          >
+                            <i className="icon mbc-icon refresh"></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'DEPLOYED' && (
-                        <span className={Styles.statusIndicator}>
+                        <span className={classNames(Styles.statusIndicator, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intDeploymentDetails?.gitjobRunID)
@@ -721,6 +775,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                             Deployed
                           </a>
+                          <span 
+                            className={Styles.refreshIcon} 
+                            onClick={onDeployedRefreshClick}
+                            tooltip-data="Check deployment health"
+                          >
+                            <i className="icon mbc-icon refresh"></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'APPROVAL_PENDING' && (

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -397,8 +397,9 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
-  const handleDeploymentStatusResult = (status) => {
+  const handleDeploymentStatusResult = (data) => {
     setIsRefreshing(false);
+    const status = data?.currentStatus;
     const isFailed = status === 'FAILED' || status === 'DEPLOYMENT_FAILED';
     if (isFailed) {
       CodeSpaceApiClient.getWorkspaceById(codeSpace.id)
@@ -410,8 +411,11 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
         .catch(() => {});
     }
     const name = codeSpace?.projectDetails?.projectName || 'Workspace';
+    const errorMsg = data?.argocdOperationMessage;
     Notification.show(
-      isFailed ? `${name} deployment status: Failed` : `${name} is healthy`,
+      isFailed
+        ? `${name} deployment status: Failed` + (errorMsg ? '\n' + errorMsg : '')
+        : `${name} is healthy`,
       isFailed ? 'alert' : undefined
     );
   };
@@ -427,13 +431,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
       projectName,
       environment,
       (data) => {
-        const status = data?.status;
+        const status = data?.currentStatus;
         if (status === 'FAILED' || status === 'DEPLOYMENT_FAILED' || status === 'DEPLOYED') {
           sse.close();
-          handleDeploymentStatusResult(status);
+          handleDeploymentStatusResult(data);
         }
       },
-      (data) => handleDeploymentStatusResult(data?.status),
+      (data) => handleDeploymentStatusResult(data),
       () => { setIsRefreshing(false); handleRefresh(); }
     );
     setTimeout(() => {


### PR DESCRIPTION
## Summary

Re-adds the refresh icon on Built (BUILD_SUCCESS) and Deployed (DEPLOYED) card statuses, with SSE-based health checking and **ArgoCD sync error message display**.

**Frontend (`CodeSpaceCardItem.js`):**
- Refresh icon on both Built and Deployed status labels
- On click: calls `subscribeToDeploymentStatus` SSE API to check ArgoCD app health + sync status
- If FAILED → refreshes card data, updates UI to Failed, and **displays the ArgoCD error message** in the notification (e.g. "json: cannot unmarshal array into Go struct field...")
- If healthy → shows "{workspace} is healthy"
- SSE auto-closes after 15s; falls back to `getWorkspaceById` on error
- Fixed bug: was checking `data?.status` instead of `data?.currentStatus` (matching the actual backend SSE field name)

**Backend (`DeploymentStatusSseController.java`):**
- Extracts `status.operationState.message` from ArgoCD response
- Includes it as `argocdOperationMessage` in the SSE `deployment-status` events
- Only sent when the message is non-empty (no change when sync is healthy)

## Review & Testing Checklist for Human

- [ ] Deploy with invalid `values.yaml` (e.g. malformed resources) → click refresh icon → verify the ArgoCD error message appears in the failure notification
- [ ] Deploy successfully → click refresh icon → verify "is healthy" notification appears
- [ ] Verify refresh icon appears on both Built and Deployed statuses
- [ ] Verify card updates from Deployed → Failed when refresh detects failure
- [ ] Deploy from both Deploy Code modal and Manage Build rocket icon → verify card status updates
