### PR TITLE
Show sync failed info icon with error details and update DB to DEPLOYMENT_FAILED

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -72,7 +72,7 @@ public class DeploymentStatusSseController {
                             seenInProgress = true;
                         }
                         
-                        if ("DEPLOYED".equals(status) || "FAILED".equals(status)) {
+                        if ("DEPLOYED".equals(status) || "FAILED".equals(status) || "DEPLOYMENT_FAILED".equals(status)) {
                             // Only accept terminal status if we've seen the deployment actually start,
                             // or enough time has passed to rule out stale ArgoCD state
                             if (seenInProgress || iteration >= minIterationsBeforeTerminal) {
@@ -214,10 +214,15 @@ public class DeploymentStatusSseController {
                     argoSyncStatus = rootNode.path("status").path("sync").path("status").asText("");
                     argoLastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
                     
+                    String argoOperationMessage = rootNode.path("status").path("operationState").path("message").asText("");
+
                     data.put("argocdHealthStatus", argoHealthStatus);
                     data.put("argocdSyncStatus", argoSyncStatus);
                     data.put("argocdLastSyncPhase", argoLastSyncPhase);
                     data.put("argocdAppUrl", argoCdService.getArgocdBaseUrl() + "/applications/" + argoAppName);
+                    if (argoOperationMessage != null && !argoOperationMessage.isEmpty()) {
+                        data.put("argocdOperationMessage", argoOperationMessage);
+                    }
                 }
             } catch (Exception e) {
                 log.debug("Could not fetch ArgoCD status: {}", e.getMessage());
@@ -240,7 +245,8 @@ public class DeploymentStatusSseController {
     }
     
     private String determineActualStatus(String dbStatus, String argoHealth, String lastSyncPhase) {
-        if ("DEPLOYED".equalsIgnoreCase(dbStatus) || "FAILED".equalsIgnoreCase(dbStatus)) {
+        if ("DEPLOYED".equalsIgnoreCase(dbStatus) || "FAILED".equalsIgnoreCase(dbStatus) 
+                || "DEPLOYMENT_FAILED".equalsIgnoreCase(dbStatus)) {
             log.debug("Using terminal DB status: {}", dbStatus);
             return dbStatus;
         }
@@ -266,6 +272,46 @@ public class DeploymentStatusSseController {
         
         // Everything else = FAILED
         return "FAILED";
+    }
+
+    @GetMapping(value = "/workspace/deployment/syncerror/{projectName}/{environment}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, String>> getSyncError(
+            @PathVariable String projectName,
+            @PathVariable String environment) {
+        Map<String, String> result = new HashMap<>();
+        try {
+            // First check if error is stored in DB
+            CodeServerWorkspaceNsql entity = workspaceRepository.findbyProjectName(projectName);
+            if (entity != null && entity.getData() != null && entity.getData().getProjectDetails() != null) {
+                CodeServerDeploymentDetails details = "int".equalsIgnoreCase(environment)
+                        ? entity.getData().getProjectDetails().getIntDeploymentDetails()
+                        : entity.getData().getProjectDetails().getProdDeploymentDetails();
+                if (details != null && details.getLastDeploymentError() != null && !details.getLastDeploymentError().isEmpty()) {
+                    result.put("errorMessage", details.getLastDeploymentError());
+                    return ResponseEntity.ok(result);
+                }
+            }
+
+            // Fallback: fetch from ArgoCD
+            String argoAppName = projectName + "-" + environment;
+            String token = argoCdService.getArgoToken();
+            ResponseEntity<String> argoResponse = argoCdService.getStatusOfArgoApp(token, argoAppName);
+            if (argoResponse != null && argoResponse.getStatusCode().is2xxSuccessful()) {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode rootNode = mapper.readTree(argoResponse.getBody());
+                String message = rootNode.path("status").path("operationState").path("message").asText("");
+                if (!message.isEmpty()) {
+                    result.put("errorMessage", message);
+                    return ResponseEntity.ok(result);
+                }
+            }
+            result.put("errorMessage", "No error details available");
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            log.error("Error fetching sync error for {}/{}: {}", projectName, environment, e.getMessage());
+            result.put("errorMessage", "Failed to fetch error details");
+            return ResponseEntity.ok(result);
+        }
     }
 
     @GetMapping(value = "/workspace/deployment/podlogs/stream/{projectName}/{environment}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/json/CodeServerDeploymentDetails.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/json/CodeServerDeploymentDetails.java
@@ -36,5 +36,6 @@ public class CodeServerDeploymentDetails implements Serializable {
 	private Boolean entitlementPrefixEnabled;
 	private List<String> selectedAliceRoles;
 	private List<DeploymentAudit> deploymentAuditLogs;
+	private String lastDeploymentError;
 	
 }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -666,6 +666,46 @@ public class ArgoCdService {
             return "DEPLOYING";
         }
     }
+    public Map<String, String> checkArgoAppDeploymentStatusWithError(String token, String appName) {
+        Map<String, String> result = new HashMap<>();
+        result.put("status", "DEPLOYING");
+        result.put("errorMessage", "");
+        try {
+            ResponseEntity<String> argoResponse = getStatusOfArgoApp(token, appName);
+            if (argoResponse == null || !argoResponse.getStatusCode().is2xxSuccessful()) {
+                int statusCode = argoResponse != null ? argoResponse.getStatusCode().value() : 0;
+                if (statusCode == 403 || statusCode == 404) {
+                    result.put("status", "FAILED");
+                    result.put("errorMessage", "ArgoCD app " + appName + " - HTTP " + statusCode);
+                    return result;
+                }
+                return result;
+            }
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode rootNode = mapper.readTree(argoResponse.getBody());
+            String healthStatus = rootNode.path("status").path("health").path("status").asText("");
+            String lastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
+            String operationMessage = rootNode.path("status").path("operationState").path("message").asText("");
+
+            if ("Healthy".equalsIgnoreCase(healthStatus) && "Succeeded".equalsIgnoreCase(lastSyncPhase)) {
+                result.put("status", "DEPLOYED");
+                return result;
+            }
+            if ("Running".equalsIgnoreCase(lastSyncPhase) || "Progressing".equalsIgnoreCase(healthStatus)) {
+                return result;
+            }
+            if (lastSyncPhase == null || lastSyncPhase.isEmpty()) {
+                return result;
+            }
+            result.put("status", "FAILED");
+            result.put("errorMessage", operationMessage != null ? operationMessage : "");
+            return result;
+        } catch (Exception e) {
+            log.error("Failed to check ArgoCD deployment status for {}", appName, e);
+            return result;
+        }
+    }
+
     private String getNamespaceForEnvironment(String clusterEnv, String targetEnv) {
         String prefix = (argocdNamespacePrefix != null && !argocdNamespacePrefix.isEmpty()) 
             ? argocdNamespacePrefix : clusterEnv;

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 
 @Component
@@ -127,7 +128,9 @@ public class DeploymentStatusMonitorJob {
         try {
             String appName = projectName.toLowerCase() + "-" + environment;
             String currentDbStatus = deployment.getLastDeploymentStatus();
-            String argoStatus = argoCdService.checkArgoAppDeploymentStatus(argoToken, appName);
+            Map<String, String> argoResult = argoCdService.checkArgoAppDeploymentStatusWithError(argoToken, appName);
+            String argoStatus = argoResult.get("status");
+            String argoErrorMessage = argoResult.get("errorMessage");
 
             
             boolean needsUpdate = false;
@@ -145,6 +148,7 @@ public class DeploymentStatusMonitorJob {
             } else if ("DEPLOYED".equals(argoStatus) && !"DEPLOYED".equalsIgnoreCase(currentDbStatus)) {
                 needsUpdate = true;
             } else if ("FAILED".equals(argoStatus) && "DEPLOYING".equalsIgnoreCase(currentDbStatus)) {
+                targetStatus = "DEPLOYMENT_FAILED";
                 needsUpdate = true;
             }
 
@@ -152,6 +156,11 @@ public class DeploymentStatusMonitorJob {
                 log.info("Reconciling deployment status for {} from {} to {}", appName, currentDbStatus, targetStatus);
                 
                 deployment.setLastDeploymentStatus(targetStatus);
+                if ("DEPLOYMENT_FAILED".equals(targetStatus) || "RESTART_FAILED".equals(targetStatus)) {
+                    deployment.setLastDeploymentError(argoErrorMessage);
+                } else {
+                    deployment.setLastDeploymentError(null);
+                }
                 
                 DeploymentAudit latestAudit = null;
                 if (deployment.getDeploymentAuditLogs() != null && !deployment.getDeploymentAuditLogs().isEmpty()) {

--- a/packages/code-space-mfe/src/apis/codespace.api.js
+++ b/packages/code-space-mfe/src/apis/codespace.api.js
@@ -432,6 +432,10 @@ const subscribeToDeploymentStatus = (projectName, environment, onStatusUpdate, o
     return sse;
 };
 
+const getSyncError = (projectName, environment) => {
+    return httpClient.get(`${baseURL}/workspace/deployment/syncerror/${projectName}/${environment}`);
+};
+
 const subscribeToPodLogs = (projectName, environment, onPodInfo, onPodLogs, onComplete, onError) => {
     const url = `${baseURL}/workspace/deployment/podlogs/stream/${projectName}/${environment}`;
 
@@ -602,6 +606,7 @@ export const CodeSpaceApiClient = {
     workSpaceStatus,
     serverStatusFromHub,
     subscribeToDeploymentStatus,
+    getSyncError,
     subscribeToPodLogs,
     restartDeployments,
     migrateWorkplace,

--- a/packages/code-space-mfe/src/components/AllCodeSpaces.js
+++ b/packages/code-space-mfe/src/components/AllCodeSpaces.js
@@ -92,8 +92,12 @@ const AllCodeSpaces = (props) => {
         
         if (statusData.currentStatus === 'DEPLOYED') {
             Notification.show(`Deployment completed successfully for ${statusData.projectName}`);
-        } else if (statusData.currentStatus === 'FAILED' || statusData.currentStatus === 'ERROR') {
-            Notification.show(`Deployment failed for ${statusData.projectName}`, 'alert');
+        } else if (statusData.currentStatus === 'FAILED' || statusData.currentStatus === 'DEPLOYMENT_FAILED' || statusData.currentStatus === 'ERROR') {
+            const errorMsg = statusData.argocdOperationMessage;
+            Notification.show(
+                `Deployment failed for ${statusData.projectName}` + (errorMsg ? '\n' + errorMsg : ''),
+                'alert'
+            );
         }
         
         CodeSpaceApiClient.getWorkspaceById(codeSpaceId)

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -52,6 +52,9 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
   const [readMeContent, setReadMeContent] = useState('');
   const enableReadMe =  Envs.CODESPACE_RECIEPES_ENABLE_README?.split(',')?.includes(codeSpace?.projectDetails?.recipeDetails?.Id) || false;
   const [showMigrateOrStartModal, setShowMigrateOrStartModal] = useState(false);
+  const [showSyncErrorModal, setShowSyncErrorModal] = useState(false);
+  const [syncErrorMessage, setSyncErrorMessage] = useState('');
+  const [syncErrorLoading, setSyncErrorLoading] = useState(false);
   const contextMenuRef = useRef(null);
   const statusPollRef = useRef(null);
 
@@ -397,6 +400,32 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     handleRefresh();
   };
 
+  const onSyncErrorInfoClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const env = projectDetails?.lastBuildOrDeployedEnv;
+    const details = env === 'int' ? projectDetails?.intDeploymentDetails : projectDetails?.prodDeploymentDetails;
+    const storedError = details?.lastDeploymentError;
+
+    if (storedError) {
+      setSyncErrorMessage(storedError);
+      setShowSyncErrorModal(true);
+    } else {
+      setSyncErrorLoading(true);
+      setShowSyncErrorModal(true);
+      const projectName = projectDetails?.projectName;
+      CodeSpaceApiClient.getSyncError(projectName, env || 'int')
+        .then((res) => {
+          setSyncErrorMessage(res.data?.errorMessage || 'No error details available');
+          setSyncErrorLoading(false);
+        })
+        .catch(() => {
+          setSyncErrorMessage('Failed to fetch error details');
+          setSyncErrorLoading(false);
+        });
+    }
+  };
+
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
@@ -667,7 +696,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                       )}
                       {(projectDetails?.lastBuildOrDeployedStatus === 'DEPLOYMENT_FAILED' ||
                         projectDetails?.lastBuildOrDeployedStatus === 'FAILED') && (
-                        <span className={classNames(Styles.statusIndicator, Styles.deployFailed)}>
+                        <span className={classNames(Styles.statusIndicator, Styles.deployFailed, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intDeploymentDetails?.gitjobRunID)
@@ -683,6 +712,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                            Failed
                           </a>
+                          <span
+                            className={Styles.syncErrorInfoIcon}
+                            onClick={onSyncErrorInfoClick}
+                            tooltip-data="View sync error details"
+                          >
+                            <i className="icon mbc-icon info"></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'BUILD_SUCCESS' && (
@@ -776,7 +812,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'RESTART_FAILED' && (
-                        <span className={classNames(Styles.statusIndicator, Styles.deployFailed)}>
+                        <span className={classNames(Styles.statusIndicator, Styles.deployFailed, Styles.statusWithRefresh)}>
                           <a
                             href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
                               ? buildGitJobLogViewAWSURL(projectDetails?.intDeploymentDetails?.gitjobRunID)
@@ -792,6 +828,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                           >
                            Failed
                           </a>
+                          <span
+                            className={Styles.syncErrorInfoIcon}
+                            onClick={onSyncErrorInfoClick}
+                            tooltip-data="View sync error details"
+                          >
+                            <i className="icon mbc-icon info"></i>
+                          </span>
                         </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'RESTARTED' && (
@@ -917,6 +960,32 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
             setShowMigrateOrStartModal(false);
           }}
           onAccept={onMigrateWorkplace}
+        />
+      )}
+      {showSyncErrorModal && (
+        <Modal
+          showAcceptButton={false}
+          showCancelButton={false}
+          show={showSyncErrorModal}
+          content={
+            <div className={Styles.syncErrorModalContent}>
+              <h3>Deployment Sync Error</h3>
+              {syncErrorLoading ? (
+                <p>Loading error details...</p>
+              ) : (
+                <pre className={Styles.syncErrorPre}>{syncErrorMessage}</pre>
+              )}
+            </div>
+          }
+          scrollableContent={true}
+          onCancel={() => {
+            setShowSyncErrorModal(false);
+            setSyncErrorMessage('');
+          }}
+          modalStyle={{
+            width: '60%',
+            maxHeight: '70%',
+          }}
         />
       )}
     </>

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -452,3 +452,41 @@
       margin: 0;
     }
   }
+
+  .syncErrorInfoIcon {
+    cursor: pointer;
+    color: #e84d47;
+    margin-left: 4px;
+    vertical-align: middle;
+
+    &:hover {
+      opacity: 0.7;
+    }
+
+    i {
+      font-size: inherit;
+      margin: 0;
+    }
+  }
+
+  .syncErrorModalContent {
+    margin-top: -20px;
+    text-align: left;
+
+    h3 {
+      margin-bottom: 15px;
+      color: #e84d47;
+    }
+  }
+
+  .syncErrorPre {
+    background: #1a1e24;
+    padding: 15px;
+    border-radius: 4px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: var(--font-size-small);
+    color: #c0c8d0;
+    max-height: 400px;
+    overflow-y: auto;
+  }


### PR DESCRIPTION
## Summary

When ArgoCD last sync fails during deployment, this PR:

1. **Backend**: Extracts the ArgoCD error message (`status.operationState.message`) and sends it in SSE data
2. **Backend**: Monitor job now updates DB status to `DEPLOYMENT_FAILED` (instead of `FAILED`) and stores the error message in a new `lastDeploymentError` field
3. **Backend**: New `/api/workspace/deployment/syncerror/{projectName}/{environment}` endpoint to fetch error on-demand
4. **Frontend**: Adds an info (i) icon next to "Failed" status on the card — clicking it opens a modal showing the ArgoCD sync error message
5. **Frontend**: Shows error message in notification when deployment fails via SSE

**Files changed (8):**
- `CodeServerDeploymentDetails.java` — new `lastDeploymentError` field
- `DeploymentStatusSseController.java` — extract `argocdOperationMessage` + new sync error endpoint
- `ArgoCdService.java` — new `checkArgoAppDeploymentStatusWithError()` method
- `DeploymentStatusMonitorJob.java` — set `DEPLOYMENT_FAILED` + store error
- `codespace.api.js` — `getSyncError()` API call
- `AllCodeSpaces.js` — handle `DEPLOYMENT_FAILED` in SSE completion
- `CodeSpaceCardItem.js` — info icon + error modal
- `CodeSpaceCardItem.scss` — styles for info icon and modal

## Review & Testing Checklist for Human

- [ ] Deploy a workspace with intentionally invalid resource values (e.g. memory request > limit) to trigger ArgoCD sync failure. Verify the card shows "Failed" with an (i) icon and clicking it shows the correct error message in a modal.
- [ ] Verify the DB record shows `DEPLOYMENT_FAILED` status and `lastDeploymentError` field populated with the ArgoCD error.
- [ ] Reload the page after a failed deployment — click the (i) icon again and verify the error still displays (fetched from DB or ArgoCD API).
- [ ] Deploy a workspace successfully and verify it still shows "Deployed" correctly (no regression).
- [ ] Verify the notification toast shows the ArgoCD error message when deployment fails during live SSE monitoring.

### Notes
- The `DEPLOYMENT_FAILED` status is handled alongside existing `FAILED` checks in frontend rendering
- The sync error endpoint first checks DB for stored error, falls back to live ArgoCD API
- Info icon also added to `RESTART_FAILED` status for consistency
