### PR TITLE
Fix private recipe: repo URL, build NPE, and deploy auto-fire

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
@@ -2143,7 +2143,13 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
                     if (argoToken != null) {
                         String gitRepoUrl;
                         if (isprivateRecipe) {
-                            gitRepoUrl = repoUrl;
+                            gitRepoUrl = entity.getData().getProjectDetails().getRecipeDetails().getRepodetails();
+                            if (gitRepoUrl != null) {
+                                gitRepoUrl = gitRepoUrl.replaceAll("/+$", "");
+                                if (!gitRepoUrl.endsWith(".git")) {
+                                    gitRepoUrl = gitRepoUrl + ".git";
+                                }
+                            }
                         } else {
                             if (repoName == null || repoName.isEmpty()) {
                                 throw new Exception("Git repository name is not set for this workspace. Cannot deploy to ArgoCD.");
@@ -5055,7 +5061,6 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 					} else {
 						auditLog.setCommitId(commitId.getSha());
 					}
-					 auditLog.setCommitId(commitId.getSha());
 					 auditLog.setImageDeleted(Boolean.FALSE);
 					 auditLog.setTriggeredOn(now);
 					 auditLog.setTriggeredBy(entity.getData().getWorkspaceOwner().getGitUserName());

--- a/packages/code-space-mfe/src/components/deployModal/DeployModal.js
+++ b/packages/code-space-mfe/src/components/deployModal/DeployModal.js
@@ -69,12 +69,6 @@ const DeployModal = (props) => {
     }
   }, [deployEnvironment]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (props.skipIntMigrationCheck && version?.length) {
-      onAcceptCodeDeploy();
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
   const onBranchChange = (selectedTags) => {
     setBranchValue(selectedTags);
     setIsBranchValueMissing(false);


### PR DESCRIPTION
## Summary

Fixes three bugs affecting private recipe workspaces:

**1. ArgoCD repo URL missing `.git` suffix**

**2. NPE in `buildWorkSpace()` crashing private recipe builds**

**3. Deploy modal auto-firing without user clicking "Deploy"**
