### PR TITLE
feat: Add CDC refresh endpoint to update published info without overwriting manual data

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricCatalogManagementController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricCatalogManagementController.java
@@ -658,6 +658,68 @@ public class FabricCatalogManagementController implements FabricCatalogManagemen
         }
     }
 
+    @ApiOperation(value = "Refresh CDC entry for a lakehouse.", nickname = "refreshCdcEntry", notes = "Re-fetches published info (tables/columns) from Fabric and updates the CDC entry. Preserves manually entered data (mandatoryFields, description, productName, etc.).", response = PublishCatalogResponseVO.class, tags={ "fabric-catalog-management", })
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Returns refreshed catalog metadata", response = PublishCatalogResponseVO.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = GenericMessage.class),
+        @ApiResponse(code = 401, message = "Request does not have sufficient credentials."),
+        @ApiResponse(code = 403, message = "Request is not authorized."),
+        @ApiResponse(code = 404, message = "Workspace or lakehouse not found."),
+        @ApiResponse(code = 405, message = "Method not allowed"),
+        @ApiResponse(code = 500, message = "Internal error") })
+    @RequestMapping(value = "/catalog/{workspaceId}/{lakehouseId}/refresh",
+        produces = { "application/json" },
+        method = RequestMethod.POST)
+    public ResponseEntity<PublishCatalogResponseVO> refreshCdcEntry(
+            @ApiParam(value = "The ID of the workspace.", required = true) @PathVariable("workspaceId") String workspaceId,
+            @ApiParam(value = "The ID of the lakehouse.", required = true) @PathVariable("lakehouseId") String lakehouseId) {
+
+        PublishCatalogResponseVO responseVO = new PublishCatalogResponseVO();
+
+        try {
+            FabricWorkspaceVO existingFabricWorkspace = fabricWorkspaceService.getById(workspaceId);
+
+            if (existingFabricWorkspace == null
+                    || !workspaceId.equalsIgnoreCase(existingFabricWorkspace.getId())) {
+                log.error("No Fabric Workspace found with id {}", workspaceId);
+                return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+            }
+
+            CreatedByVO requestUser = this.userStore.getVO();
+            String creatorId = existingFabricWorkspace.getCreatedBy().getId();
+
+            if (!requestUser.getId().equalsIgnoreCase(creatorId)
+                    && !utility.hasProjectAdminAccess(requestUser.getId(), workspaceId)) {
+                log.error("User {} not authorized to refresh CDC for workspace {}",
+                        requestUser.getId(), workspaceId);
+                return new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
+            }
+
+            responseVO = service.refreshCdcEntry(workspaceId, lakehouseId, existingFabricWorkspace);
+
+            GenericMessage responseMessage = responseVO.getResponses();
+            if (responseMessage != null && "SUCCESS".equalsIgnoreCase(responseMessage.getSuccess())) {
+                return new ResponseEntity<>(responseVO, HttpStatus.OK);
+            } else if (responseMessage != null && "NOT_FOUND".equalsIgnoreCase(responseMessage.getSuccess())) {
+                return new ResponseEntity<>(responseVO, HttpStatus.NOT_FOUND);
+            } else {
+                return new ResponseEntity<>(responseVO, HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        } catch (Exception e) {
+            log.error("Exception occurred while refreshing CDC entry: {}", e.getMessage());
+            GenericMessage failedResponse = new GenericMessage();
+            List<MessageDescription> messages = new ArrayList<>();
+            MessageDescription message = new MessageDescription();
+            message.setMessage("Failed to refresh CDC entry: " + e.getMessage());
+            messages.add(message);
+            failedResponse.addErrors(message);
+            failedResponse.setSuccess("FAILED");
+            responseVO.setData(null);
+            responseVO.setResponses(failedResponse);
+            return new ResponseEntity<>(responseVO, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     @Override
     @ApiOperation(value = "get the groups status which are request to add to the lakehouse.", nickname = "getGroupsAssignmentStatus", notes = "This endpoint will return the status of groups requested to be added to a lakehouse.", response = List.class, tags={ "fabric-catalog-management", })
     @ApiResponses(value = { 

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/catalogManagement/BaseFabricCatalogManagementService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/catalogManagement/BaseFabricCatalogManagementService.java
@@ -1670,6 +1670,217 @@ public class BaseFabricCatalogManagementService extends BaseCommonService<Fabric
 
 
     @Override
+    @Transactional
+    public PublishCatalogResponseVO refreshCdcEntry(String workspaceId, String lakehouseId,
+            FabricWorkspaceVO workspace) {
+        log.info("Refreshing CDC entry for workspace: {}, lakehouse: {}", workspaceId, lakehouseId);
+
+        PublishCatalogResponseVO response = new PublishCatalogResponseVO();
+        try {
+            Optional<FabricCatalogMetadataNsql> lakehouseEntityOpt = catalogRepo.findById(lakehouseId);
+            if (!lakehouseEntityOpt.isPresent()) {
+                log.error("No existing CDC entry found for lakehouse: {}", lakehouseId);
+                response.setResponses(createErrorResponse(NOT_FOUND_STATUS,
+                        "No existing CDC entry found for lakehouse: " + lakehouseId));
+                return response;
+            }
+
+            FabricCatalogMetadataDetailsVO storedVO = catalogAssembler.toVo(lakehouseEntityOpt.get());
+            CdcTableDetailVO storedDetail = storedVO.getPublishedCDCCatalogs() == null ? null
+                    : storedVO.getPublishedCDCCatalogs().stream()
+                        .filter(d -> lakehouseId.equals(d.getLakeHouseId()))
+                        .findFirst()
+                        .orElse(null);
+
+            if (storedDetail == null) {
+                log.error("No stored CDC detail found for lakehouse: {}", lakehouseId);
+                response.setResponses(createErrorResponse(NOT_FOUND_STATUS,
+                        "No stored CDC detail found for lakehouse: " + lakehouseId));
+                return response;
+            }
+
+            // Re-fetch current tables/columns from Fabric
+            var fabricTablesResponse = cdcPushServiceClient.getLakehouseTables(workspaceId, lakehouseId);
+            if (fabricTablesResponse == null || fabricTablesResponse.getData() == null
+                    || fabricTablesResponse.getData().getTables() == null) {
+                log.warn("No tables returned from Fabric for workspace: {}, lakehouse: {}",
+                        workspaceId, lakehouseId);
+                response.setResponses(createErrorResponse(FAILED_STATUS,
+                        "No tables returned from Fabric for this lakehouse."));
+                return response;
+            }
+
+            // Build fresh table/column details from Fabric, preserving enabled flags
+            Set<String> previouslyEnabledTables = new HashSet<>();
+            Map<String, Set<String>> previouslyEnabledColumns = new HashMap<>();
+            if (storedDetail.getPublishedLakehouseTableDetails() != null) {
+                for (LakehouseTableDetailVO t : storedDetail.getPublishedLakehouseTableDetails()) {
+                    if (t.isEnabled()) {
+                        previouslyEnabledTables.add(t.getTableName());
+                    }
+                    if (t.getColumns() != null) {
+                        Set<String> enabledCols = new HashSet<>();
+                        for (LakehouseColumnDetailVO c : t.getColumns()) {
+                            if (c.isEnabled()) {
+                                enabledCols.add(c.getColumnName());
+                            }
+                        }
+                        previouslyEnabledColumns.put(t.getTableName(), enabledCols);
+                    }
+                }
+            }
+
+            List<String> refreshedTableNames = new ArrayList<>();
+            List<LakehouseTableDetailVO> refreshedTableDetails = new ArrayList<>();
+
+            for (var fabricTable : fabricTablesResponse.getData().getTables()) {
+                String tableName = fabricTable.getTableName();
+                if (tableName == null || tableName.trim().isEmpty()) {
+                    continue;
+                }
+                refreshedTableNames.add(tableName);
+
+                LakehouseTableDetailVO tableDetail = new LakehouseTableDetailVO();
+                tableDetail.setTableName(tableName);
+                // Keep enabled flag for previously enabled tables; new tables default to false
+                tableDetail.setEnabled(previouslyEnabledTables.contains(tableName));
+
+                List<LakehouseColumnDetailVO> columnDetails = new ArrayList<>();
+                try {
+                    var columnsResponse = cdcPushServiceClient.getTableSchema(
+                            workspaceId, lakehouseId, "dbo", tableName);
+                    if (columnsResponse != null && columnsResponse.getData() != null
+                            && columnsResponse.getData().getColumns() != null) {
+                        Set<String> enabledCols = previouslyEnabledColumns.getOrDefault(tableName, new HashSet<>());
+                        for (var fabricColumn : columnsResponse.getData().getColumns()) {
+                            LakehouseColumnDetailVO colDetail = new LakehouseColumnDetailVO();
+                            colDetail.setColumnName(fabricColumn.getColumnName());
+                            colDetail.setEnabled(enabledCols.contains(fabricColumn.getColumnName()));
+                            columnDetails.add(colDetail);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to fetch columns for table {} during refresh: {}", tableName, e.getMessage());
+                }
+                tableDetail.setColumns(columnDetails);
+                refreshedTableDetails.add(tableDetail);
+            }
+
+            // Preserve all manually entered fields, only update the Fabric-derived fields
+            storedDetail.setPublishedLakehouseTables(refreshedTableNames);
+            storedDetail.setPublishedLakehouseTableDetails(refreshedTableDetails);
+            storedDetail.setModifiedOn(LocalDate.now());
+
+            // Update OpenMetadata with new tables/schemas if they exist
+            try {
+                refreshOpenMetadataEntries(workspace, lakehouseId, storedDetail, refreshedTableNames);
+            } catch (Exception e) {
+                log.warn("Failed to refresh OpenMetadata entries for lakehouse {}: {}",
+                        lakehouseId, e.getMessage());
+            }
+
+            // Save updated metadata back to the database
+            FabricCatalogMetadataDetailsVO updatedVO = new FabricCatalogMetadataDetailsVO();
+            updatedVO.setId(lakehouseId);
+            updatedVO.setPublishedCDCCatalogs(storedVO.getPublishedCDCCatalogs());
+
+            FabricCatalogMetadataNsql entity = catalogAssembler.toEntity(updatedVO);
+            entity.setId(lakehouseId);
+            catalogRepo.save(entity);
+
+            prepareSuccessResponse(response, updatedVO);
+            log.info("CDC entry refreshed successfully for lakehouse: {}", lakehouseId);
+        } catch (Exception e) {
+            log.error("Failed to refresh CDC entry for lakehouse {}: {}", lakehouseId, e.getMessage(), e);
+            response.setResponses(createErrorResponse(FAILED_STATUS,
+                    "Failed to refresh CDC entry: " + e.getMessage()));
+        }
+        return response;
+    }
+
+    /**
+     * Syncs OpenMetadata entries for a lakehouse after a CDC refresh. Adds new
+     * tables/columns that appeared in Fabric without removing any existing ones
+     * whose data may have been manually curated.
+     */
+    private void refreshOpenMetadataEntries(FabricWorkspaceVO workspace,
+            String lakehouseId, CdcTableDetailVO storedDetail,
+            List<String> currentFabricTableNames) {
+        try {
+            FabricLakehouseVO lakehouse = workspace.getLakehouses() == null ? null
+                    : workspace.getLakehouses().stream()
+                        .filter(lh -> lakehouseId.equals(lh.getId()))
+                        .findFirst()
+                        .orElse(null);
+            if (lakehouse == null) {
+                return;
+            }
+
+            try {
+                openMetadataClient.getDatabaseService(workspace.getName());
+            } catch (EntityNotFoundException e) {
+                log.info("No database service found in OpenMetadata for workspace {}, skipping OM refresh",
+                        workspace.getName());
+                return;
+            }
+
+            Database database;
+            try {
+                database = openMetadataClient.getDatabase(workspace.getName(), lakehouse.getName());
+            } catch (EntityNotFoundException e) {
+                log.info("Database not found in OpenMetadata for lakehouse {}, skipping OM refresh",
+                        lakehouse.getName());
+                return;
+            }
+
+            List<DatabaseSchema> schemas = openMetadataClient.getSchemasForDatabase(
+                    database.getFullyQualifiedName());
+            if (schemas == null || schemas.isEmpty()) {
+                return;
+            }
+
+            // Collect all existing OM table names across all schemas
+            Set<String> existingOmTableNames = new HashSet<>();
+            for (DatabaseSchema schema : schemas) {
+                List<Table> tables = openMetadataClient.getTablesForSchema(schema.getFullyQualifiedName());
+                if (tables != null) {
+                    for (Table t : tables) {
+                        existingOmTableNames.add(t.getName());
+                    }
+                }
+            }
+
+            // Add new tables that appear in Fabric but not yet in OpenMetadata
+            DatabaseSchema defaultSchema = schemas.get(0);
+            for (String fabricTableName : currentFabricTableNames) {
+                if (!existingOmTableNames.contains(fabricTableName)) {
+                    try {
+                        var columnsResponse = cdcPushServiceClient.getTableSchema(
+                                workspace.getId(), lakehouseId, "dbo", fabricTableName);
+                        List<Column> columns = new ArrayList<>();
+                        if (columnsResponse != null && columnsResponse.getData() != null
+                                && columnsResponse.getData().getColumns() != null) {
+                            for (var col : columnsResponse.getData().getColumns()) {
+                                columns.add(openMetadataClient.buildColumn(
+                                        col.getColumnName(), null,
+                                        col.getDataType(), null));
+                            }
+                        }
+                        openMetadataClient.createTable(fabricTableName,
+                                defaultSchema.getFullyQualifiedName(), columns);
+                        log.info("Created new OM table {} during CDC refresh", fabricTableName);
+                    } catch (Exception e) {
+                        log.warn("Failed to create OM table {} during refresh: {}",
+                                fabricTableName, e.getMessage());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Error refreshing OpenMetadata entries: {}", e.getMessage());
+        }
+    }
+
+    @Override
     public TableMismatchResponseVO checkTableMismatch(String workspaceId, String lakehouseId, String serviceName) {
         log.info("Checking table mismatch for workspace: {}, lakehouse: {}", workspaceId, lakehouseId);
         TableMismatchResponseVO response = new TableMismatchResponseVO();

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/catalogManagement/FabricCatalogManagementService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/catalogManagement/FabricCatalogManagementService.java
@@ -26,7 +26,14 @@ public interface FabricCatalogManagementService extends CommonService<FabricCata
 	PublishCatalogResponseVO updateCatalogMetaData(PublishCatalogRequestVO request, FabricWorkspaceVO existingFabricWorkspace);
 	LakehouseObjectsResponseVO getLakehouseObjects(String workspaceId, String lakehouseId, String schemaName);
 	TableMismatchResponseVO checkTableMismatch(String workspaceId, String lakehouseId, String serviceName);
-	
+
+	/**
+	 * Refreshes the CDC entry for a specific lakehouse by re-fetching published info
+	 * (tables/columns) from Fabric. Preserves manually entered data such as
+	 * mandatoryFields, description, productName, productId, createdBy, and createdOn.
+	 */
+	PublishCatalogResponseVO refreshCdcEntry(String workspaceId, String lakehouseId, FabricWorkspaceVO workspace);
+
 	/**
 	 * This method is fetech and retrun all the legal enteties from the genesis 
 	 * @return List<LegalEntitiesResponseVO>

--- a/packages/fabric-backend/lib/src/main/resources/api/fabricCatalogManagement.yaml
+++ b/packages/fabric-backend/lib/src/main/resources/api/fabricCatalogManagement.yaml
@@ -218,6 +218,44 @@ paths:
         500:
           description: "Internal error"
 
+  /catalog/{workspaceId}/{lakehouseId}/refresh:
+    post:
+      tags:
+        - "fabric-catalog-management"
+      summary: "Refresh CDC entry for a lakehouse."
+      description: "Re-fetches published info (tables/columns) from Fabric and updates the CDC entry. Preserves manually entered data (mandatoryFields, description, productName, etc.)."
+      operationId: "refreshCdcEntry"
+      parameters:
+        - name: "workspaceId"
+          in: "path"
+          description: "The ID of the workspace."
+          required: true
+          type: "string"
+        - name: "lakehouseId"
+          in: "path"
+          description: "The ID of the lakehouse."
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "Returns refreshed catalog metadata"
+          schema:
+            $ref: "#/definitions/PublishCatalogResponseVO"
+        400:
+          description: "Bad Request"
+          schema:
+            $ref: "#/definitions/GenericMessage"
+        401:
+          description: "Request does not have sufficient credentials."
+        403:
+          description: "Request is not authorized."
+        404:
+          description: "Workspace or lakehouse not found."
+        405:
+          description: "Method not allowed"
+        500:
+          description: "Internal error"
+
   /catalog/{workspaceId}/check-mismatch:
     get:
       tags:

--- a/packages/fabric-mfe/src/apis/fabric.api.js
+++ b/packages/fabric-mfe/src/apis/fabric.api.js
@@ -193,6 +193,10 @@ const saveLakehouseSnapshot = (workspaceId, lakehouseId, payload) => {
   return server.post(`/fabric-workspaces/catalog/${workspaceId}/lakehouses/${lakehouseId}/snapshot`, payload);
 };
 
+const refreshCdcEntry = (workspaceId, lakehouseId) => {
+  return server.post(`/fabric-workspaces/catalog/${workspaceId}/${lakehouseId}/refresh`);
+};
+
 export const fabricApi = {
   getFabricWorkspaces,
   getFabricWorkspacesForAdmin,
@@ -225,4 +229,5 @@ export const fabricApi = {
   checkTableMismatch,
   getCatalogMetadata,
   saveLakehouseSnapshot,
+  refreshCdcEntry,
 };

--- a/packages/fabric-mfe/src/components/Lakehouses/Lakehouses.js
+++ b/packages/fabric-mfe/src/components/Lakehouses/Lakehouses.js
@@ -383,6 +383,31 @@ function Lakehouses({ user, workspace, lakehouses, onDeleteLakehouse, onRefreshW
       });
   };
 
+  const handleRefreshCdc = (lakehouse) => {
+    if (workspace?.typeOfProject?.toLowerCase() !== "production") {
+      setShowNonProdProjectModal(true);
+      return;
+    }
+
+    ProgressIndicator.show();
+    fabricApi.refreshCdcEntry(workspace.id, lakehouse.id)
+      .then(() => {
+        ProgressIndicator.hide();
+        Notification.show("CDC entry refreshed successfully!", "success");
+        if (onRefreshWorkspace) {
+          onRefreshWorkspace();
+        }
+      })
+      .catch((e) => {
+        ProgressIndicator.hide();
+        const backendMessage =
+          e?.response?.data?.responses?.errors?.[0]?.message ||
+          e?.response?.data?.errors?.[0]?.message ||
+          'Failed to refresh CDC entry';
+        Notification.show(backendMessage, 'alert');
+      });
+  };
+
   // Pagination 
   const [totalNumberOfPages, setTotalNumberOfPages] = useState(0);
   const [currentPageNumber, setCurrentPageNumber] = useState(1);
@@ -660,6 +685,18 @@ function Lakehouses({ user, workspace, lakehouses, onDeleteLakehouse, onRefreshW
                         >
                           <i className="icon mbc-icon dublicate" />
                           <span>Push to CDC</span>
+                        </button>
+                      </li>
+                      <li className="contextListItem">
+                        <button className={classNames('btn btn-primary', Styles.outlineBtn, !(workspace?.cdcPublishedLakeHouseDetails?.publishedLakeHouseNames?.includes(lakehouse.id)) && Styles.disabledBtn)}
+                          onClick={() => {
+                            if (workspace?.cdcPublishedLakeHouseDetails?.publishedLakeHouseNames?.includes(lakehouse.id)) {
+                              handleRefreshCdc(lakehouse);
+                            }
+                          }}
+                        >
+                          <i className="icon mbc-icon refresh" />
+                          <span>Refresh CDC</span>
                         </button>
                       </li>
                       <li className="contextListItem">


### PR DESCRIPTION
## Summary

Adds a **Refresh CDC** capability that re-fetches the latest tables/columns from Fabric and updates the CDC entry, **without overwriting manually entered data** (mandatoryFields, description, productName, productId, createdBy, createdOn).

### Backend

New endpoint: `POST /catalog/{workspaceId}/{lakehouseId}/refresh`

```
refreshCdcEntry(workspaceId, lakehouseId, workspace):
  storedVO = catalogRepo.findById(lakehouseId)
  storedDetail = storedVO.publishedCDCCatalogs.find(d -> d.lakeHouseId == lakehouseId)
  
  // Re-fetch from Fabric
  fabricTables = cdcPushServiceClient.getLakehouseTables(workspaceId, lakehouseId)
  
  // Preserve previously enabled table/column flags
  previouslyEnabledTables = storedDetail.publishedLakehouseTableDetails
      .filter(t -> t.enabled).map(t -> t.tableName)
  
  // Build refreshed list from Fabric, keeping enabled flags for existing items
  refreshedTableDetails = fabricTables.map(table -> {
      detail.enabled = previouslyEnabledTables.contains(table.name)
      detail.columns = fetchColumns(table).map(col -> {
          col.enabled = previouslyEnabledColumns[table.name].contains(col.name)
      })
  })
  
  // Only update Fabric-derived fields; mandatoryFields, createdBy, etc. untouched
  storedDetail.publishedLakehouseTables = refreshedTableNames
  storedDetail.publishedLakehouseTableDetails = refreshedTableDetails
  storedDetail.modifiedOn = now
  
  // Sync new tables to OpenMetadata (additive only, no deletions)
  refreshOpenMetadataEntries(...)
  
  catalogRepo.save(updatedVO)
```

Key design choices:
- **Additive-only OM sync**: New Fabric tables are created in OpenMetadata but existing tables are not removed, preserving any manually curated metadata.
- **Enabled flag preservation**: Tables/columns that were previously enabled keep their enabled status after refresh; new items default to disabled.
- **Same auth/access checks** as existing publish/mismatch endpoints (workspace owner or project admin).

### Frontend

- `fabricApi.refreshCdcEntry(workspaceId, lakehouseId)` API function
- "Refresh CDC" button in the lakehouse context menu, enabled only for lakehouses already published to CDC

### Swagger

- Added `POST /catalog/{workspaceId}/{lakehouseId}/refresh` endpoint definition

Link to Devin session: https://mercedes-benz.devinenterprise.com/sessions/611d5cd01d7d48d3ae7ea14740e7d6d9