### PR TITLE
Enable CDC refresh with pre-populated fields without overwriting manual data

### DIFF
--- a/packages/fabric-mfe/src/apis/fabric.api.js
+++ b/packages/fabric-mfe/src/apis/fabric.api.js
@@ -163,6 +163,16 @@ const pushSelectedTables = (workspaceId, payload) => {
   return server.post(`fabric-workspaces/catalog/${workspaceId}/publish`, payload);
 };
 
+const updateSelectedTables = (workspaceId, payload) => {
+  return server.put(`fabric-workspaces/catalog/${workspaceId}/publish`, payload);
+};
+
+const getStoredCdcMetadata = (workspaceId, serviceName) => {
+  return server.get(`/fabric-workspaces/catalog/${workspaceId}/${encodeURIComponent(serviceName)}`, {
+    data: {},
+  });
+};
+
 const takeOwnership = (id) => {
   return server.patch(`/fabric-workspaces/${id}/takeOwnership`, {
     data: {},
@@ -219,6 +229,8 @@ export const fabricApi = {
   getLakehouseTables,
   getTableSchema,
   pushSelectedTables,
+  updateSelectedTables,
+  getStoredCdcMetadata,
   takeOwnership,
   getLegalEntities,
   publishDdxDataProduct,

--- a/packages/fabric-mfe/src/components/Lakehouses/CdcPush.js
+++ b/packages/fabric-mfe/src/components/Lakehouses/CdcPush.js
@@ -99,7 +99,11 @@ export const buildCdcPayload = ({
   };
 };
 
-const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRefreshWorkspace }) => {
+const REVERSE_TIER_MAP = Object.fromEntries(
+  Object.entries(DATA_TIER_MAP).map(([label, value]) => [value, label])
+);
+
+const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRefreshWorkspace, isRefresh, workspaceName }) => {
   const [tables, setTables] = useState([]);
   const [columnsByTable, setColumnsByTable] = useState({});
   const [selectedTables, setSelectedTables] = useState({});
@@ -113,6 +117,8 @@ const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRef
   const [description, setDescription] = useState(null);
   const [showCdcLogin, setShowCdcLogin] = useState(false);
   const [hasPushedOnce, setHasPushedOnce] = useState(false);
+  const [storedCdcData, setStoredCdcData] = useState(null);
+  const [prePopulated, setPrePopulated] = useState(false);
 
   const methods = useForm();
   const { 
@@ -165,6 +171,103 @@ const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRef
         );
       });
   }, [workspaceId]);
+
+  useEffect(() => {
+    if (!isRefresh || !workspaceId || !workspaceName) return;
+
+    fabricApi.getStoredCdcMetadata(workspaceId, workspaceName)
+      .then(res => {
+        const data = res?.data?.data;
+        if (!data) return;
+
+        const cdcCatalogs = data.publishedCDCCatalogs || [];
+        const lakehouseDetail = cdcCatalogs.find(c => c.lakeHouseId === lakehouseId);
+        if (lakehouseDetail) {
+          setStoredCdcData(lakehouseDetail);
+        }
+
+        const databases = data.metadata?.databases || [];
+        const matchDb = databases.find(db =>
+          db.dbId === lakehouseId || db.dbName === lakehouseName
+        );
+        if (matchDb?.description) {
+          setDescription(matchDb.description);
+          setValue('description', matchDb.description);
+        }
+      })
+      .catch(err => {
+        console.error('Failed to fetch stored CDC metadata:', err);
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isRefresh, workspaceId, workspaceName, lakehouseId]);
+
+  useEffect(() => {
+    if (!storedCdcData || prePopulated) return;
+
+    const mandatoryFields = storedCdcData.mandatoryFields;
+    if (mandatoryFields) {
+      if (mandatoryFields.tier != null) {
+        const tierLabel = REVERSE_TIER_MAP[mandatoryFields.tier];
+        if (tierLabel) {
+          setDataTier(tierLabel);
+        }
+      }
+      if (mandatoryFields.divisions && mandatoryFields.divisions.length > 0) {
+        setDivision(mandatoryFields.divisions);
+        setTimeout(() => {
+          const selectEl = document.getElementById('divisionField');
+          if (selectEl) {
+            Array.from(selectEl.options).forEach(opt => {
+              opt.selected = mandatoryFields.divisions.includes(opt.value);
+            });
+          }
+        }, 0);
+      }
+      if (mandatoryFields.isDocumentationUpdated != null) {
+        setIsDocumentationUpdated(mandatoryFields.isDocumentationUpdated === "Yes");
+        setValue('documentationUpdated', mandatoryFields.isDocumentationUpdated === "Yes" ? 'true' : 'false');
+      }
+    }
+
+    const tableDetails = storedCdcData.publishedLakehouseTableDetails;
+    if (tableDetails && tableDetails.length > 0 && tables.length > 0) {
+      const newSelectedTables = {};
+      const newSelectedColumns = {};
+      const newColumnsByTable = { ...columnsByTable };
+
+      for (const tableDetail of tableDetails) {
+        if (!tableDetail.enabled) continue;
+
+        const tableName = tableDetail.tableName;
+        const tableExists = tables.some(t => t.tableName === tableName);
+        if (!tableExists) continue;
+
+        newSelectedTables[tableName] = true;
+
+        if (tableDetail.columns && tableDetail.columns.length > 0) {
+          const colSelections = {};
+          const colData = [];
+          for (const col of tableDetail.columns) {
+            if (col.enabled) {
+              colSelections[col.columnName] = true;
+            }
+            colData.push({ columnName: col.columnName, colType: '', colConstraint: '' });
+          }
+          newSelectedColumns[tableName] = colSelections;
+          if (!newColumnsByTable[tableName]) {
+            newColumnsByTable[tableName] = colData;
+          }
+        }
+      }
+
+      setSelectedTables(prev => ({ ...prev, ...newSelectedTables }));
+      setSelectedColumns(prev => ({ ...prev, ...newSelectedColumns }));
+      setColumnsByTable(newColumnsByTable);
+    }
+
+    setPrePopulated(true);
+    setTimeout(() => SelectBox.defaultSetup(), 100);
+  }, [storedCdcData, tables, prePopulated, columnsByTable, setValue]);
 
   useEffect(() => {
     ExpansionPanel.defaultSetup();
@@ -319,7 +422,10 @@ const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRef
     });
 
     ProgressIndicator.show();
-    fabricApi.pushSelectedTables(workspaceId, payload)
+    const pushApi = isRefresh
+      ? fabricApi.updateSelectedTables(workspaceId, payload)
+      : fabricApi.pushSelectedTables(workspaceId, payload);
+    pushApi
       .then(() => {
         const publishedSnapshot = {
           workspaceId,
@@ -342,7 +448,7 @@ const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRef
           });
 
         ProgressIndicator.hide();
-        Notification.show("Push to CDC successful!", "success");
+        Notification.show(isRefresh ? "CDC refresh successful!" : "Push to CDC successful!", "success");
 
         setHasPushedOnce(true);
 
@@ -385,14 +491,20 @@ const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRef
     description,
     workspaceCreator,
     onRefreshWorkspace,
+    isRefresh,
   ]);
 
   const onPush = handleSubmit(handlePush);
 
+  const hasSelectedTables = Object.values(selectedTables).some(v => v);
+  const hasSelectedColumns = Object.values(selectedColumns).some(cols =>
+    cols && Object.values(cols).some(v => v)
+  );
+
   const isPushDisabled =
   !workspaceMetadata || 
-  Object.keys(selectedTables).length === 0 ||
-  Object.keys(selectedColumns).length === 0 ||
+  !hasSelectedTables ||
+  !hasSelectedColumns ||
   hasPushedOnce;
 
     return (
@@ -412,7 +524,7 @@ const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRef
               <div className={classNames('custom-select')}>
                 <select
                   id="dataTierField"
-                  defaultValue={dataTier}
+                  value={dataTier}
                   onChange={(e) => {
                     setDataTier(e.target.value);
                     if (dataTierError) setDataTierError(""); 
@@ -524,9 +636,8 @@ const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRef
               id="description"
               className={'input-field-area'}
               type="text"
-              defaultValue={description}
               rows={50}
-              {...register('description', { required: '*Missing entry', pattern: /^(?!\s+$)(\s*\S+\s*)+$/, onChange: (e) => { setDescription(e.target.value) } })}
+              {...register('description', { required: '*Missing entry', pattern: /^(?!\s+$)(\s*\S+\s*)+$/, onChange: (e) => { setDescription(e.target.value) }, value: description || '' })}
             />
             <span className={'error-message'}>{errors?.description?.message}{errors.description?.type === 'pattern' && `Spaces (and special characters) not allowed as field value.`}</span>
           </div>
@@ -657,7 +768,7 @@ const ViewTablesModalContent = ({ workspaceId, lakehouseId, lakehouseName, onRef
 
       <div className={Styles.pushButtonContainer}>
         <button className={isPushDisabled ? classNames("btn btn-tertiary") : classNames("btn btn-primary")} type="button" disabled={isPushDisabled} onClick={onPush}>
-          Push
+          {isRefresh ? 'Refresh CDC' : 'Push'}
         </button>
       </div>
 

--- a/packages/fabric-mfe/src/components/Lakehouses/Lakehouses.js
+++ b/packages/fabric-mfe/src/components/Lakehouses/Lakehouses.js
@@ -322,6 +322,7 @@ function Lakehouses({ user, workspace, lakehouses, onDeleteLakehouse, onRefreshW
   const [showNonProdProjectModal, setShowNonProdProjectModal] = useState(false);
   const [showMismatchModal, setShowMismatchModal] = useState(false);
   const [mismatchData, setMismatchData] = useState(null);
+  const [isCdcRefresh, setIsCdcRefresh] = useState(false);
   const [showDdxViewTables, setShowDdxViewTablesModal] = useState(false);
   const [contextMenus, setContextMenus] = useState({});
   const [showLocationsContextMenu, setShowLocationsContextMenu] = useState(false);
@@ -356,6 +357,7 @@ function Lakehouses({ user, workspace, lakehouses, onDeleteLakehouse, onRefreshW
     console.log('[PushToCdc] isAlreadyPublished:', isAlreadyPublished);
 
     if (!isAlreadyPublished) {
+      setIsCdcRefresh(false);
       setShowViewTablesModal(true);
       return;
     }
@@ -373,12 +375,14 @@ function Lakehouses({ user, workspace, lakehouses, onDeleteLakehouse, onRefreshW
           });
           setShowMismatchModal(true);
         } else {
+          setIsCdcRefresh(true);
           setShowViewTablesModal(true);
         }
       })
       .catch((e) => {
         ProgressIndicator.hide();
         console.error('[PushToCdc] API ERROR:', e?.response?.status, e?.message);
+        setIsCdcRefresh(true);
         setShowViewTablesModal(true);
       });
   };
@@ -792,7 +796,7 @@ function Lakehouses({ user, workspace, lakehouses, onDeleteLakehouse, onRefreshW
         <InfoModal
           title={
             <div className={Styles.modalTitle}>
-              <span>{selectedLakehouse ? `${selectedLakehouse.name} - Tables` : 'Tables'}</span>
+              <span>{selectedLakehouse ? `${selectedLakehouse.name} - ${isCdcRefresh ? 'Refresh CDC' : 'Tables'}` : 'Tables'}</span>
                 <a
                   href={Envs.CONFLUENCE_PAGE}
                   target="_blank"
@@ -808,9 +812,9 @@ function Lakehouses({ user, workspace, lakehouses, onDeleteLakehouse, onRefreshW
           modalWidth={'90%'}
           buttonAlignment="right"
           show={showViewTables}
-        content={<ViewTablesModalContent workspaceId={workspace?.id} lakehouseId={selectedLakehouse?.id} lakehouseName={selectedLakehouse?.name} onRefreshWorkspace={onRefreshWorkspace} />}
+        content={<ViewTablesModalContent workspaceId={workspace?.id} lakehouseId={selectedLakehouse?.id} lakehouseName={selectedLakehouse?.name} onRefreshWorkspace={onRefreshWorkspace} isRefresh={isCdcRefresh} workspaceName={workspace?.name} />}
           scrollableContent={true}
-          onCancel={() => { setSelectedLakehouse(); setShowViewTablesModal(false) }}
+          onCancel={() => { setSelectedLakehouse(); setShowViewTablesModal(false); setIsCdcRefresh(false); }}
         />
       }
       {showNonProdProjectModal &&
@@ -919,10 +923,11 @@ function Lakehouses({ user, workspace, lakehouses, onDeleteLakehouse, onRefreshW
                 onClick={() => {
                   setShowMismatchModal(false);
                   setMismatchData(null);
+                  setIsCdcRefresh(true);
                   setShowViewTablesModal(true);
                 }}
               >
-                Continue to Push to CDC
+                Continue to Refresh CDC
               </button>
             </div>
           }


### PR DESCRIPTION
## Summary

Enables CDC refresh for already-published lakehouses without overwriting manually entered data (tier, divisions, documentation updated, description).

**Key changes:**

**API layer** (`fabric.api.js`):
- `updateSelectedTables(workspaceId, payload)` → `PUT .../catalog/{workspaceId}/publish`
- `getStoredCdcMetadata(workspaceId, serviceName)` → `GET .../catalog/{workspaceId}/{serviceName}`

**CdcPush component** — when `isRefresh=true`:
1. Fetches stored CDC metadata via `getStoredCdcMetadata`
2. Pre-populates mandatory fields from `storedCdcData.mandatoryFields`:
   - Tier → reverse-mapped via `REVERSE_TIER_MAP` (numeric → label)
   - Divisions → programmatic multi-select option selection
   - Documentation updated → radio button state
   - Description → from `metadata.databases[].description`
3. Pre-selects previously enabled tables/columns from `publishedLakehouseTableDetails`
4. Routes submit through `updateSelectedTables` (PUT) instead of `pushSelectedTables` (POST)

**Lakehouses component**:
- Tracks `isCdcRefresh` state based on `workspace.cdcPublishedLakeHouseDetails.publishedLakeHouseNames.includes(lakehouse.id)`
- Passes `isRefresh` and `workspaceName` props to `ViewTablesModalContent`
- Mismatch modal "Continue" button now opens refresh flow

**Why the backend doesn't need changes**: `mergeCdcTableDetail` already preserves existing mandatory fields when the new detail's fields are null. Since the frontend pre-populates and sends back existing values, manual data is preserved by default.

Link to Devin session: https://mercedes-benz.devinenterprise.com/sessions/68961199add343629d100f0b84622c00