### PR TITLE
Send deployment success notification to collaborators via ArgoCD

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -370,7 +370,7 @@ public class DeploymentStatusMonitorJob {
         try {
             String eventType;
             String message;
-            String envLabel = "prod".equalsIgnoreCase(environment) ? "Production" : environment;
+            String envLabel = "prod".equalsIgnoreCase(environment) ? "Production" : "Staging";
             String resourceID = workspace.getData().getWorkspaceId();
             UserInfo deployedBy = deployment.getLastDeployedBy();
             UserInfo projectOwner = workspace.getData().getProjectDetails().getProjectOwner();
@@ -414,12 +414,16 @@ public class DeploymentStatusMonitorJob {
                     teamMembersEmails.add(projectOwner.getEmail());
                 }
             }
-            // Also notify the deployer if different from project owner
-            if (deployedBy != null && deployedBy.getId() != null
-                    && (projectOwner == null || !deployedBy.getId().equalsIgnoreCase(projectOwner.getId()))) {
-                teamMembers.add(deployedBy.getId());
-                if (deployedBy.getEmail() != null) {
-                    teamMembersEmails.add(deployedBy.getEmail());
+            // Notify all collaborators
+            List<UserInfo> collaborators = workspace.getData().getProjectDetails().getProjectCollaborators();
+            if (collaborators != null) {
+                for (UserInfo collab : collaborators) {
+                    if (collab != null && collab.getId() != null) {
+                        teamMembers.add(collab.getId());
+                    }
+                    if (collab != null && collab.getEmail() != null) {
+                        teamMembersEmails.add(collab.getEmail());
+                    }
                 }
             }
 

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
@@ -5529,6 +5529,17 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 			UserInfo projectOwner = data.getProjectDetails().getProjectOwner();
 			teamMembers.add(projectOwner.getId());
 			teamMembersEmails.add(projectOwner.getEmail());
+			List<UserInfo> collaborators = data.getProjectDetails().getProjectCollaborators();
+			if (collaborators != null) {
+				for (UserInfo collab : collaborators) {
+					if (collab != null && collab.getId() != null) {
+						teamMembers.add(collab.getId());
+					}
+					if (collab != null && collab.getEmail() != null) {
+						teamMembersEmails.add(collab.getEmail());
+					}
+				}
+			}
 			if(data.getProjectDetails().getLastBuildOrDeployedStatus().equalsIgnoreCase("BUILD_REQUESTED")){
 				CodeServerBuildDetails buildDetails = entity.getData().getProjectDetails().getIntBuildDetails();
 					 if (!"int".equalsIgnoreCase(data.getProjectDetails().getLastBuildOrDeployedEnv())) {


### PR DESCRIPTION
## Summary

Deployment success/failure notifications from the ArgoCD polling job (`DeploymentStatusMonitorJob`) were only sent to the project owner and the deployer, but not to project collaborators. Build notifications (via `WorkspaceJobStatusUpdateController`) already included all collaborators. This PR aligns the deployment notification behavior.

**Changes in `DeploymentStatusMonitorJob.sendDeploymentNotification`:**
- Replace the "notify deployer if different from owner" block with a loop over `workspace.getData().getProjectDetails().getProjectCollaborators()`, adding each collaborator's `id` and `email` to `teamMembers`/`teamMembersEmails` — matching how `WorkspaceJobStatusUpdateController` builds recipients.
- Fix `envLabel`: was `"prod" ? "Production" : environment` (showing raw `"int"`), now `"prod" ? "Production" : "Staging"` to match the build notification format.

**Changes in `BaseWorkspaceService.getStatusByJobRunId`:**
- Added the same collaborator loop after adding the project owner, so notifications from the GitHub Actions status-polling path also include collaborators.

Notification message example: `Successfully deployed Codespace dev-cs-test-ghe-collab with branch main on Staging triggered by SUDARSV`