### PR TITLE
Fix staging namespace in Deployed App Resource Usage monitoring URL

### DIFF
--- a/packages/code-space-mfe/src/components/CodeSpace.js
+++ b/packages/code-space-mfe/src/components/CodeSpace.js
@@ -203,7 +203,7 @@ const CodeSpace = (props) => {
   
     const resources = codeSpaceData?.projectDetails?.recipeDetails?.resource?.split(',');
     const resourceUsageUrl = Envs.MONITORING_DASHBOARD_BASE_URL + `codespace-cpu-and-memory-usage?orgId=1&from=now-1h&to=now&var-namespace=${Envs.CODESERVER_NAMESPACE}&var-pod=${codeSpaceData?.workspaceId}&var-container=notebook`;
-  const intAppResourceUsageUrl = Envs.MONITORING_DASHBOARD_APP_BASE_URL + `codespace-app-cpu-and-memory-usage?orgId=1&var-namespace=${Envs.CODESERVER_APP_NAMESPACE}&var-app=${codeSpaceData?.projectDetails?.projectName}-int&var-container=`;
+  const intAppResourceUsageUrl = Envs.MONITORING_DASHBOARD_APP_BASE_URL + `codespace-app-cpu-and-memory-usage?orgId=1&var-namespace=${Envs.CODESERVER_APP_NAMESPACE}-int&var-app=${codeSpaceData?.projectDetails?.projectName}-int&var-container=`;
   const prodAppResourceUsageUrl = Envs.MONITORING_DASHBOARD_APP_BASE_URL + `codespace-app-cpu-and-memory-usage?orgId=1&var-namespace=${Envs.CODESERVER_APP_NAMESPACE}&var-app=${codeSpaceData?.projectDetails?.projectName}-prod&var-container=`;
 
     const intSecuredWithOneApi = codeSpaceData?.projectDetails?.intDeploymentDetails?.oneApiVersionShortName?.length || false;

--- a/packages/code-space-mfe/src/components/codeSpaceBlueprint/blueprintTemplate.js
+++ b/packages/code-space-mfe/src/components/codeSpaceBlueprint/blueprintTemplate.js
@@ -150,7 +150,7 @@ export const blueprintTemplate = (codespace) => {
     return `${collaborator?.firstName} ${collaborator?.lastName} (${collaborator?.id})`;
   });
 
-  const intAppResourceUsageUrl = Envs.MONITORING_DASHBOARD_APP_BASE_URL + `codespace-app-cpu-and-memory-usage?orgId=1&var-namespace=${Envs.CODESERVER_APP_NAMESPACE}&var-app=${codespace?.projectDetails?.projectName}-int&var-container=`;
+  const intAppResourceUsageUrl = Envs.MONITORING_DASHBOARD_APP_BASE_URL + `codespace-app-cpu-and-memory-usage?orgId=1&var-namespace=${Envs.CODESERVER_APP_NAMESPACE}-int&var-app=${codespace?.projectDetails?.projectName}-int&var-container=`;
   const prodAppResourceUsageUrl = Envs.MONITORING_DASHBOARD_APP_BASE_URL + `codespace-app-cpu-and-memory-usage?orgId=1&var-namespace=${Envs.CODESERVER_APP_NAMESPACE}&var-app=${codespace?.projectDetails?.projectName}-prod&var-container=`;
 
   const template = `

--- a/packages/code-space-mfe/src/components/contextMenu/ContextMenu.js
+++ b/packages/code-space-mfe/src/components/contextMenu/ContextMenu.js
@@ -76,7 +76,7 @@ const ContextMenu = (props) => {
 
   const intAppResourceUsageUrl =
     Envs.MONITORING_DASHBOARD_APP_BASE_URL +
-    `codespace-app-cpu-and-memory-usage?orgId=1&var-namespace=${Envs.CODESERVER_APP_NAMESPACE}&var-app=${projectDetails?.projectName?.toLowerCase()}-int&var-container=`;
+    `codespace-app-cpu-and-memory-usage?orgId=1&var-namespace=${Envs.CODESERVER_APP_NAMESPACE}-int&var-app=${projectDetails?.projectName?.toLowerCase()}-int&var-container=`;
 
   const prodAppResourceUsageUrl =
     Envs.MONITORING_DASHBOARD_APP_BASE_URL +


### PR DESCRIPTION
## Summary

The "Deployed App Resource Usage" link in the codespace context menu was using the same `CODESERVER_APP_NAMESPACE` (e.g. `dev-dna-cs-apps`) for both staging and prod Grafana URLs. Staging should use `dev-dna-cs-apps-int`.

Fix: append `-int` to `Envs.CODESERVER_APP_NAMESPACE` in the staging URL template string across all 3 files that construct this URL:

```diff
- var-namespace=${Envs.CODESERVER_APP_NAMESPACE}
+ var-namespace=${Envs.CODESERVER_APP_NAMESPACE}-int
```

Prod URLs remain unchanged (`var-namespace=${Envs.CODESERVER_APP_NAMESPACE}`).

**Files changed:** `ContextMenu.js`, `CodeSpace.js`, `blueprintTemplate.js`