### PR TITLE
feat: populate appId and leanIXDetails from project's leanIX via planningit API

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
@@ -1,0 +1,55 @@
+package com.daimler.data.application.client;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.daimler.data.dto.planningit.PlanningITApiItemVO;
+import com.daimler.data.dto.planningit.PlanningITApiResponseVO;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class PlanningITClient {
+
+    @Value("${dataProduct.planningit.baseUrl}")
+    private String planningItBaseUrl;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    public List<PlanningITApiItemVO> searchPlanningIT(String searchTerm) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Accept", "application/json");
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+
+            String url = UriComponentsBuilder.fromHttpUrl(planningItBaseUrl)
+                    .queryParam("searchTerm", searchTerm)
+                    .toUriString();
+
+            ResponseEntity<PlanningITApiResponseVO> response = restTemplate.exchange(
+                    url, HttpMethod.GET, requestEntity, PlanningITApiResponseVO.class);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.hasBody()
+                    && response.getBody().getData() != null) {
+                return response.getBody().getData();
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch PlanningIT data for searchTerm {}: {}", searchTerm, e.getMessage());
+        }
+        return Collections.emptyList();
+    }
+}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
@@ -801,6 +801,7 @@ public class FabricWorkspaceController implements FabricWorkspacesApi, LovsApi
 			existingFabricWorkspace.setRelatedReports(workspaceUpdateRequestVO.getRelatedReports());
 			existingFabricWorkspace.setRelatedSolutions(workspaceUpdateRequestVO.getRelatedSolutions());
 			existingFabricWorkspace.setLastModifiedOn(new Date());
+			service.populateLeanIXDetailsFromProject(existingFabricWorkspace);
 			try {
 				FabricWorkspaceVO updatedRecord = service.updateFabricProject(existingFabricWorkspace);
 				responseVO.setData(updatedRecord);

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/planningit/PlanningITApiItemVO.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/planningit/PlanningITApiItemVO.java
@@ -1,0 +1,30 @@
+package com.daimler.data.dto.planningit;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlanningITApiItemVO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String id;
+    private String appReferenceStr;
+    private String name;
+    private String shortName;
+    @JsonProperty("ObjectState")
+    private String objectState;
+    private String providerOrgRefstr;
+    private String providerOrgId;
+    private String providerOrgShortname;
+    private String providerOrgDeptid;
+}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/planningit/PlanningITApiResponseVO.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/planningit/PlanningITApiResponseVO.java
@@ -1,0 +1,21 @@
+package com.daimler.data.dto.planningit;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlanningITApiResponseVO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<PlanningITApiItemVO> data;
+}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/BaseFabricWorkspaceService.java
@@ -114,6 +114,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.daimler.data.service.tag.TagService;
 import com.daimler.data.db.repo.adaProjects.ADAProjectsCustomRepository;
 import com.daimler.data.db.repo.adaProjects.ADAProjectsCustomRepositoryImpl;
+import com.daimler.data.application.client.PlanningITClient;
+import com.daimler.data.dto.planningit.PlanningITApiItemVO;
+import com.daimler.data.dto.fabricWorkspace.LeanIXDetailsVO;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -166,6 +169,9 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 
 	@Autowired
 	private ADAProjectsCustomRepository adaProjectsRepo;
+
+	@Autowired
+	private PlanningITClient planningITClient;
 
 
 	@Value("${fabricWorkspaces.powerbiCapacityId}")
@@ -531,6 +537,7 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 		GenericMessage responseMessage = new GenericMessage();
 		List<MessageDescription> errors = new ArrayList<>();
 		List<MessageDescription> warnings = new ArrayList<>();
+		populateLeanIXDetailsFromProject(vo);
 		CreateWorkspaceDto createRequest = new CreateWorkspaceDto();
 		createRequest.setDescription(vo.getDescription());
 		createRequest.setDisplayName(vo.getName());
@@ -1743,6 +1750,44 @@ public class BaseFabricWorkspaceService extends BaseCommonService<FabricWorkspac
 					tagService.create(newTagVO);
 				}
 			});
+		}
+	}
+
+	@Override
+	public void populateLeanIXDetailsFromProject(FabricWorkspaceVO workspace) {
+		String projectId = workspace.getProjectId();
+		if (projectId == null || projectId.isBlank()) {
+			return;
+		}
+		ADAProjectsNsql adaProject = adaProjectsRepo.findbyUniqueLiteral("projectID", projectId);
+		if (adaProject == null || adaProject.getData() == null) {
+			log.warn("ADA project not found for projectId {}, skipping leanIX population", projectId);
+			return;
+		}
+		String leanIXId = adaProject.getData().getLeanIX();
+		if (leanIXId == null || leanIXId.isBlank()) {
+			log.info("No leanIX value on project {}, skipping leanIX population", projectId);
+			return;
+		}
+		List<PlanningITApiItemVO> planningITItems = planningITClient.searchPlanningIT(leanIXId);
+		if (planningITItems != null && !planningITItems.isEmpty()) {
+			PlanningITApiItemVO matched = planningITItems.stream()
+					.filter(item -> leanIXId.equalsIgnoreCase(item.getId()))
+					.findFirst()
+					.orElse(planningITItems.get(0));
+			workspace.setAppId(matched.getId());
+			LeanIXDetailsVO details = new LeanIXDetailsVO();
+			details.setAppReferenceStr(matched.getAppReferenceStr());
+			details.setName(matched.getName());
+			details.setShortName(matched.getShortName());
+			details.setObjectState(matched.getObjectState());
+			details.setProviderOrgRefstr(matched.getProviderOrgRefstr());
+			details.setProviderOrgId(matched.getProviderOrgId());
+			details.setProviderOrgShortname(matched.getProviderOrgShortname());
+			details.setProviderOrgDeptid(matched.getProviderOrgDeptid());
+			workspace.setLeanIXDetails(details);
+		} else {
+			log.warn("No PlanningIT entry found for leanIX id {}", leanIXId);
 		}
 	}
 

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/FabricWorkspaceService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/fabric/FabricWorkspaceService.java
@@ -84,4 +84,6 @@ public interface FabricWorkspaceService extends CommonService<FabricWorkspaceVO,
 	GenericMessage transferOwnership(FabricWorkspaceVO existingFabricWorkspace, CreatedByVO currentOwner, CreatedByVO newOwner);
 
 	ADAProjectDetailsCollectionVO searchProjects(String projectName);
+
+	void populateLeanIXDetailsFromProject(FabricWorkspaceVO workspace);
 }

--- a/packages/fabric-backend/lib/src/main/resources/application.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application.yml
@@ -151,6 +151,10 @@ cdcIntegration:
       baseUrl: ${FABRIC_CDC_PUSH_SERVICE_BASE_URL:XXXX}
       authToken: ${FABRIC_CDC_PUSH_SERVICE_AUTH_TOKEN:XXXX}
 
+dataProduct:
+  planningit:
+    baseUrl: ${DATA_PRODUCT_PLANNINGIT_BASE_URL:XXXX}
+
 ddxIntegration:
   fabricDdxPush:
     baseUrl: ${FABRIC_DDX_PUSH_SERVICE_BASE_URL:XXXX}


### PR DESCRIPTION
## Summary

When a workspace is created or updated with a `projectId`, the backend now auto-populates `appId` and `leanIXDetails` by calling the planningit API:

```
projectId → ada_projects_nsql.leanIX → planningit API(?searchTerm=leanIX) → workspace.appId + workspace.leanIXDetails
```

If no `projectId` is in the payload, the existing UI-driven leanIX flow remains unchanged.