### PR TITLE
fix: forward JWT token and remove Content-Type from planningit API call

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -33,7 +32,6 @@ public class PlanningITClient {
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.set("Accept", "application/json");
-            headers.setContentType(MediaType.APPLICATION_JSON);
             HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 
             String url = UriComponentsBuilder.fromHttpUrl(planningItBaseUrl)

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
@@ -3,6 +3,8 @@ package com.daimler.data.application.client;
 import java.util.Collections;
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -28,10 +30,17 @@ public class PlanningITClient {
     @Autowired
     private RestTemplate restTemplate;
 
+    @Autowired
+    private HttpServletRequest httpRequest;
+
     public List<PlanningITApiItemVO> searchPlanningIT(String searchTerm) {
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.set("Accept", "application/json");
+            String authHeader = httpRequest.getHeader("Authorization");
+            if (authHeader != null && !authHeader.isBlank()) {
+                headers.set("Authorization", authHeader);
+            }
             HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 
             String url = UriComponentsBuilder.fromHttpUrl(planningItBaseUrl)


### PR DESCRIPTION
## Summary

Fixes 400 Bad Request from the planningit API gateway when `PlanningITClient` calls `GET /api/planningit?searchTerm=...`.

Two issues:
1. `Content-Type: application/json` was being set on a GET request with no body — removed.
2. The API gateway requires authentication — now forwards the incoming request's `Authorization` header to the planningit API call.