### PR TITLE
fix: use OIDC token from AuthoriserClient for planningit API call

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
@@ -2,8 +2,7 @@ package com.daimler.data.application.client;
 
 import java.util.Collections;
 import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,26 +27,28 @@ public class PlanningITClient {
     private String planningItBaseUrl;
 
     @Autowired
-    private RestTemplate restTemplate;
+    private RestTemplate proxyRestTemplate;
 
     @Autowired
-    private HttpServletRequest httpRequest;
+    private AuthoriserClient authoriserClient;
 
     public List<PlanningITApiItemVO> searchPlanningIT(String searchTerm) {
         try {
+            String token = authoriserClient.getToken();
+            if (!Objects.nonNull(token)) {
+                log.error("Failed to fetch token to invoke planningit API");
+                return Collections.emptyList();
+            }
             HttpHeaders headers = new HttpHeaders();
             headers.set("Accept", "application/json");
-            String authHeader = httpRequest.getHeader("Authorization");
-            if (authHeader != null && !authHeader.isBlank()) {
-                headers.set("Authorization", authHeader);
-            }
+            headers.set("Authorization", "Bearer " + token);
             HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 
             String url = UriComponentsBuilder.fromHttpUrl(planningItBaseUrl)
                     .queryParam("searchTerm", searchTerm)
                     .toUriString();
 
-            ResponseEntity<PlanningITApiResponseVO> response = restTemplate.exchange(
+            ResponseEntity<PlanningITApiResponseVO> response = proxyRestTemplate.exchange(
                     url, HttpMethod.GET, requestEntity, PlanningITApiResponseVO.class);
 
             if (response.getStatusCode().is2xxSuccessful() && response.hasBody()

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
@@ -2,7 +2,8 @@ package com.daimler.data.application.client;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,18 +31,16 @@ public class PlanningITClient {
     private RestTemplate restTemplate;
 
     @Autowired
-    private AuthoriserClient authoriserClient;
+    private HttpServletRequest httpRequest;
 
     public List<PlanningITApiItemVO> searchPlanningIT(String searchTerm) {
         try {
-            String token = authoriserClient.getToken();
-            if (!Objects.nonNull(token)) {
-                log.error("Failed to fetch token to invoke planningit API");
-                return Collections.emptyList();
-            }
             HttpHeaders headers = new HttpHeaders();
             headers.set("Accept", "application/json");
-            headers.set("Authorization", "Bearer " + token);
+            String userinfo = httpRequest.getHeader("dna-request-userdetails");
+            if (userinfo != null && !userinfo.isBlank()) {
+                headers.set("dna-request-userdetails", userinfo);
+            }
             HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 
             String url = UriComponentsBuilder.fromHttpUrl(planningItBaseUrl)

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/PlanningITClient.java
@@ -27,7 +27,7 @@ public class PlanningITClient {
     private String planningItBaseUrl;
 
     @Autowired
-    private RestTemplate proxyRestTemplate;
+    private RestTemplate restTemplate;
 
     @Autowired
     private AuthoriserClient authoriserClient;
@@ -48,7 +48,7 @@ public class PlanningITClient {
                     .queryParam("searchTerm", searchTerm)
                     .toUriString();
 
-            ResponseEntity<PlanningITApiResponseVO> response = proxyRestTemplate.exchange(
+            ResponseEntity<PlanningITApiResponseVO> response = restTemplate.exchange(
                     url, HttpMethod.GET, requestEntity, PlanningITApiResponseVO.class);
 
             if (response.getStatusCode().is2xxSuccessful() && response.hasBody()


### PR DESCRIPTION
## Summary

Fixes 401 Unauthorized from the planningit API gateway. The incoming request's Authorization header is not a valid JWT for the data-product gateway.

Now uses the same OAuth client credentials flow (`AuthoriserClient.getToken()`) that other fabric clients use, and switches to `proxyRestTemplate` for proper external network access.