### PR TITLE
fix(kong): always send fixed session_secret when attaching OIDC plugin

### DIFF
--- a/packages/authenticator-service/authenticator-lib/src/main/java/com/daimler/data/kong/client/AttachPluginConfigRequestDto.java
+++ b/packages/authenticator-service/authenticator-lib/src/main/java/com/daimler/data/kong/client/AttachPluginConfigRequestDto.java
@@ -17,6 +17,8 @@ public class AttachPluginConfigRequestDto implements Serializable{
 
 	  private String session_secret;
 
+	  private String skip_already_auth_requests;
+
 	  private String client_secret;
 
 	  private String discovery;

--- a/packages/authenticator-service/authenticator-lib/src/main/java/com/daimler/data/kong/client/AttachPluginConfigRequestDto.java
+++ b/packages/authenticator-service/authenticator-lib/src/main/java/com/daimler/data/kong/client/AttachPluginConfigRequestDto.java
@@ -15,6 +15,8 @@ public class AttachPluginConfigRequestDto implements Serializable{
 	
 	  private static final long serialVersionUID = 1L;
 
+	  private String session_secret;
+
 	  private String client_secret;
 
 	  private String discovery;

--- a/packages/authenticator-service/authenticator-lib/src/main/java/com/daimler/data/kong/client/KongClientImpl.java
+++ b/packages/authenticator-service/authenticator-lib/src/main/java/com/daimler/data/kong/client/KongClientImpl.java
@@ -246,6 +246,7 @@ public class KongClientImpl implements KongClient {
 			ResponseEntity<String> response = null;
 			if(attachPluginVO.getName().name().toLowerCase().equalsIgnoreCase("oidc")) {
 				requestWrapper.setName(attachPluginVO.getName().name().toLowerCase());
+				attachPluginConfigRequestDto.setSession_secret(attachPluginConfigVO.getSessionSecret());
 				attachPluginConfigRequestDto.setBearer_only(attachPluginConfigVO.getBearerOnly());
 				attachPluginConfigRequestDto.setClient_id(attachPluginConfigVO.getClientId());
 				attachPluginConfigRequestDto.setClient_secret(attachPluginConfigVO.getClientSecret());

--- a/packages/authenticator-service/authenticator-lib/src/main/java/com/daimler/data/kong/client/KongClientImpl.java
+++ b/packages/authenticator-service/authenticator-lib/src/main/java/com/daimler/data/kong/client/KongClientImpl.java
@@ -247,6 +247,7 @@ public class KongClientImpl implements KongClient {
 			if(attachPluginVO.getName().name().toLowerCase().equalsIgnoreCase("oidc")) {
 				requestWrapper.setName(attachPluginVO.getName().name().toLowerCase());
 				attachPluginConfigRequestDto.setSession_secret(attachPluginConfigVO.getSessionSecret());
+				attachPluginConfigRequestDto.setSkip_already_auth_requests(attachPluginConfigVO.getSkipAlreadyAuthRequests());
 				attachPluginConfigRequestDto.setBearer_only(attachPluginConfigVO.getBearerOnly());
 				attachPluginConfigRequestDto.setClient_id(attachPluginConfigVO.getClientId());
 				attachPluginConfigRequestDto.setClient_secret(attachPluginConfigVO.getClientSecret());

--- a/packages/authenticator-service/authenticator-lib/src/main/resources/api/kongGateway.yaml
+++ b/packages/authenticator-service/authenticator-lib/src/main/resources/api/kongGateway.yaml
@@ -988,6 +988,8 @@ definitions:
     properties:
       session_secret:
         type: string
+      skip_already_auth_requests:
+        type: string
       client_secret:
         type: string
       discovery:

--- a/packages/authenticator-service/authenticator-lib/src/main/resources/api/kongGateway.yaml
+++ b/packages/authenticator-service/authenticator-lib/src/main/resources/api/kongGateway.yaml
@@ -986,6 +986,8 @@ definitions:
  AttachPluginConfigVO:
     type: object
     properties:
+      session_secret:
+        type: string
       client_secret:
         type: string
       discovery:

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AttachPluginConfigVO.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AttachPluginConfigVO.java
@@ -18,6 +18,8 @@ public class AttachPluginConfigVO  implements Serializable {
 
 	private String session_secret;
 
+	private String skip_already_auth_requests;
+
 	private String client_secret;
 
 	  private String discovery;

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AttachPluginConfigVO.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AttachPluginConfigVO.java
@@ -16,6 +16,8 @@ public class AttachPluginConfigVO  implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
 
+	private String session_secret;
+
 	private String client_secret;
 
 	  private String discovery;

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AuthenticatorClientImpl.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AuthenticatorClientImpl.java
@@ -231,6 +231,9 @@ public class AuthenticatorClientImpl  implements AuthenticatorClient{
 	@Value("${kong.oidc.session-secret}")
 	private String oidcSessionSecret;
 
+	@Value("${kong.oidc.skip-already-auth-requests}")
+	private String oidcSkipAlreadyAuthRequests;
+
 
 	@Autowired
 	RestTemplate restTemplate;
@@ -1911,6 +1914,7 @@ public class AuthenticatorClientImpl  implements AuthenticatorClient{
 			attachOIDCPluginConfigVO.setRedirect_after_logout_uri(prodRedirectAfterLogoutUri);
 		}
 		attachOIDCPluginConfigVO.setSession_secret(oidcSessionSecret);
+		attachOIDCPluginConfigVO.setSkip_already_auth_requests(oidcSkipAlreadyAuthRequests);
 		attachOIDCPluginConfigVO.setBearer_only(authoriserBearerOnly);
 		attachOIDCPluginConfigVO.setClient_id(clientID);
 		attachOIDCPluginConfigVO.setClient_secret(clientSecret);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AuthenticatorClientImpl.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/auth/client/AuthenticatorClientImpl.java
@@ -228,6 +228,9 @@ public class AuthenticatorClientImpl  implements AuthenticatorClient{
 	@Value("${kong.accessTokenHeaderName}")
 	private String accessTokenHeaderName;
 
+	@Value("${kong.oidc.session-secret}")
+	private String oidcSessionSecret;
+
 
 	@Autowired
 	RestTemplate restTemplate;
@@ -963,6 +966,7 @@ public class AuthenticatorClientImpl  implements AuthenticatorClient{
 										attachOIDCPluginConfigVO.setIntrospection_endpoint(prodIntrospectionEndpoint);
 										attachOIDCPluginConfigVO.setRedirect_after_logout_uri(prodRedirectAfterLogoutUri);
 									}
+									attachOIDCPluginConfigVO.setSession_secret(oidcSessionSecret);
 									attachOIDCPluginConfigVO.setBearer_only("no");
 									attachOIDCPluginConfigVO.setClient_id(clientID);
 									attachOIDCPluginConfigVO.setClient_secret(clientSecret);
@@ -1906,6 +1910,7 @@ public class AuthenticatorClientImpl  implements AuthenticatorClient{
 			attachOIDCPluginConfigVO.setIntrospection_endpoint(prodIntrospectionEndpoint);
 			attachOIDCPluginConfigVO.setRedirect_after_logout_uri(prodRedirectAfterLogoutUri);
 		}
+		attachOIDCPluginConfigVO.setSession_secret(oidcSessionSecret);
 		attachOIDCPluginConfigVO.setBearer_only(authoriserBearerOnly);
 		attachOIDCPluginConfigVO.setClient_id(clientID);
 		attachOIDCPluginConfigVO.setClient_secret(clientSecret);

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -226,6 +226,7 @@ kong:
    dnaAppId : ${DNA_APP_ID:XXXX}
    oidc:
      session-secret: ${KONG_OIDC_SESSION_SECRET:XXXX}
+     skip-already-auth-requests: ${KONG_OIDC_SKIP_ALREADY_AUTH_REQUESTS:true}
 
 alice:
   aliceBaseUrl: ${ALICE_SERVICE_BASE_URL:XXXX}

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -224,6 +224,8 @@ kong:
    accessTokenAsBearer :  ${ACCESS_TOKEN_AS_BEARER:XXXX}
    dnaClientSecret : ${DNA_CLIENT_SECRET:XXXX}
    dnaAppId : ${DNA_APP_ID:XXXX}
+   oidc:
+     session-secret: ${KONG_OIDC_SESSION_SECRET:XXXX}
 
 alice:
   aliceBaseUrl: ${ALICE_SERVICE_BASE_URL:XXXX}

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -226,7 +226,7 @@ kong:
    dnaAppId : ${DNA_APP_ID:XXXX}
    oidc:
      session-secret: ${KONG_OIDC_SESSION_SECRET:XXXX}
-     skip-already-auth-requests: ${KONG_OIDC_SKIP_ALREADY_AUTH_REQUESTS:true}
+     skip-already-auth-requests: ${KONG_OIDC_SKIP_ALREADY_AUTH_REQUESTS:yes}
 
 alice:
   aliceBaseUrl: ${ALICE_SERVICE_BASE_URL:XXXX}


### PR DESCRIPTION
## Summary

Kong's `oidc` plugin was attached without a `session_secret`, so each Kong worker/replica used its own random key. The OIDC state cookie set before the IdP redirect could then not be decrypted by a different replica handling the callback, causing the intermittent:

```
openidc.lua:1484 authenticate(): request to the redirect_uri path but there's no session state found
```

This wires a single fixed `session_secret` through every OIDC-plugin attach/update path so the state cookie is decryptable by any replica, and (for API-type apps) sends `skip_already_auth_requests` so already-authenticated API calls bypass the session/redirect flow entirely. `redirect_uri` logic is intentionally untouched.

### Changes

**authenticator-lib**
- `kongGateway.yaml`: add `session_secret` and `skip_already_auth_requests` (`type: string`) to `AttachPluginConfigVO` -> regenerates `getSessionSecret()` / `getSkipAlreadyAuthRequests()`.
- `AttachPluginConfigRequestDto`: add `private String session_secret;` and `private String skip_already_auth_requests;` (Lombok setters); serialized directly into the Kong Admin API body, so the exact field names matter.
- `KongClientImpl.attachPluginToService` (oidc branch): `setSession_secret(...)` and `setSkip_already_auth_requests(...)`.

**code-server-lib**
- `AttachPluginConfigVO` (hand-written DTO in `auth.client`): add `session_secret` and `skip_already_auth_requests` fields.
- `AuthenticatorClientImpl`:
  - inject `@Value("${kong.oidc.session-secret}") oidcSessionSecret` and set `setSession_secret(...)` in **both** OIDC attach builders (non-api recipe path and the authoriser/API path).
  - inject `@Value("${kong.oidc.skip-already-auth-requests}") oidcSkipAlreadyAuthRequests` and set `setSkip_already_auth_requests(...)` **only in the API attach path** (`attachOIDCPluginToApiRecipes`); the UI path is unchanged so interactive login still works.
- `application.yml`: add under `kong:`
  ```yaml
  oidc:
    session-secret: ${KONG_OIDC_SESSION_SECRET:XXXX}
    skip-already-auth-requests: ${KONG_OIDC_SKIP_ALREADY_AUTH_REQUESTS:true}
  ```
  `session-secret` is backed by the `kong-settings` secret per environment; the **same** value must be used across all replicas/environments.

### Why `skip_already_auth_requests` (API apps)
API-type apps are called from the already-authenticated UI carrying a bearer/access token. With `skip_already_auth_requests`, the plugin passes those already-authenticated requests straight upstream instead of running the authorization-code/redirect flow — so no session/state cookie is created and those endpoints are immune to the "no session state found" error, independent of `session_secret`.

### Verification
- `:authenticator-lib:compileJava` and `:code-server-lib:compileJava` both build; confirmed the regenerated model exposes `getSessionSecret()`/`getSkipAlreadyAuthRequests()`.

### Follow-up (not in this PR)
~300 existing `oidc` plugin instances in the Kong Postgres DB still have `session_secret: null`. These changes only affect newly attached/re-attached plugins. A one-time Kong Admin API PATCH loop over existing `oidc` plugins to set `config.session_secret` is needed to remediate already-deployed apps.
