### PR TITLE
fix(code-space-mfe): keep cancel deployment button inside deploy logs modal

### DIFF
--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -71,6 +71,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
   const [crashLoopReason, setCrashLoopReason] = useState('');
   const [deployingThresholdExceeded, setDeployingThresholdExceeded] = useState(false);
   const [cancellingDeployment, setCancellingDeployment] = useState(false);
+  const [deployLogsCopied, setDeployLogsCopied] = useState(false);
   const podLogsSseRef = useRef(null);
   const deployStatusSseRef = useRef(null);
   const deployLogEditorRef = useRef(null);
@@ -442,6 +443,17 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
         setTimeout(() => setErrorCopied(false), 2000);
       }).catch(err => {
         console.error('Failed to copy error message:', err);
+      });
+    }
+  };
+
+  const handleCopyDeployLogs = () => {
+    if (deployLogText) {
+      navigator.clipboard.writeText(deployLogText).then(() => {
+        setDeployLogsCopied(true);
+        setTimeout(() => setDeployLogsCopied(false), 2000);
+      }).catch(err => {
+        console.error('Failed to copy deployment logs:', err);
       });
     }
   };
@@ -1208,6 +1220,11 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
           title={
             <div className={Styles.modalHeader}>
               <span>Deployment Logs</span>
+              <i
+                className={classNames('icon mbc-icon copy', Styles.copyLogsIcon, deployLogsCopied ? Styles.copyLogsIconCopied : '')}
+                tooltip-data={deployLogsCopied ? 'Copied!' : 'Copy logs'}
+                onClick={handleCopyDeployLogs}
+              ></i>
             </div>
           }
           showAcceptButton={false}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -71,7 +71,6 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
   const [crashLoopReason, setCrashLoopReason] = useState('');
   const [deployingThresholdExceeded, setDeployingThresholdExceeded] = useState(false);
   const [cancellingDeployment, setCancellingDeployment] = useState(false);
-  const [deployLogsCopied, setDeployLogsCopied] = useState(false);
   const podLogsSseRef = useRef(null);
   const deployStatusSseRef = useRef(null);
   const deployLogEditorRef = useRef(null);
@@ -443,17 +442,6 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
         setTimeout(() => setErrorCopied(false), 2000);
       }).catch(err => {
         console.error('Failed to copy error message:', err);
-      });
-    }
-  };
-
-  const handleCopyDeployLogs = () => {
-    if (deployLogText) {
-      navigator.clipboard.writeText(deployLogText).then(() => {
-        setDeployLogsCopied(true);
-        setTimeout(() => setDeployLogsCopied(false), 2000);
-      }).catch(err => {
-        console.error('Failed to copy deployment logs:', err);
       });
     }
   };
@@ -1220,14 +1208,6 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
           title={
             <div className={Styles.modalHeader}>
               <span>Deployment Logs</span>
-              <button
-                className={Styles.copyButton}
-                onClick={handleCopyDeployLogs}
-                disabled={!deployLogText}
-                tooltip-data="Copy logs to clipboard"
-              >
-                {deployLogsCopied ? 'Copied!' : 'Copy logs'}
-              </button>
             </div>
           }
           showAcceptButton={false}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -480,7 +480,7 @@
     max-width: 100%;
     display: flex;
     flex-direction: column;
-    max-height: calc(80vh - 150px);
+    height: calc(80vh - 150px);
     overflow: hidden;
 
     .errorContainer {
@@ -497,7 +497,7 @@
       max-width: 100%;
       overflow: hidden;
       flex: 1;
-      min-height: 0;
+      min-height: 200px;
     }
 
     .ace_editor {

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -616,6 +616,22 @@
     }
   }
 
+  .copyLogsIcon {
+    cursor: pointer;
+    color: #c0c8d0;
+    font-size: 18px;
+    margin: 0 8px 0 0;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: #00adef;
+    }
+  }
+
+  .copyLogsIconCopied {
+    color: #00adef;
+  }
+
   .copyButton {
     background-color: #00adef;
     color: #ffffff;


### PR DESCRIPTION
## Summary

Keeps the **Cancel Deployment** button inside the Deployment Logs modal, and ensures the logs render correctly.

### Changes
- `CodeSpaceCardItem.scss` — the modal content now uses a **definite** height (`height: calc(80vh - 150px)` instead of `max-height`) so the log editor's `height:100%` resolves to a real size and the logs display; the editor wrapper gets a `min-height: 200px` floor. The log editor scrolls internally while the reason banner and the actions row (Cancel Deployment) stay pinned inside the modal (`flex-shrink: 0`).
- `CodeSpaceCardItem.js` — removed the previously added "Copy logs" button from the modal header (no other change).

### Result
Cancel Deployment button sits inside the modal, logs are visible, no copy button.

No backend changes.