### PR TITLE
Release: fix(code-server): force ArgoCD sync on deploy and stop false DEPLOYMENT_FAILED

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -5,6 +5,7 @@ import com.daimler.data.db.entities.CodeServerWorkspaceNsql;
 import com.daimler.data.db.json.CodeServerBuildDeploy;
 import com.daimler.data.db.json.CodeServerBuildDetails;
 import com.daimler.data.db.json.CodeServerDeploymentDetails;
+import com.daimler.data.db.json.BuildAudit;
 import com.daimler.data.db.json.DeploymentAudit;
 import com.daimler.data.db.repo.workspace.WorkSpaceCodeServerBuildDeployRepository;
 import com.daimler.data.db.repo.workspace.WorkspaceCustomBuildDeployRepo;
@@ -92,7 +93,8 @@ public class DeploymentStatusSseController {
                         String status = (String) statusData.get("currentStatus");
                         log.debug("SSE iteration {}: status={} seenInProgress={} for {}/{}", iteration, status, seenInProgress, projectName, environment);
                         
-                        if ("DEPLOY_REQUESTED".equals(status) || "BUILDING".equals(status)) {
+                        if ("DEPLOY_REQUESTED".equals(status) || "DEPLOYING".equals(status)
+                                || "BUILDING".equals(status)) {
                             seenInProgress = true;
                         }
                         
@@ -114,6 +116,9 @@ public class DeploymentStatusSseController {
                             // or enough time has passed to rule out stale ArgoCD state.
                             // A user-cancelled deployment is always terminal, even on the very first iteration.
                             if (userCancelled || seenInProgress || iteration >= minIterationsBeforeTerminal || argoConfirmedFailed) {
+                                if ("DEPLOYED".equals(status) && seenInProgress) {
+                                    logDeploymentCompletion(projectName, environment, statusData);
+                                }
                                 log.info("Deployment finished with status: {} after {} iterations (seenInProgress={})", status, iteration, seenInProgress);
                                 emitter.send(SseEmitter.event()
                                         .name("deployment-complete")
@@ -422,6 +427,64 @@ public class DeploymentStatusSseController {
         }
 
         return data;
+    }
+
+    private void logDeploymentCompletion(String projectName, String environment, Map<String, Object> statusData) {
+        String version = statusData.get("version") != null ? String.valueOf(statusData.get("version")) : null;
+        Date deployTriggerTime = statusData.get("triggeredOn") instanceof Date
+                ? (Date) statusData.get("triggeredOn") : null;
+        Date completionTime = statusData.get("deployedOn") instanceof Date
+                ? (Date) statusData.get("deployedOn") : new Date();
+
+        String durationPart = "";
+        if (deployTriggerTime != null && !deployTriggerTime.after(completionTime)) {
+            long elapsedSeconds = (completionTime.getTime() - deployTriggerTime.getTime()) / 1000L;
+            durationPart = String.format(" duration=%ds (%02d:%02d)", elapsedSeconds,
+                    elapsedSeconds / 60, elapsedSeconds % 60);
+        }
+
+        String buildPart = "";
+        try {
+            CodeServerBuildDeployNsql buildDeployEntity = buildDeployCustomRepo.findByProjectName(projectName);
+            BuildAudit buildAudit = findBuildAudit(buildDeployEntity, environment, version);
+            if (buildAudit != null && buildAudit.getTriggeredOn() != null) {
+                buildPart = " buildTriggeredAt=" + buildAudit.getTriggeredOn();
+                if (buildAudit.getBuildOn() != null && !buildAudit.getBuildOn().before(buildAudit.getTriggeredOn())) {
+                    long buildSeconds = (buildAudit.getBuildOn().getTime() - buildAudit.getTriggeredOn().getTime()) / 1000L;
+                    buildPart += String.format(" buildDuration=%ds (%02d:%02d)", buildSeconds,
+                            buildSeconds / 60, buildSeconds % 60);
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Could not obtain build timing for {}/{}: {}", projectName, environment, e.getMessage());
+        }
+
+        log.info("Deployment completed: project={} environment={} version={} deployTriggeredAt={} completedAt={}{}{}",
+                projectName, environment, version, deployTriggerTime, completionTime, durationPart, buildPart);
+    }
+
+    private BuildAudit findBuildAudit(CodeServerBuildDeployNsql buildDeployEntity, String environment,
+            String version) {
+        if (buildDeployEntity == null || buildDeployEntity.getData() == null || version == null) {
+            return null;
+        }
+        List<BuildAudit> buildAudits = "int".equalsIgnoreCase(environment)
+                ? buildDeployEntity.getData().getIntBuildAuditLogs()
+                : buildDeployEntity.getData().getProdBuildAuditLogs();
+        if (buildAudits == null) {
+            return null;
+        }
+        return buildAudits.stream()
+                .filter(audit -> audit.getVersion() != null && version.equalsIgnoreCase(audit.getVersion()))
+                .max((a1, a2) -> {
+                    Date first = a1.getTriggeredOn();
+                    Date second = a2.getTriggeredOn();
+                    if (first == null && second == null) return 0;
+                    if (first == null) return -1;
+                    if (second == null) return 1;
+                    return first.compareTo(second);
+                })
+                .orElse(null);
     }
     
     private String determineActualStatus(String dbStatus, String argoHealth, String syncStatus, String lastSyncPhase,

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -48,6 +48,9 @@ public class DeploymentStatusSseController {
     @Value("${deployment.stuckThresholdMinutes:15}")
     private int stuckThresholdMinutes;
 
+    @Value("${deployment.ssePollSeconds:10}")
+    private int ssePollSeconds;
+
     /** Marker persisted in lastDeploymentError so reconcilers can recognise a user-cancelled deployment. */
     public static final String USER_CANCELLED_MARKER = "Deployment cancelled by user";
 
@@ -66,14 +69,15 @@ public class DeploymentStatusSseController {
         executor.execute(() -> {
             int errorCount = 0;
             int maxErrors = 5;
-            int maxIterations = 600;
+            int pollIntervalSeconds = Math.max(1, ssePollSeconds);
+            int maxIterations = Math.max(1, (30 * 60) / pollIntervalSeconds);
             int iteration = 0;
             boolean seenInProgress = false;
             // Minimum iterations before accepting terminal status from ArgoCD.
             // This prevents false "DEPLOYED" when re-deploying an already-deployed app,
             // because ArgoCD still shows the old deployment as Healthy+Succeeded
             // before the new sync starts.
-            int minIterationsBeforeTerminal = 5; // ~15 seconds at 3s interval
+            int minIterationsBeforeTerminal = Math.max(1, (int) Math.ceil(15.0 / pollIntervalSeconds));
             
             try {
                 while (iteration < maxIterations) {
@@ -134,7 +138,7 @@ public class DeploymentStatusSseController {
                             errorCount = 0;
                         }
 
-                        Thread.sleep(3000);
+                        Thread.sleep(pollIntervalSeconds * 1000L);
 
                     } catch (IOException e) {
                         log.warn("Client disconnected from SSE stream at iteration {}", iteration);
@@ -295,6 +299,7 @@ public class DeploymentStatusSseController {
             String confirmedArgoFailure = null;
             boolean imageMatchesDesired = true;
             boolean deploymentEvidenceReady = true;
+            JsonNode argoApplicationNode = null;
             String expectedVersion = latestAudit != null ? latestAudit.getVersion() : null;
             if (expectedVersion == null || expectedVersion.isEmpty()) {
                 CodeServerBuildDetails buildDetails = "int".equalsIgnoreCase(environment)
@@ -312,6 +317,7 @@ public class DeploymentStatusSseController {
                 if (argoResponse != null && argoResponse.getStatusCode().is2xxSuccessful()) {
                     ObjectMapper mapper = new ObjectMapper();
                     JsonNode rootNode = mapper.readTree(argoResponse.getBody());
+                    argoApplicationNode = rootNode;
                     argoHealthStatus = rootNode.path("status").path("health").path("status").asText("");
                     argoSyncStatus = rootNode.path("status").path("sync").path("status").asText("");
                     argoLastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
@@ -366,7 +372,8 @@ public class DeploymentStatusSseController {
                 try {
                     String argoAppName = projectName + "-" + environment;
                     String token = argoCdService.getArgoToken();
-                    Map<String, Object> crashStatus = argoCdService.getNewPodCrashLoopStatus(token, argoAppName);
+                    Map<String, Object> crashStatus = argoCdService.getNewPodCrashLoopStatus(token, argoAppName,
+                            argoApplicationNode);
                     data.put("newPodCrashLooping", crashStatus.get("newPodCrashLooping"));
                     if (crashStatus.get("crashLoopReason") != null) {
                         data.put("crashLoopReason", crashStatus.get("crashLoopReason"));

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -322,7 +322,7 @@ public class DeploymentStatusSseController {
                     argoSyncStatus = rootNode.path("status").path("sync").path("status").asText("");
                     argoLastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
                     confirmedArgoFailure = argoCdService.getConfirmedDeploymentFailure(
-                            rootNode, argoAppName, deployTriggerTime);
+                            token, rootNode, argoAppName, deployTriggerTime);
                     
                     String argoOperationMessage = rootNode.path("status").path("operationState").path("message").asText("");
 

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/WorkspaceController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/WorkspaceController.java
@@ -1823,7 +1823,7 @@ import org.springframework.beans.factory.annotation.Value;
 					vo.getProjectDetails().getRecipeDetails().setIsDeployEnabled(true);
 				}
 			 }
-			 // Status reconciliation with ArgoCD is handled by DeploymentStatusMonitorJob (every 10s).
+			 // Status reconciliation with ArgoCD is handled by DeploymentStatusMonitorJob (every 20s).
 			 // Removed inline reconcileDeploymentStatusWithArgoCD(vo) to avoid slow synchronous
 			 // HTTP calls to ArgoCD on every card refresh and spurious 403 logs for undeployed envs.
 			 return new ResponseEntity<>(vo, HttpStatus.OK);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepository.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepository.java
@@ -50,6 +50,8 @@ public interface WorkspaceCustomRepository extends CommonDataRepository<CodeServ
 
 	List<CodeServerWorkspaceNsql>  findAll();
 
+	List<CodeServerWorkspaceNsql> findDeploymentReconciliationWorkspaces();
+
 	Integer getCount(String userId);
 
 	CodeServerWorkspaceNsql findbyUniqueLiteral(String userId, String uniqueLiteral, String value);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepositoryImpl.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepositoryImpl.java
@@ -90,10 +90,26 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 				WHERE lower(jsonb_extract_path_text(data, 'status')) <> 'deleted'
 				  AND (
 					jsonb_extract_path_text(data, 'projectDetails', 'intDeploymentDetails', 'lastDeploymentStatus')
-						IN (:deployRequested, :deploymentFailed, :restartRequested)
+						IN (:deployRequested, :restartRequested)
 					OR jsonb_extract_path_text(data, 'projectDetails', 'prodDeploymentDetails', 'lastDeploymentStatus')
-						IN (:deployRequested, :deploymentFailed, :restartRequested)
+						IN (:deployRequested, :restartRequested)
 					OR jsonb_extract_path_text(data, 'projectDetails', 'lastBuildOrDeployedStatus') = :restartRequested
+					OR (
+						jsonb_extract_path_text(data, 'projectDetails', 'intDeploymentDetails', 'lastDeploymentStatus')
+							= :deploymentFailed
+						AND (
+							jsonb_extract_path_text(data, 'projectDetails', 'intDeploymentDetails', 'lastDeployedBy') IS NULL
+							OR jsonb_extract_path_text(data, 'projectDetails', 'intDeploymentDetails', 'lastDeployedOn') IS NULL
+						)
+					)
+					OR (
+						jsonb_extract_path_text(data, 'projectDetails', 'prodDeploymentDetails', 'lastDeploymentStatus')
+							= :deploymentFailed
+						AND (
+							jsonb_extract_path_text(data, 'projectDetails', 'prodDeploymentDetails', 'lastDeployedBy') IS NULL
+							OR jsonb_extract_path_text(data, 'projectDetails', 'prodDeploymentDetails', 'lastDeployedOn') IS NULL
+						)
+					)
 				  )
 				""";
 		Query reconciliationQuery = em.createNativeQuery(query, CodeServerWorkspaceNsql.class);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepositoryImpl.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepositoryImpl.java
@@ -81,7 +81,28 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 		TypedQuery<CodeServerWorkspaceNsql> getAllQuery = em.createQuery(getAll);
 		return getAllQuery.getResultList();		
 	} 
-			
+
+	@Override
+	public List<CodeServerWorkspaceNsql> findDeploymentReconciliationWorkspaces() {
+		String query = """
+				SELECT *
+				FROM workspace_nsql
+				WHERE lower(jsonb_extract_path_text(data, 'status')) <> 'deleted'
+				  AND (
+					jsonb_extract_path_text(data, 'projectDetails', 'intDeploymentDetails', 'lastDeploymentStatus')
+						IN (:deployRequested, :deploymentFailed, :restartRequested)
+					OR jsonb_extract_path_text(data, 'projectDetails', 'prodDeploymentDetails', 'lastDeploymentStatus')
+						IN (:deployRequested, :deploymentFailed, :restartRequested)
+					OR jsonb_extract_path_text(data, 'projectDetails', 'lastBuildOrDeployedStatus') = :restartRequested
+				  )
+				""";
+		Query reconciliationQuery = em.createNativeQuery(query, CodeServerWorkspaceNsql.class);
+		reconciliationQuery.setParameter("deployRequested", "DEPLOY_REQUESTED");
+		reconciliationQuery.setParameter("deploymentFailed", "DEPLOYMENT_FAILED");
+		reconciliationQuery.setParameter("restartRequested", "RESTART_REQUESTED");
+		return reconciliationQuery.getResultList();
+	}
+
 	@Override
 	public List<CodeServerWorkspaceNsql> findAll(String userId, int limit, int offset) {
 		CriteriaBuilder cb = em.getCriteriaBuilder();

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.time.Duration;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +35,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.yaml.snakeyaml.Yaml;
 
@@ -196,6 +198,8 @@ public class ArgoCdService {
         
             if (response != null && response.getStatusCode().is2xxSuccessful()) {
                 log.info("ArgoCD application created/updated successfully: {}", appName);
+                refreshArgoApp(token, appName);
+                triggerArgoSync(token, appName);
                 return "success";
             } else {
                 String errorBody = response != null ? response.getBody() : "no response";
@@ -213,6 +217,57 @@ public class ArgoCdService {
         } catch (Exception e) {
             log.error("ArgoCD deployment exception for {}-{}: {}", projectName, environment, e.getMessage());
             throw e;
+        }
+    }
+
+    private void refreshArgoApp(String token, String appName) {
+        String url = argocdCreateUrl + "/" + appName + "?refresh=hard";
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(token);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            if (response != null && response.getStatusCode().is2xxSuccessful()) {
+                log.info("ArgoCD hard refresh requested successfully for {}", appName);
+            } else {
+                log.warn("ArgoCD hard refresh failed for {}: status={} body={}", appName,
+                        response != null ? response.getStatusCode() : "null",
+                        response != null ? response.getBody() : "no response");
+            }
+        } catch (HttpStatusCodeException e) {
+            log.warn("ArgoCD hard refresh failed for {}: status={} body={}", appName,
+                    e.getStatusCode(), e.getResponseBodyAsString());
+        } catch (Exception e) {
+            log.warn("ArgoCD hard refresh failed for {}: connection/error={}", appName, e.getMessage());
+        }
+    }
+
+    private String triggerArgoSync(String token, String appName) {
+        String url = argocdCreateUrl + "/" + appName + "/sync";
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(token);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            Map<String, Boolean> syncPayload = new HashMap<>();
+            syncPayload.put("prune", false);
+            HttpEntity<Map<String, Boolean>> entity = new HttpEntity<>(syncPayload, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+            if (response != null && response.getStatusCode().is2xxSuccessful()) {
+                log.info("ArgoCD sync requested successfully for {}", appName);
+                return "success";
+            }
+            log.warn("ArgoCD sync request failed for {}: status={} body={}", appName,
+                    response != null ? response.getStatusCode() : "null",
+                    response != null ? response.getBody() : "no response");
+            return "failed";
+        } catch (HttpStatusCodeException e) {
+            log.warn("ArgoCD sync request failed for {}: status={} body={}", appName,
+                    e.getStatusCode(), e.getResponseBodyAsString());
+            return e.getStatusCode().value() == 404 ? "not_found" : "failed";
+        } catch (Exception e) {
+            log.warn("ArgoCD sync request failed for {}: connection/error={}", appName, e.getMessage());
+            return "failed";
         }
     }
 
@@ -1080,9 +1135,10 @@ public class ArgoCdService {
         }
         try {
             Instant operationStart = Instant.parse(startedAt);
+            long queueGapSeconds = Duration.between(deployTriggerTime.toInstant(), operationStart).getSeconds();
             boolean matched = !operationStart.isBefore(deployTriggerTime.toInstant().minusSeconds(30));
-            log.info("New-sync validation for {}: operation startedAt={}, trigger time={}, matched={}",
-                    appName, startedAt, deployTriggerTime, matched);
+            log.info("New-sync validation for {}: operation startedAt={}, trigger time={}, queue gap={}s, matched={}",
+                    appName, startedAt, deployTriggerTime, queueGapSeconds, matched);
             return matched;
         } catch (DateTimeException e) {
             log.info("New-sync validation for {}: invalid operation startedAt={}, trigger time={} - matched=false",

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -66,6 +66,9 @@ public class ArgoCdService {
     @Value("${argocd.vaultKvPath}")
     private String vaultKvPath;
 
+    @Value("${deployment.hardRefreshEnabled:false}")
+    private boolean hardRefreshEnabled;
+
     @Value("${codeServer.env.ref}")
     private String codeServerEnvRef;
 
@@ -198,8 +201,16 @@ public class ArgoCdService {
         
             if (response != null && response.getStatusCode().is2xxSuccessful()) {
                 log.info("ArgoCD application created/updated successfully: {}", appName);
-                refreshArgoApp(token, appName);
-                triggerArgoSync(token, appName);
+                log.info("ArgoCD deployment trigger mode for {}: hardRefreshEnabled={}, sync=unconditional",
+                        appName, hardRefreshEnabled);
+                if (hardRefreshEnabled) {
+                    refreshArgoApp(token, appName);
+                } else {
+                    log.info("ArgoCD hard refresh disabled for {}; proceeding with sync only", appName);
+                }
+                String syncOutcome = triggerArgoSync(token, appName);
+                log.info("ArgoCD deployment trigger completed for {}: mode={}, syncOutcome={}",
+                        appName, hardRefreshEnabled ? "hard-refresh-and-sync" : "sync-only", syncOutcome);
                 return "success";
             } else {
                 String errorBody = response != null ? response.getBody() : "no response";

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -822,7 +822,7 @@ public class ArgoCdService {
             String operationMessage = rootNode.path("status").path("operationState").path("message").asText("");
             log.info("ArgoCD app {} - Health: {}, LastSyncPhase: {}, Message: {}", appName, healthStatus, lastSyncPhase, operationMessage);
 
-            String failureMessage = getConfirmedDeploymentFailure(rootNode, appName, deployTriggerTime);
+            String failureMessage = getConfirmedDeploymentFailure(token, rootNode, appName, deployTriggerTime);
             if (failureMessage != null) {
                 return "DEPLOYMENT_FAILED";
             }
@@ -894,7 +894,7 @@ public class ArgoCdService {
             String healthStatus = rootNode.path("status").path("health").path("status").asText("");
             String lastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
 
-            String failureMessage = getConfirmedDeploymentFailure(rootNode, appName, deployTriggerTime);
+            String failureMessage = getConfirmedDeploymentFailure(token, rootNode, appName, deployTriggerTime);
             if (failureMessage != null) {
                 result.put("status", "DEPLOYMENT_FAILED");
                 result.put("errorMessage", failureMessage);
@@ -933,6 +933,11 @@ public class ArgoCdService {
      * still deploying or has no confirmed failure.
      */
     public String getConfirmedDeploymentFailure(JsonNode rootNode, String appName, Date deployTriggerTime) {
+        return getConfirmedDeploymentFailure(null, rootNode, appName, deployTriggerTime);
+    }
+
+    public String getConfirmedDeploymentFailure(String token, JsonNode rootNode, String appName,
+            Date deployTriggerTime) {
         JsonNode operationState = rootNode.path("status").path("operationState");
         String healthStatus = rootNode.path("status").path("health").path("status").asText("");
         String phase = operationState.path("phase").asText("");
@@ -966,10 +971,22 @@ public class ArgoCdService {
             }
             if (degradedSince == null
                     || !Instant.now().isBefore(degradedSince.plusSeconds(degradedGraceSeconds))) {
+                String desiredTag = getDesiredImageTag(rootNode);
+                if (desiredTag == null || desiredTag.isEmpty()) {
+                    log.warn("Degraded ArgoCD deployment {} lacks a desired image tag; failure is not proven", appName);
+                    return null;
+                }
+                Map<String, Object> crashLoopStatus = getNewPodCrashLoopStatus(token, appName, rootNode);
+                if (!Boolean.TRUE.equals(crashLoopStatus.get("newPodCrashLooping"))) {
+                    log.warn("Degraded ArgoCD deployment {} has no strong crash evidence from a new-version pod; failure is not proven",
+                            appName);
+                    return null;
+                }
                 String failureMessage = message != null && !message.isEmpty()
                         ? message : "Application health is Degraded. Check pod logs for details.";
-                log.info("Confirmed ArgoCD deployment failure for {}: phase={}, health={}, startedAt={}, finishedAt={}, triggerTime={}",
-                        appName, phase, healthStatus, startedAt, finishedAt, deployTriggerTime);
+                log.info("Confirmed ArgoCD deployment failure for {}: phase={}, health={}, startedAt={}, finishedAt={}, triggerTime={}, crashReason={}",
+                        appName, phase, healthStatus, startedAt, finishedAt, deployTriggerTime,
+                        crashLoopStatus.get("crashLoopReason"));
                 return failureMessage;
             }
         }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -201,12 +201,8 @@ public class ArgoCdService {
         
             if (response != null && response.getStatusCode().is2xxSuccessful()) {
                 log.info("ArgoCD application created/updated successfully: {}", appName);
-                log.info("ArgoCD deployment trigger mode for {}: hardRefreshEnabled={}, sync=unconditional",
-                        appName, hardRefreshEnabled);
                 if (hardRefreshEnabled) {
                     refreshArgoApp(token, appName);
-                } else {
-                    log.info("ArgoCD hard refresh disabled for {}; proceeding with sync only", appName);
                 }
                 String syncOutcome = triggerArgoSync(token, appName);
                 log.info("ArgoCD deployment trigger completed for {}: mode={}, syncOutcome={}",

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -1318,7 +1318,6 @@ public class ArgoCdService {
      * returned as a best-effort fallback.
      */
     public List<PodInfo> getNewVersionPods(String token, String appName) {
-        List<PodInfo> pods = new ArrayList<>();
         try {
             String desiredTag = null;
             ResponseEntity<String> appResponse = getStatusOfArgoApp(token, appName);
@@ -1326,6 +1325,21 @@ public class ArgoCdService {
                 JsonNode appNode = new ObjectMapper().readTree(appResponse.getBody());
                 desiredTag = getDesiredImageTag(appNode);
             }
+            return getNewVersionPodsWithDesiredTag(token, appName, desiredTag);
+        } catch (Exception e) {
+            log.warn("Failed to resolve new-version pods for {}: {}", appName, e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    public List<PodInfo> getNewVersionPods(String token, String appName, JsonNode appNode) {
+        String desiredTag = appNode != null ? getDesiredImageTag(appNode) : null;
+        return getNewVersionPodsWithDesiredTag(token, appName, desiredTag);
+    }
+
+    private List<PodInfo> getNewVersionPodsWithDesiredTag(String token, String appName, String desiredTag) {
+        List<PodInfo> pods = new ArrayList<>();
+        try {
 
             JsonNode tree = getResourceTree(token, appName);
             if (tree == null) {
@@ -1401,6 +1415,29 @@ public class ArgoCdService {
         result.put("crashLoopReason", null);
         try {
             List<PodInfo> pods = getNewVersionPods(token, appName);
+            return evaluateCrashLoopStatus(appName, pods, result);
+        } catch (Exception e) {
+            log.warn("Failed to evaluate crash-loop status for {}: {}", appName, e.getMessage());
+            return result;
+        }
+    }
+
+    public Map<String, Object> getNewPodCrashLoopStatus(String token, String appName, JsonNode appNode) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("newPodCrashLooping", false);
+        result.put("crashLoopReason", null);
+        try {
+            List<PodInfo> pods = getNewVersionPods(token, appName, appNode);
+            return evaluateCrashLoopStatus(appName, pods, result);
+        } catch (Exception e) {
+            log.warn("Failed to evaluate crash-loop status for {}: {}", appName, e.getMessage());
+        }
+        return result;
+    }
+
+    private Map<String, Object> evaluateCrashLoopStatus(String appName, List<PodInfo> pods,
+            Map<String, Object> result) {
+        try {
             for (PodInfo pod : pods) {
                 String reason = pod.getStatusReason();
                 if (reason != null && CRASH_LOOP_REASONS.contains(reason)) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -932,10 +932,6 @@ public class ArgoCdService {
      * be attributed to the current deployment, or null when the application is
      * still deploying or has no confirmed failure.
      */
-    public String getConfirmedDeploymentFailure(JsonNode rootNode, String appName, Date deployTriggerTime) {
-        return getConfirmedDeploymentFailure(null, rootNode, appName, deployTriggerTime);
-    }
-
     public String getConfirmedDeploymentFailure(String token, JsonNode rootNode, String appName,
             Date deployTriggerTime) {
         JsonNode operationState = rootNode.path("status").path("operationState");

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -1382,6 +1382,8 @@ public class ArgoCdService {
         return getNewVersionPodSelection(token, appName).getPods();
     }
 
+    // Keep selection metadata with the pods so the SSE layer can distinguish
+    // a precise version match from the compatibility fallback.
     public PodSelectionResult getNewVersionPodSelection(String token, String appName) {
         List<PodInfo> emptyPods = new ArrayList<>();
         try {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -442,6 +442,11 @@ public class DeploymentStatusMonitorJob {
                     return false;
                 }
 
+                if ("DEPLOYED".equals(targetStatus)) {
+                    logDeploymentCompletion(projectName, environment, deployment.getLastDeployedVersion(),
+                            latestAudit != null ? latestAudit.getTriggeredOn() : null, buildDeployEntity, new Date());
+                }
+
                 // Clean up non-retained build images after successful deployment
                 if ("DEPLOYED".equals(targetStatus)) {
                     String deployedVersion = deployment.getLastDeployedVersion();
@@ -457,6 +462,54 @@ public class DeploymentStatusMonitorJob {
             log.warn("Failed to check ArgoCD status for {}-{}: {}", projectName, environment, e.getMessage());
         }
         return false;
+    }
+
+    private void logDeploymentCompletion(String projectName, String environment, String version,
+            Date deployTriggerTime, CodeServerBuildDeployNsql buildDeployEntity, Date completionTime) {
+        String durationPart = "";
+        if (deployTriggerTime != null && !deployTriggerTime.after(completionTime)) {
+            long elapsedSeconds = (completionTime.getTime() - deployTriggerTime.getTime()) / 1000L;
+            durationPart = String.format(" duration=%ds (%02d:%02d)", elapsedSeconds,
+                    elapsedSeconds / 60, elapsedSeconds % 60);
+        }
+
+        String buildPart = "";
+        BuildAudit buildAudit = findBuildAudit(buildDeployEntity, environment, version);
+        if (buildAudit != null && buildAudit.getTriggeredOn() != null) {
+            buildPart = " buildTriggeredAt=" + buildAudit.getTriggeredOn();
+            if (buildAudit.getBuildOn() != null && !buildAudit.getBuildOn().before(buildAudit.getTriggeredOn())) {
+                long buildSeconds = (buildAudit.getBuildOn().getTime() - buildAudit.getTriggeredOn().getTime()) / 1000L;
+                buildPart += String.format(" buildDuration=%ds (%02d:%02d)", buildSeconds,
+                        buildSeconds / 60, buildSeconds % 60);
+            }
+        }
+
+        log.info("Deployment completed: project={} environment={} version={} deployTriggeredAt={} completedAt={}{}{}",
+                projectName, environment, version, deployTriggerTime, completionTime, durationPart, buildPart);
+    }
+
+    private BuildAudit findBuildAudit(CodeServerBuildDeployNsql buildDeployEntity, String environment,
+            String version) {
+        if (buildDeployEntity == null || buildDeployEntity.getData() == null || version == null) {
+            return null;
+        }
+        List<BuildAudit> buildAudits = "int".equalsIgnoreCase(environment)
+                ? buildDeployEntity.getData().getIntBuildAuditLogs()
+                : buildDeployEntity.getData().getProdBuildAuditLogs();
+        if (buildAudits == null) {
+            return null;
+        }
+        return buildAudits.stream()
+                .filter(audit -> audit.getVersion() != null && version.equalsIgnoreCase(audit.getVersion()))
+                .max((a1, a2) -> {
+                    Date first = a1.getTriggeredOn();
+                    Date second = a2.getTriggeredOn();
+                    if (first == null && second == null) return 0;
+                    if (first == null) return -1;
+                    if (second == null) return 1;
+                    return first.compareTo(second);
+                })
+                .orElse(null);
     }
 
     private void fixStaleBuildDeployAuditLog(String projectName, String environment) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -18,6 +18,7 @@ import com.daimler.data.service.ArgoCdService;
 import com.daimler.dna.notifications.common.producer.KafkaProducerService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -50,6 +51,8 @@ public class DeploymentStatusMonitorJob {
     @Autowired
     private CodeServerClient codeServerClient;
 
+    @Value("${deployment.failedRecheckMinutes:30}")
+    private int failedRecheckMinutes;
 
     @Scheduled(fixedDelay = 10000, initialDelay = 5000)
     @SchedulerLock(name = "deploymentStatusMonitorJob", lockAtMostFor = "2m", lockAtLeastFor = "5s")
@@ -63,7 +66,7 @@ public class DeploymentStatusMonitorJob {
                 return;
             }
 
-            List<CodeServerWorkspaceNsql> workspaces = workspaceCustomRepository.findAll();
+            List<CodeServerWorkspaceNsql> workspaces = workspaceCustomRepository.findDeploymentReconciliationWorkspaces();
             int checkedCount = 0;
             int updatedCount = 0;
 
@@ -83,7 +86,7 @@ public class DeploymentStatusMonitorJob {
                 String topLevelEnv = workspace.getData().getProjectDetails().getLastBuildOrDeployedEnv();
 
                 CodeServerDeploymentDetails intDeployment = workspace.getData().getProjectDetails().getIntDeploymentDetails();
-                boolean intNeedsCheck = intDeployment != null && shouldCheckDeployment(intDeployment.getLastDeploymentStatus())
+                boolean intNeedsCheck = intDeployment != null && shouldCheckDeployment(intDeployment)
                         && !isUserCancelled(intDeployment);
                 // Recovery for stuck restarts: top-level says RESTART_REQUESTED for this env but per-env field was never updated
                 if (!intNeedsCheck && intDeployment != null 
@@ -105,14 +108,9 @@ public class DeploymentStatusMonitorJob {
                     if (checkAndUpdateDeployment(argoToken, workspace, intDeployment, projectName, "int")) {
                         updatedCount++;
                     }
-                } else if (intDeployment != null && "DEPLOYED".equalsIgnoreCase(intDeployment.getLastDeploymentStatus())) {
-                    // Fix stale build deploy entities for workspaces that were already updated
-                    // before the build deploy audit log fix was deployed
-                    fixStaleBuildDeployAuditLog(projectName, "int");
                 }
-
                 CodeServerDeploymentDetails prodDeployment = workspace.getData().getProjectDetails().getProdDeploymentDetails();
-                boolean prodNeedsCheck = prodDeployment != null && shouldCheckDeployment(prodDeployment.getLastDeploymentStatus())
+                boolean prodNeedsCheck = prodDeployment != null && shouldCheckDeployment(prodDeployment)
                         && !isUserCancelled(prodDeployment);
                 if (!prodNeedsCheck && prodDeployment != null 
                         && "RESTART_REQUESTED".equalsIgnoreCase(topLevelStatus) 
@@ -133,8 +131,6 @@ public class DeploymentStatusMonitorJob {
                     if (checkAndUpdateDeployment(argoToken, workspace, prodDeployment, projectName, "prod")) {
                         updatedCount++;
                     }
-                } else if (prodDeployment != null && "DEPLOYED".equalsIgnoreCase(prodDeployment.getLastDeploymentStatus())) {
-                    fixStaleBuildDeployAuditLog(projectName, "prod");
                 }
             }
 
@@ -162,8 +158,45 @@ public class DeploymentStatusMonitorJob {
         }
     }
 
-    private boolean shouldCheckDeployment(String status) {
-        if (status == null) return false;
+    @Scheduled(fixedDelayString = "#{${deployment.auditLogBackfillMinutes:10} * 60000}",
+            initialDelayString = "#{${deployment.auditLogBackfillMinutes:10} * 60000}")
+    @SchedulerLock(name = "deploymentAuditLogBackfillJob", lockAtMostFor = "15m", lockAtLeastFor = "5s")
+    public void backfillStaleBuildDeployAuditLogs() {
+        try {
+            for (CodeServerWorkspaceNsql workspace : workspaceCustomRepository.findAll()) {
+                if (workspace.getData() == null || workspace.getData().getProjectDetails() == null) {
+                    continue;
+                }
+                String projectName = workspace.getData().getProjectDetails().getProjectName();
+                if (projectName == null) {
+                    continue;
+                }
+                CodeServerDeploymentDetails intDeployment = workspace.getData().getProjectDetails().getIntDeploymentDetails();
+                if (intDeployment != null && "DEPLOYED".equalsIgnoreCase(intDeployment.getLastDeploymentStatus())) {
+                    fixStaleBuildDeployAuditLog(projectName, "int");
+                }
+                CodeServerDeploymentDetails prodDeployment = workspace.getData().getProjectDetails().getProdDeploymentDetails();
+                if (prodDeployment != null && "DEPLOYED".equalsIgnoreCase(prodDeployment.getLastDeploymentStatus())) {
+                    fixStaleBuildDeployAuditLog(projectName, "prod");
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error in stale build deploy audit log backfill", e);
+        }
+    }
+
+    private boolean shouldCheckDeployment(CodeServerDeploymentDetails deployment) {
+        if (deployment == null || deployment.getLastDeploymentStatus() == null) {
+            return false;
+        }
+        String status = deployment.getLastDeploymentStatus();
+        if ("DEPLOYMENT_FAILED".equalsIgnoreCase(status)) {
+            Date lastDeployedOn = deployment.getLastDeployedOn();
+            if (lastDeployedOn != null
+                    && System.currentTimeMillis() - lastDeployedOn.getTime() > failedRecheckMinutes * 60_000L) {
+                return false;
+            }
+        }
         return "DEPLOY_REQUESTED".equalsIgnoreCase(status) || "DEPLOYMENT_FAILED".equalsIgnoreCase(status)
                 || "RESTART_REQUESTED".equalsIgnoreCase(status);
     }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -18,7 +18,6 @@ import com.daimler.data.service.ArgoCdService;
 import com.daimler.dna.notifications.common.producer.KafkaProducerService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -50,9 +49,6 @@ public class DeploymentStatusMonitorJob {
 
     @Autowired
     private CodeServerClient codeServerClient;
-
-    @Value("${deployment.failedRecheckMinutes:30}")
-    private int failedRecheckMinutes;
 
     @Scheduled(fixedDelay = 10000, initialDelay = 5000)
     @SchedulerLock(name = "deploymentStatusMonitorJob", lockAtMostFor = "2m", lockAtLeastFor = "5s")
@@ -86,6 +82,7 @@ public class DeploymentStatusMonitorJob {
                 String topLevelEnv = workspace.getData().getProjectDetails().getLastBuildOrDeployedEnv();
 
                 CodeServerDeploymentDetails intDeployment = workspace.getData().getProjectDetails().getIntDeploymentDetails();
+                repairMissingFailureFields(workspace, intDeployment, projectName, "int");
                 boolean intNeedsCheck = intDeployment != null && shouldCheckDeployment(intDeployment)
                         && !isUserCancelled(intDeployment);
                 // Recovery for stuck restarts: top-level says RESTART_REQUESTED for this env but per-env field was never updated
@@ -110,6 +107,7 @@ public class DeploymentStatusMonitorJob {
                     }
                 }
                 CodeServerDeploymentDetails prodDeployment = workspace.getData().getProjectDetails().getProdDeploymentDetails();
+                repairMissingFailureFields(workspace, prodDeployment, projectName, "prod");
                 boolean prodNeedsCheck = prodDeployment != null && shouldCheckDeployment(prodDeployment)
                         && !isUserCancelled(prodDeployment);
                 if (!prodNeedsCheck && prodDeployment != null 
@@ -190,15 +188,60 @@ public class DeploymentStatusMonitorJob {
             return false;
         }
         String status = deployment.getLastDeploymentStatus();
-        if ("DEPLOYMENT_FAILED".equalsIgnoreCase(status)) {
-            Date lastDeployedOn = deployment.getLastDeployedOn();
-            if (lastDeployedOn != null
-                    && System.currentTimeMillis() - lastDeployedOn.getTime() > failedRecheckMinutes * 60_000L) {
-                return false;
+        return "DEPLOY_REQUESTED".equalsIgnoreCase(status) || "RESTART_REQUESTED".equalsIgnoreCase(status);
+    }
+
+    private void repairMissingFailureFields(CodeServerWorkspaceNsql workspace,
+            CodeServerDeploymentDetails deployment, String projectName, String environment) {
+        if (deployment == null || !"DEPLOYMENT_FAILED".equalsIgnoreCase(deployment.getLastDeploymentStatus())
+                || (deployment.getLastDeployedBy() != null && deployment.getLastDeployedOn() != null)) {
+            return;
+        }
+        try {
+            DeploymentAudit latestAudit = findLatestDeploymentAudit(projectName, environment, deployment);
+            UserInfo deployedByUser = resolveTriggeredByUser(workspace, latestAudit);
+            if (deployment.getLastDeployedBy() == null && deployedByUser != null) {
+                deployment.setLastDeployedBy(deployedByUser);
+            }
+            if (deployment.getLastDeployedOn() == null) {
+                deployment.setLastDeployedOn(new Date());
+            }
+            GenericMessage update = workspaceCustomRepository.updateReconciledDeploymentStatus(
+                    projectName, environment, deployment, "DEPLOYMENT_FAILED");
+            if (update != null && "SUCCESS".equalsIgnoreCase(update.getSuccess())) {
+                log.info("Repaired missing failure fields for {}-{}", projectName, environment);
+            } else {
+                log.warn("Failed to repair missing failure fields for {}-{}", projectName, environment);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to repair missing failure fields for {}-{}: {}", projectName, environment, e.getMessage());
+        }
+    }
+
+    private DeploymentAudit findLatestDeploymentAudit(String projectName, String environment,
+            CodeServerDeploymentDetails deployment) {
+        CodeServerBuildDeployNsql buildDeployEntity = buildDeployCustomRepo.findByProjectName(projectName);
+        if (buildDeployEntity != null && buildDeployEntity.getData() != null) {
+            List<DeploymentAudit> auditLogs = "int".equalsIgnoreCase(environment)
+                    ? buildDeployEntity.getData().getIntDeploymentAuditLogs()
+                    : buildDeployEntity.getData().getProdDeploymentAuditLogs();
+            if (auditLogs != null && !auditLogs.isEmpty()) {
+                DeploymentAudit latest = auditLogs.stream()
+                        .filter(audit -> audit.getTriggeredOn() != null)
+                        .max((a1, a2) -> a1.getTriggeredOn().compareTo(a2.getTriggeredOn()))
+                        .orElse(null);
+                if (latest != null) {
+                    return latest;
+                }
             }
         }
-        return "DEPLOY_REQUESTED".equalsIgnoreCase(status) || "DEPLOYMENT_FAILED".equalsIgnoreCase(status)
-                || "RESTART_REQUESTED".equalsIgnoreCase(status);
+        if (deployment.getDeploymentAuditLogs() == null) {
+            return null;
+        }
+        return deployment.getDeploymentAuditLogs().stream()
+                .filter(audit -> audit.getTriggeredOn() != null)
+                .max((a1, a2) -> a1.getTriggeredOn().compareTo(a2.getTriggeredOn()))
+                .orElse(null);
     }
 
     /**

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -57,7 +57,8 @@ public class DeploymentStatusMonitorJob {
 
     private final Map<String, Long> onDemandReconciliationTimes = new ConcurrentHashMap<>();
 
-    @Scheduled(fixedDelay = 10000, initialDelay = 5000)
+    @Scheduled(fixedDelayString = "#{${deployment.statusMonitorSeconds:20} * 1000}",
+            initialDelay = 5000)
     @SchedulerLock(name = "deploymentStatusMonitorJob", lockAtMostFor = "2m", lockAtLeastFor = "5s")
     public void monitorDeploymentStatus() {
         try {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -443,13 +443,10 @@ public class DeploymentStatusMonitorJob {
                 }
 
                 if ("DEPLOYED".equals(targetStatus)) {
-                    logDeploymentCompletion(projectName, environment, deployment.getLastDeployedVersion(),
-                            latestAudit != null ? latestAudit.getTriggeredOn() : null, buildDeployEntity, new Date());
-                }
-
-                // Clean up non-retained build images after successful deployment
-                if ("DEPLOYED".equals(targetStatus)) {
                     String deployedVersion = deployment.getLastDeployedVersion();
+                    logDeploymentCompletion(projectName, environment, deployedVersion,
+                            latestAudit != null ? latestAudit.getTriggeredOn() : null, buildDeployEntity, new Date());
+                    // Clean up non-retained build images after successful deployment
                     cleanupNonRetainedBuildImages(projectName, environment, deployedVersion);
                 }
 

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -18,6 +18,7 @@ import com.daimler.data.service.ArgoCdService;
 import com.daimler.dna.notifications.common.producer.KafkaProducerService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 @Component
@@ -49,6 +51,11 @@ public class DeploymentStatusMonitorJob {
 
     @Autowired
     private CodeServerClient codeServerClient;
+
+    @Value("${deployment.onDemandRefreshCooldownSeconds:5}")
+    private long onDemandRefreshCooldownSeconds;
+
+    private final Map<String, Long> onDemandReconciliationTimes = new ConcurrentHashMap<>();
 
     @Scheduled(fixedDelay = 10000, initialDelay = 5000)
     @SchedulerLock(name = "deploymentStatusMonitorJob", lockAtMostFor = "2m", lockAtLeastFor = "5s")
@@ -138,6 +145,63 @@ public class DeploymentStatusMonitorJob {
         } catch (Exception e) {
             log.error("Error in deployment status monitoring job", e);
         }
+    }
+
+    public boolean reconcileDeploymentOnDemand(CodeServerWorkspaceNsql workspace, String environment) {
+        if (workspace == null || workspace.getData() == null
+                || workspace.getData().getProjectDetails() == null
+                || (!"int".equalsIgnoreCase(environment) && !"prod".equalsIgnoreCase(environment))) {
+            return false;
+        }
+
+        String projectName = workspace.getData().getProjectDetails().getProjectName();
+        CodeServerDeploymentDetails deployment = "int".equalsIgnoreCase(environment)
+                ? workspace.getData().getProjectDetails().getIntDeploymentDetails()
+                : workspace.getData().getProjectDetails().getProdDeploymentDetails();
+        if (projectName == null || deployment == null || isUserCancelled(deployment)) {
+            return false;
+        }
+
+        boolean needsCheck = shouldCheckDeployment(deployment);
+        if (!needsCheck
+                && "RESTART_REQUESTED".equalsIgnoreCase(
+                        workspace.getData().getProjectDetails().getLastBuildOrDeployedStatus())
+                && environment.equalsIgnoreCase(
+                        workspace.getData().getProjectDetails().getLastBuildOrDeployedEnv())) {
+            deployment.setLastDeploymentStatus("RESTART_REQUESTED");
+            needsCheck = true;
+        }
+        if (!needsCheck || isUserCancelled(deployment) || !hasDeploymentHistory(projectName, environment)) {
+            return false;
+        }
+
+        String workspaceKey = workspace.getData().getWorkspaceId() != null
+                ? workspace.getData().getWorkspaceId() : projectName;
+        String cooldownKey = workspaceKey + ":" + environment.toLowerCase();
+        long now = System.currentTimeMillis();
+        Long previousRun = onDemandReconciliationTimes.get(cooldownKey);
+        if (previousRun != null
+                && now - previousRun < onDemandRefreshCooldownSeconds * 1000L) {
+            log.info("Skipping on-demand deployment reconciliation for {}-{}: cooldown active",
+                    projectName, environment);
+            return false;
+        }
+
+        String argoToken;
+        try {
+            argoToken = argoCdService.getArgoToken();
+        } catch (Exception e) {
+            log.warn("Unable to get ArgoCD token for on-demand deployment reconciliation of {}-{}: {}",
+                    projectName, environment, e.getMessage());
+            return false;
+        }
+        if (argoToken == null) {
+            log.warn("Unable to get ArgoCD token for on-demand deployment reconciliation of {}-{}",
+                    projectName, environment);
+            return false;
+        }
+        onDemandReconciliationTimes.put(cooldownKey, now);
+        return checkAndUpdateDeployment(argoToken, workspace, deployment, projectName, environment);
     }
 
     private boolean hasDeploymentHistory(String projectName, String environment) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -194,6 +194,7 @@ public class DeploymentStatusMonitorJob {
     private void repairMissingFailureFields(CodeServerWorkspaceNsql workspace,
             CodeServerDeploymentDetails deployment, String projectName, String environment) {
         if (deployment == null || !"DEPLOYMENT_FAILED".equalsIgnoreCase(deployment.getLastDeploymentStatus())
+                || isUserCancelled(deployment)
                 || (deployment.getLastDeployedBy() != null && deployment.getLastDeployedOn() != null)) {
             return;
         }
@@ -204,7 +205,12 @@ public class DeploymentStatusMonitorJob {
                 deployment.setLastDeployedBy(deployedByUser);
             }
             if (deployment.getLastDeployedOn() == null) {
-                deployment.setLastDeployedOn(new Date());
+                Date repairedOn = latestAudit != null && latestAudit.getTriggeredOn() != null
+                        ? latestAudit.getTriggeredOn() : new Date();
+                deployment.setLastDeployedOn(repairedOn);
+                log.info("Repairing lastDeployedOn for {}-{} using {} timestamp",
+                        projectName, environment,
+                        latestAudit != null && latestAudit.getTriggeredOn() != null ? "audit" : "current time");
             }
             GenericMessage update = workspaceCustomRepository.updateReconciledDeploymentStatus(
                     projectName, environment, deployment, "DEPLOYMENT_FAILED");

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -200,6 +200,9 @@ public class DeploymentStatusMonitorJob {
                     projectName, environment);
             return false;
         }
+        long cooldownMillis = onDemandRefreshCooldownSeconds * 1000L;
+        onDemandReconciliationTimes.entrySet().removeIf(entry ->
+                now - entry.getValue() >= cooldownMillis);
         onDemandReconciliationTimes.put(cooldownKey, now);
         return checkAndUpdateDeployment(argoToken, workspace, deployment, projectName, environment);
     }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
@@ -1655,7 +1655,7 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 				log.info("getById - lookup by userId+id: userId={}, id={}", userId, id);
 			}
 			// Status reconciliation (ArgoCD, GitHub Actions, backfill) is handled
-			// by DeploymentStatusMonitorJob which runs every 10s. Keeping getById
+			// by DeploymentStatusMonitorJob which runs every 20s. Keeping getById
 			// as a pure DB read avoids slow synchronous HTTP calls to ArgoCD/GitHub
 			// on every card refresh.
 
@@ -1665,7 +1665,7 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 			// ArgoCD.
 			// This reconciliation only runs when explicitly triggered by user refresh
 			// (refreshTriggeredByUser=true).
-			// Auto-poll requests (every 10s) skip this entirely and return DB state only.
+			// Auto-poll requests (every 20s) skip this entirely and return DB state only.
 			if (refreshTriggeredByUser && entity != null && entity.getData() != null
 					&& entity.getData().getProjectDetails() != null
 					&& entity.getData().getProjectDetails().getLastBuildOrDeployedStatus() != null) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
@@ -48,10 +48,7 @@ import java.util.regex.Matcher;
  import java.util.stream.Collectors;
  import java.util.Collections;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-
- import org.json.JSONObject;
+import org.json.JSONObject;
  import org.springframework.beans.BeanUtils;
  import org.springframework.beans.factory.annotation.Autowired;
  import org.springframework.beans.factory.annotation.Value;
@@ -273,9 +270,6 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 
 	 @Autowired
 	 private DeploymentStatusMonitorJob deploymentStatusMonitorJob;
-
-	 @PersistenceContext
-	 private EntityManager entityManager;
 
 	 @Value("${codeServer.build.retainedlimit}")
      private String retainedBuildLimitValue;
@@ -1903,7 +1897,14 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 				deploymentReconciled |= deploymentStatusMonitorJob
 						.reconcileDeploymentOnDemand(entity, "prod");
 				if (deploymentReconciled) {
-					entityManager.refresh(entity);
+					CodeServerWorkspaceNsql refreshedEntity = technicalId.equalsIgnoreCase(userId)
+							? workspaceCustomRepository.findByWorkspaceId(id)
+							: workspaceCustomRepository.findById(userId, id);
+					if (refreshedEntity != null) {
+						entity = refreshedEntity;
+					} else {
+						log.warn("getById - Re-read after deployment reconciliation returned no row for id={}", id);
+					}
 				}
 			}
 

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
@@ -48,6 +48,9 @@ import java.util.regex.Matcher;
  import java.util.stream.Collectors;
  import java.util.Collections;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
  import org.json.JSONObject;
  import org.springframework.beans.BeanUtils;
  import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +71,7 @@ import java.util.regex.Matcher;
  import com.daimler.data.auth.client.AuthenticatorClient;
  import com.daimler.data.auth.client.DnaAuthClient;
  import com.daimler.data.service.ArgoCdService;
+import com.daimler.data.service.scheduler.DeploymentStatusMonitorJob;
  import com.daimler.data.controller.exceptions.GenericMessage;
  import com.daimler.data.controller.exceptions.MessageDescription;
  import com.daimler.data.db.entities.CodeServerBuildDeployNsql;
@@ -266,6 +270,12 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 
 	 @Autowired
 	 private ArgoCdService argoCdService;
+
+	 @Autowired
+	 private DeploymentStatusMonitorJob deploymentStatusMonitorJob;
+
+	 @PersistenceContext
+	 private EntityManager entityManager;
 
 	 @Value("${codeServer.build.retainedlimit}")
      private String retainedBuildLimitValue;
@@ -1883,6 +1893,17 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 									projectName, minutesSinceRequest, staleThresholdMinutes);
 						}
 					}
+				}
+			}
+
+			if (refreshTriggeredByUser && entity != null && entity.getData() != null
+					&& entity.getData().getProjectDetails() != null) {
+				boolean deploymentReconciled = deploymentStatusMonitorJob
+						.reconcileDeploymentOnDemand(entity, "int");
+				deploymentReconciled |= deploymentStatusMonitorJob
+						.reconcileDeploymentOnDemand(entity, "prod");
+				if (deploymentReconciled) {
+					entityManager.refresh(entity);
 				}
 			}
 

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.9
+    version: 1.12.10
   profile:
     active: production
 
@@ -266,7 +266,6 @@ argocd:
 deployment:
   stuckThresholdMinutes: ${DEPLOYMENT_STUCK_THRESHOLD_MINUTES:15}
   deployedFallbackMinutes: ${DEPLOYMENT_DEPLOYED_FALLBACK_MINUTES:15}
-  degradedGraceSeconds: ${DEPLOYMENT_DEGRADED_GRACE_SECONDS:120}
-  failedRecheckMinutes: ${DEPLOYMENT_FAILED_RECHECK_MINUTES:30}
+  degradedGraceSeconds: ${DEPLOYMENT_DEGRADED_GRACE_SECONDS:300}
   auditLogBackfillMinutes: ${DEPLOYMENT_AUDIT_LOG_BACKFILL_MINUTES:10}
   ssePollSeconds: ${DEPLOYMENT_SSE_POLL_SECONDS:10}

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.15
+    version: 1.12.16
   profile:
     active: production
 

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.8
+    version: 1.12.9
   profile:
     active: production
 
@@ -267,3 +267,6 @@ deployment:
   stuckThresholdMinutes: ${DEPLOYMENT_STUCK_THRESHOLD_MINUTES:15}
   deployedFallbackMinutes: ${DEPLOYMENT_DEPLOYED_FALLBACK_MINUTES:15}
   degradedGraceSeconds: ${DEPLOYMENT_DEGRADED_GRACE_SECONDS:120}
+  failedRecheckMinutes: ${DEPLOYMENT_FAILED_RECHECK_MINUTES:30}
+  auditLogBackfillMinutes: ${DEPLOYMENT_AUDIT_LOG_BACKFILL_MINUTES:10}
+  ssePollSeconds: ${DEPLOYMENT_SSE_POLL_SECONDS:10}

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.18
+    version: 1.12.19
   profile:
     active: production
 

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.17
+    version: 1.12.18
   profile:
     active: production
 
@@ -271,3 +271,4 @@ deployment:
   ssePollSeconds: ${DEPLOYMENT_SSE_POLL_SECONDS:10}
   onDemandRefreshCooldownSeconds: ${DEPLOYMENT_ON_DEMAND_REFRESH_COOLDOWN_SECONDS:5}
   statusMonitorSeconds: ${DEPLOYMENT_STATUS_MONITOR_SECONDS:20}
+  hardRefreshEnabled: ${DEPLOYMENT_HARD_REFRESH_ENABLED:false}

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.16
+    version: 1.12.17
   profile:
     active: production
 
@@ -270,3 +270,4 @@ deployment:
   auditLogBackfillMinutes: ${DEPLOYMENT_AUDIT_LOG_BACKFILL_MINUTES:10}
   ssePollSeconds: ${DEPLOYMENT_SSE_POLL_SECONDS:10}
   onDemandRefreshCooldownSeconds: ${DEPLOYMENT_ON_DEMAND_REFRESH_COOLDOWN_SECONDS:5}
+  statusMonitorSeconds: ${DEPLOYMENT_STATUS_MONITOR_SECONDS:20}

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.7
+    version: 1.12.8
   profile:
     active: production
 

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.14
+    version: 1.12.15
   profile:
     active: production
 
@@ -269,3 +269,4 @@ deployment:
   degradedGraceSeconds: ${DEPLOYMENT_DEGRADED_GRACE_SECONDS:300}
   auditLogBackfillMinutes: ${DEPLOYMENT_AUDIT_LOG_BACKFILL_MINUTES:10}
   ssePollSeconds: ${DEPLOYMENT_SSE_POLL_SECONDS:10}
+  onDemandRefreshCooldownSeconds: ${DEPLOYMENT_ON_DEMAND_REFRESH_COOLDOWN_SECONDS:5}

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.11
+    version: 1.12.12
   profile:
     active: production
 

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.10
+    version: 1.12.11
   profile:
     active: production
 


### PR DESCRIPTION
## Summary

Deployments were taking up to 30 minutes to reach `Deployed` and occasionally showed `DEPLOYMENT_FAILED` while the rollout was still healthy. Logs showed the classification was correct — the requested image genuinely wasn't running yet — so the wait was ArgoCD reconciliation latency: `createArgoApp` only upserted the Application with `syncPolicy.automated` and then waited for the app-controller to get round to that app (default 3 min, longer with 500+ apps on a shared repo-server).

**1. Trigger the rollout instead of waiting for it.** After a successful upsert:

```
GET  {argocdCreateUrl}/{appName}?refresh=hard   // re-render manifests, bypass the cache
POST {argocdCreateUrl}/{appName}/sync   {"prune": false}
```

No force/replace strategy. The sync is unconditional; the hard refresh is opt-in via `DEPLOYMENT_HARD_REFRESH_ENABLED` and **off by default**, because a hard refresh re-renders manifests and invalidates cached live state (kube-API cost) while only helping when repo-server served a stale render — the sync alone is what starts the rollout. Both calls are warning-only: a failure never fails the deployment, and `syncPolicy.automated` remains the fallback. `hasNewSyncEvidence` now also logs `queue gap=Ns` (deploy trigger → `operationState.startedAt`) so the ArgoCD-queueing share of the wait is measurable per deploy.

**2. `DEPLOYMENT_FAILED` is only reported when we're sure.** Previously `health=Degraded` + `phase=Succeeded` outliving the grace window was enough — which is what a slow image pull or readiness warmup also looks like. Now, after the grace window (raised 120s → 300s), a Degraded app fails only with pod-level proof:

```
desiredTag present                     (else WARN, stay DEPLOYING)
&& pod matched precisely on that tag   (fallback-selected pods can't prove failure)
&& strong reason: CrashLoopBackOff | ImagePullBackOff | ErrImagePull | Error | ...
```

Restart-count-only evidence no longer confirms a failure. `operationState.phase` `Failed`/`Error` attributed to the current deployment still fails immediately.

**3. `DEPLOYMENT_FAILED` is terminal.** `shouldCheckDeployment` returns true only for `DEPLOY_REQUESTED`/`RESTART_REQUESTED`, so a failed environment is no longer re-polled forever (previously every ever-failed row cost one ArgoCD GET per poll in perpetuity — the dominant source of ArgoCD load, independent of live deploys). Old rows missing `lastDeployedBy`/`lastDeployedOn` are still repaired, but without any ArgoCD call, using the latest audit's `triggeredOn` rather than a fabricated timestamp, and user-cancelled rows are left untouched.

**4. Less polling.** The monitor (now every `DEPLOYMENT_STATUS_MONITOR_SECONDS`, default 20s, was a hardcoded 10s) no longer runs `findAll()` + in-memory filtering; `findDeploymentReconciliationWorkspaces()` selects only actionable rows (bound parameters). The stale-audit backfill that ran for every DEPLOYED workspace on every poll moved to its own 10-minute job with a separate ShedLock name. The SSE modal polls every `DEPLOYMENT_SSE_POLL_SECONDS` (default 10, was hardcoded 3) with the watch duration and pre-terminal window kept at the same wall-clock times, and crash-loop detection reuses the already-parsed Application JSON instead of re-fetching it — 2 ArgoCD calls per 10s per modal instead of 3 per 3s.

**5. Completion timing log.** On the transition into `DEPLOYED` (monitor: only after the status write actually matched a row; SSE: only on the transition, not every poll):

```
Deployment completed: project=X environment=int version=int-v3 deployTriggeredAt=... completedAt=...
  duration=462s (07:42) buildTriggeredAt=... buildDuration=230s (03:50)
```

Build timing comes from the matching `BuildAudit` for that version and is omitted when unavailable; durations are omitted rather than printed negative if timestamps are inconsistent.

**6. Refresh icon reconciles on demand.** The refresh icon on a Deploying/Building card used to be a pure DB re-read (`getById` deliberately excluded deployment status), so a finished deploy still waited for the 10s scheduler. `refreshTriggeredByUser=true` now reconciles that workspace's `int`/`prod` deployment against ArgoCD through the monitor's own `checkAndUpdateDeployment`, so there is no second classifier that could disagree with the scheduler. Guards: user-triggered only, in-progress statuses only, never user-cancelled or terminal rows, deployment history must exist, and a per-workspace/env cooldown (`DEPLOYMENT_ON_DEMAND_REFRESH_COOLDOWN_SECONDS`, default 5) makes click-spam cheap. Auto-poll stays a pure DB read with zero ArgoCD calls.