### PR TITLE
Release: fix(code-server): dedupe deployment monitoring and record real build/deploy completion times

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/assembler/WorkspaceAssembler.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/assembler/WorkspaceAssembler.java
@@ -290,6 +290,8 @@ import com.daimler.data.dto.workspace.DeploymentAuditVO;
 		 CodeServerDeploymentDetails deploymentDetails = new CodeServerDeploymentDetails();
 		 if (vo != null) {
 			 BeanUtils.copyProperties(vo, deploymentDetails);
+			 deploymentDetails.setNewPodCrashLooping(vo.isNewPodCrashLooping());
+			 deploymentDetails.setCrashLoopReason(vo.getCrashLoopReason());
 			 if(vo.isSecureWithIAMRequired()!=null)
 			 {
 				deploymentDetails.setSecureWithIAMRequired(vo.isSecureWithIAMRequired());
@@ -394,6 +396,8 @@ import com.daimler.data.dto.workspace.DeploymentAuditVO;
 		 SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS+00:00");
 		 if (deploymentDetails != null) {
 			 BeanUtils.copyProperties(deploymentDetails, deploymentDetailsVO);
+			 deploymentDetailsVO.setNewPodCrashLooping(deploymentDetails.getNewPodCrashLooping());
+			 deploymentDetailsVO.setCrashLoopReason(deploymentDetails.getCrashLoopReason());
 			 deploymentDetailsVO.setLastDeployedBy(toUserInfoVO(deploymentDetails.getLastDeployedBy()));
 			 if (Objects.isNull(deploymentDetails.getSecureWithIAMRequired())) {
 				 deploymentDetailsVO.setSecureWithIAMRequired(false);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/DeploymentStatusSseController.java
@@ -455,6 +455,7 @@ public class DeploymentStatusSseController {
             if (buildAudit != null && buildAudit.getTriggeredOn() != null) {
                 buildPart = " buildTriggeredAt=" + buildAudit.getTriggeredOn();
                 if (buildAudit.getBuildOn() != null && !buildAudit.getBuildOn().before(buildAudit.getTriggeredOn())) {
+                    buildPart += " buildCompletedAt=" + buildAudit.getBuildOn();
                     long buildSeconds = (buildAudit.getBuildOn().getTime() - buildAudit.getTriggeredOn().getTime()) / 1000L;
                     buildPart += String.format(" buildDuration=%ds (%02d:%02d)", buildSeconds,
                             buildSeconds / 60, buildSeconds % 60);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/json/CodeServerDeploymentDetails.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/json/CodeServerDeploymentDetails.java
@@ -38,5 +38,7 @@ public class CodeServerDeploymentDetails implements Serializable {
 	private List<String> selectedAliceRoles;
 	private List<DeploymentAudit> deploymentAuditLogs;
 	private String lastDeploymentError;
+	private Boolean newPodCrashLooping;
+	private String crashLoopReason;
 	
 }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepository.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepository.java
@@ -71,6 +71,9 @@ public interface WorkspaceCustomRepository extends CommonDataRepository<CodeServ
 	GenericMessage updateCancelledDeploymentStatus(String projectName, String environment,
 			String lastDeploymentStatus, String lastDeploymentError, Date lastDeployedOn);
 
+	GenericMessage updateDeploymentCrashLoopStatus(String projectName, String environment,
+			Boolean newPodCrashLooping, String crashLoopReason);
+
 	GenericMessage updateDeployedAppConfig(String projectName, String environment, boolean secureWithIAMRequired,
 			String oneApiVersionShortName, boolean isSecuredWithCookie, String deploymentType, String clientID,
 			String redirectUri, String ignorePaths, String scope, String ssoType, boolean secureWithDnaRequired,

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepositoryImpl.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepositoryImpl.java
@@ -559,6 +559,22 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 		fields.lastBuildOrDeployedStatus = lastDeploymentStatus;
 		fields.lastBuildOrDeployedEnv = environment;
 		fields.lastBuildOrDeployedOn = lastDeployedOn;
+		fields.crashLoopUpdate = CrashLoopUpdate.CLEAR;
+		return updateDeploymentStatusFields(projectName, environment, fields);
+	}
+
+	@Transactional
+	@Override
+	public GenericMessage updateDeploymentCrashLoopStatus(String projectName, String environment,
+			Boolean newPodCrashLooping, String crashLoopReason) {
+		DeploymentStatusFields fields = new DeploymentStatusFields();
+		if (Boolean.TRUE.equals(newPodCrashLooping)) {
+			fields.crashLooping = true;
+			fields.crashLoopReason = crashLoopReason;
+			fields.crashLoopUpdate = CrashLoopUpdate.SET;
+		} else {
+			fields.crashLoopUpdate = CrashLoopUpdate.CLEAR;
+		}
 		return updateDeploymentStatusFields(projectName, environment, fields);
 	}
 
@@ -590,6 +606,27 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 			} else if (fields.errorUpdate == ErrorUpdate.CLEAR) {
 				updateExpression = jsonbSet(updateExpression,
 						"{projectDetails," + environmentJsonbName + ",lastDeploymentError}",
+						"CAST('null' AS jsonb)");
+			}
+			if (fields.crashLoopUpdate == CrashLoopUpdate.SET) {
+				updateExpression = jsonbSet(updateExpression,
+						"{projectDetails," + environmentJsonbName + ",newPodCrashLooping}",
+						"to_jsonb(CAST(:newPodCrashLooping AS boolean))");
+				if (fields.crashLoopReason != null) {
+					updateExpression = jsonbSet(updateExpression,
+							"{projectDetails," + environmentJsonbName + ",crashLoopReason}",
+							"to_jsonb(CAST(:crashLoopReason AS text))");
+				} else {
+					updateExpression = jsonbSet(updateExpression,
+							"{projectDetails," + environmentJsonbName + ",crashLoopReason}",
+							"CAST('null' AS jsonb)");
+				}
+			} else if (fields.crashLoopUpdate == CrashLoopUpdate.CLEAR) {
+				updateExpression = jsonbSet(updateExpression,
+						"{projectDetails," + environmentJsonbName + ",newPodCrashLooping}",
+						"to_jsonb(false)");
+				updateExpression = jsonbSet(updateExpression,
+						"{projectDetails," + environmentJsonbName + ",crashLoopReason}",
 						"CAST('null' AS jsonb)");
 			}
 			if (fields.lastDeployedVersion != null) {
@@ -644,6 +681,12 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 			if (fields.errorUpdate == ErrorUpdate.SET) {
 				query.setParameter("lastDeploymentError", fields.lastDeploymentError);
 			}
+			if (fields.crashLoopUpdate == CrashLoopUpdate.SET) {
+				query.setParameter("newPodCrashLooping", fields.crashLooping);
+				if (fields.crashLoopReason != null) {
+					query.setParameter("crashLoopReason", fields.crashLoopReason);
+				}
+			}
 			if (fields.lastDeployedVersion != null) {
 				query.setParameter("lastDeployedVersion", fields.lastDeployedVersion);
 			}
@@ -695,10 +738,17 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 		NONE, SET, CLEAR
 	}
 
+	private enum CrashLoopUpdate {
+		NONE, SET, CLEAR
+	}
+
 	private static class DeploymentStatusFields {
 		private String lastDeploymentStatus;
 		private String lastDeploymentError;
 		private ErrorUpdate errorUpdate = ErrorUpdate.NONE;
+		private Boolean crashLooping;
+		private String crashLoopReason;
+		private CrashLoopUpdate crashLoopUpdate = CrashLoopUpdate.NONE;
 		private String lastDeployedVersion;
 		private String lastDeployedBranch;
 		private Date lastDeployedOn;
@@ -715,6 +765,7 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 			fields.lastDeploymentError = deploymentDetails.getLastDeploymentError();
 			fields.errorUpdate = deploymentDetails.getLastDeploymentError() == null
 					? ErrorUpdate.CLEAR : ErrorUpdate.SET;
+			fields.crashLoopUpdate = CrashLoopUpdate.CLEAR;
 			fields.lastDeployedVersion = deploymentDetails.getLastDeployedVersion();
 			fields.lastDeployedBranch = deploymentDetails.getLastDeployedBranch();
 			fields.lastDeployedOn = deploymentDetails.getLastDeployedOn();

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/dto/GitHubWorkflowJobsResponseDto.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/dto/GitHubWorkflowJobsResponseDto.java
@@ -29,5 +29,7 @@ public class GitHubWorkflowJobsResponseDto implements Serializable {
         private String name;
         private String status;
         private String conclusion;
+        @JsonProperty("completed_at")
+        private String completedAt;
     }
 }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -924,22 +924,38 @@ public class ArgoCdService {
             String healthStatus = rootNode.path("status").path("health").path("status").asText("");
             String lastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
 
-            String failureMessage = getConfirmedDeploymentFailure(token, rootNode, appName, deployTriggerTime);
+            Map<String, Object> crashLoopStatus = null;
+            String failureMessage;
+            boolean operationFailed = "Failed".equalsIgnoreCase(lastSyncPhase)
+                    || "Error".equalsIgnoreCase(lastSyncPhase);
+            if ("Degraded".equalsIgnoreCase(healthStatus) && !operationFailed) {
+                crashLoopStatus = getNewPodCrashLoopStatus(token, appName, rootNode);
+                failureMessage = getConfirmedDeploymentFailure(
+                        token, rootNode, appName, deployTriggerTime, crashLoopStatus);
+            } else {
+                failureMessage = getConfirmedDeploymentFailure(token, rootNode, appName, deployTriggerTime);
+            }
             if (failureMessage != null) {
                 result.put("status", "DEPLOYMENT_FAILED");
                 result.put("errorMessage", failureMessage);
                 return result;
             }
             if ("Degraded".equalsIgnoreCase(healthStatus)) {
+                if (crashLoopStatus == null) {
+                    crashLoopStatus = getNewPodCrashLoopStatus(token, appName, rootNode);
+                }
+                addCrashLoopEvidence(result, crashLoopStatus);
                 result.put("status", "DEPLOYING");
                 return result;
             }
             if ("Running".equalsIgnoreCase(lastSyncPhase)) {
+                addCrashLoopEvidence(result, getNewPodCrashLoopStatus(token, appName, rootNode));
                 return result; 
             }
  
             String syncStatus = rootNode.path("status").path("sync").path("status").asText("");
             if ("OutOfSync".equalsIgnoreCase(syncStatus)) {
+                addCrashLoopEvidence(result, getNewPodCrashLoopStatus(token, appName, rootNode));
                 return result; 
             }
             if ("Healthy".equalsIgnoreCase(healthStatus)) {
@@ -950,6 +966,7 @@ public class ArgoCdService {
                 result.put("status", "DEPLOYED");
                 return result;
             }
+            addCrashLoopEvidence(result, getNewPodCrashLoopStatus(token, appName, rootNode));
             return result;
         } catch (Exception e) {
             log.error("Failed to check ArgoCD deployment status for {}", appName, e);
@@ -964,6 +981,11 @@ public class ArgoCdService {
      */
     public String getConfirmedDeploymentFailure(String token, JsonNode rootNode, String appName,
             Date deployTriggerTime) {
+        return getConfirmedDeploymentFailure(token, rootNode, appName, deployTriggerTime, null);
+    }
+
+    private String getConfirmedDeploymentFailure(String token, JsonNode rootNode, String appName,
+            Date deployTriggerTime, Map<String, Object> computedCrashLoopStatus) {
         JsonNode operationState = rootNode.path("status").path("operationState");
         String healthStatus = rootNode.path("status").path("health").path("status").asText("");
         String phase = operationState.path("phase").asText("");
@@ -1002,7 +1024,9 @@ public class ArgoCdService {
                     log.warn("Degraded ArgoCD deployment {} lacks a desired image tag; failure is not proven", appName);
                     return null;
                 }
-                Map<String, Object> crashLoopStatus = getNewPodCrashLoopStatus(token, appName, rootNode);
+                Map<String, Object> crashLoopStatus = computedCrashLoopStatus != null
+                        ? computedCrashLoopStatus
+                        : getNewPodCrashLoopStatus(token, appName, rootNode);
                 if (!Boolean.TRUE.equals(crashLoopStatus.get("newPodCrashLooping"))
                         || Boolean.TRUE.equals(crashLoopStatus.get("fallbackSelected"))
                         || !Boolean.TRUE.equals(crashLoopStatus.get("strongCrashReason"))) {
@@ -1021,6 +1045,16 @@ public class ArgoCdService {
             }
         }
         return null;
+    }
+
+    private void addCrashLoopEvidence(Map<String, String> result, Map<String, Object> crashLoopStatus) {
+        if (crashLoopStatus == null) {
+            return;
+        }
+        result.put("newPodCrashLooping",
+                String.valueOf(Boolean.TRUE.equals(crashLoopStatus.get("newPodCrashLooping"))));
+        Object reason = crashLoopStatus.get("crashLoopReason");
+        result.put("crashLoopReason", reason == null ? "" : String.valueOf(reason));
     }
 
     private boolean isWithinDeploymentGracePeriod(Date deployTriggerTime) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -960,6 +960,8 @@ public class ArgoCdService {
             }
             if ("Healthy".equalsIgnoreCase(healthStatus)) {
                 if (!isDeploymentReady(rootNode, appName, expectedVersion, deployTriggerTime)) {
+                    result.put("newPodCrashLooping", "false");
+                    result.put("crashLoopReason", "");
                     result.put("status", "DEPLOYING");
                     return result;
                 }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -596,7 +596,7 @@ public class DeploymentStatusMonitorJob {
                     } else if (wasCrashLooping && !argoCrashLooping) {
                         log.info("Crash-loop cleared for project={} environment={}", projectName, environment);
                     }
-                    return true;
+                    return false;
                 }
             }
         } catch (Exception e) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -25,7 +25,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -71,81 +73,122 @@ public class DeploymentStatusMonitorJob {
             }
 
             List<CodeServerWorkspaceNsql> workspaces = workspaceCustomRepository.findDeploymentReconciliationWorkspaces();
-            int checkedCount = 0;
-            int updatedCount = 0;
-
+            Map<String, List<CodeServerWorkspaceNsql>> workspacesByProject = new LinkedHashMap<>();
             for (CodeServerWorkspaceNsql workspace : workspaces) {
                 if (workspace.getData() == null || workspace.getData().getProjectDetails() == null) {
                     continue;
                 }
-
                 String projectName = workspace.getData().getProjectDetails().getProjectName();
                 if (projectName == null) {
                     continue;
                 }
-
-                // Recovery: if top-level lastBuildOrDeployedStatus is RESTART_REQUESTED but
-                // per-environment lastDeploymentStatus was never updated, force-check it.
-                String topLevelStatus = workspace.getData().getProjectDetails().getLastBuildOrDeployedStatus();
-                String topLevelEnv = workspace.getData().getProjectDetails().getLastBuildOrDeployedEnv();
-
-                CodeServerDeploymentDetails intDeployment = workspace.getData().getProjectDetails().getIntDeploymentDetails();
-                repairMissingFailureFields(workspace, intDeployment, projectName, "int");
-                boolean intNeedsCheck = intDeployment != null && shouldCheckDeployment(intDeployment)
-                        && !isUserCancelled(intDeployment);
-                // Recovery for stuck restarts: top-level says RESTART_REQUESTED for this env but per-env field was never updated
-                if (!intNeedsCheck && intDeployment != null 
-                        && "RESTART_REQUESTED".equalsIgnoreCase(topLevelStatus) 
-                        && "int".equalsIgnoreCase(topLevelEnv)) {
-                    log.info("Recovery: workspace {} has top-level RESTART_REQUESTED for int but per-env status is {}",
-                            projectName, intDeployment.getLastDeploymentStatus());
-                    intDeployment.setLastDeploymentStatus("RESTART_REQUESTED");
-                    intNeedsCheck = true;
-                }
-                if (intNeedsCheck && !hasDeploymentHistory(projectName, "int")) {
-                    log.info("Clearing stale status for {}-int: no deployment audit logs exist", projectName);
-                    intDeployment.setLastDeploymentStatus(null);
-                    workspaceCustomRepository.updateDeploymentDetails(projectName, "int", intDeployment, null);
-                    intNeedsCheck = false;
-                }
-                if (intNeedsCheck) {
-                    checkedCount++;
-                    if (checkAndUpdateDeployment(argoToken, workspace, intDeployment, projectName, "int")) {
-                        updatedCount++;
-                    }
-                }
-                CodeServerDeploymentDetails prodDeployment = workspace.getData().getProjectDetails().getProdDeploymentDetails();
-                repairMissingFailureFields(workspace, prodDeployment, projectName, "prod");
-                boolean prodNeedsCheck = prodDeployment != null && shouldCheckDeployment(prodDeployment)
-                        && !isUserCancelled(prodDeployment);
-                if (!prodNeedsCheck && prodDeployment != null 
-                        && "RESTART_REQUESTED".equalsIgnoreCase(topLevelStatus) 
-                        && "prod".equalsIgnoreCase(topLevelEnv)) {
-                    log.info("Recovery: workspace {} has top-level RESTART_REQUESTED for prod but per-env status is {}",
-                            projectName, prodDeployment.getLastDeploymentStatus());
-                    prodDeployment.setLastDeploymentStatus("RESTART_REQUESTED");
-                    prodNeedsCheck = true;
-                }
-                if (prodNeedsCheck && !hasDeploymentHistory(projectName, "prod")) {
-                    log.info("Clearing stale status for {}-prod: no deployment audit logs exist", projectName);
-                    prodDeployment.setLastDeploymentStatus(null);
-                    workspaceCustomRepository.updateDeploymentDetails(projectName, "prod", prodDeployment, null);
-                    prodNeedsCheck = false;
-                }
-                if (prodNeedsCheck) {
-                    checkedCount++;
-                    if (checkAndUpdateDeployment(argoToken, workspace, prodDeployment, projectName, "prod")) {
-                        updatedCount++;
-                    }
-                }
+                workspacesByProject.computeIfAbsent(projectName.toLowerCase(Locale.ROOT),
+                        key -> new ArrayList<>()).add(workspace);
             }
 
-            if (checkedCount > 0) {
-                log.info("Deployment status monitoring completed - Checked: {}, Updated: {}", checkedCount, updatedCount);
+            MonitorCounts counts = new MonitorCounts();
+            for (List<CodeServerWorkspaceNsql> projectWorkspaces : workspacesByProject.values()) {
+                reconcileProjectEnvironment(argoToken, projectWorkspaces, "int", counts);
+                reconcileProjectEnvironment(argoToken, projectWorkspaces, "prod", counts);
+            }
+
+            if (counts.checkedCount > 0) {
+                log.info("Deployment status monitoring completed - Checked: {}, Updated: {}",
+                        counts.checkedCount, counts.updatedCount);
             }
         } catch (Exception e) {
             log.error("Error in deployment status monitoring job", e);
         }
+    }
+
+    private void reconcileProjectEnvironment(String argoToken, List<CodeServerWorkspaceNsql> projectWorkspaces,
+            String environment, MonitorCounts counts) {
+        List<CodeServerWorkspaceNsql> checkCandidates = new ArrayList<>();
+        List<CodeServerWorkspaceNsql> repairCandidates = new ArrayList<>();
+
+        for (CodeServerWorkspaceNsql workspace : projectWorkspaces) {
+            String projectName = workspace.getData().getProjectDetails().getProjectName();
+            CodeServerDeploymentDetails deployment = "int".equalsIgnoreCase(environment)
+                    ? workspace.getData().getProjectDetails().getIntDeploymentDetails()
+                    : workspace.getData().getProjectDetails().getProdDeploymentDetails();
+            if (needsFailureFieldRepair(deployment)) {
+                repairCandidates.add(workspace);
+            }
+
+            boolean needsCheck = deployment != null && shouldCheckDeployment(deployment)
+                    && !isUserCancelled(deployment);
+            String topLevelStatus = workspace.getData().getProjectDetails().getLastBuildOrDeployedStatus();
+            String topLevelEnv = workspace.getData().getProjectDetails().getLastBuildOrDeployedEnv();
+            if (!needsCheck && deployment != null
+                    && "RESTART_REQUESTED".equalsIgnoreCase(topLevelStatus)
+                    && environment.equalsIgnoreCase(topLevelEnv)
+                    && !isUserCancelled(deployment)) {
+                needsCheck = true;
+            }
+            if (needsCheck) {
+                checkCandidates.add(workspace);
+            }
+        }
+
+        if (!checkCandidates.isEmpty()) {
+            CodeServerWorkspaceNsql representative = chooseRepresentative(checkCandidates);
+            String projectName = representative.getData().getProjectDetails().getProjectName();
+            CodeServerDeploymentDetails deployment = "int".equalsIgnoreCase(environment)
+                    ? representative.getData().getProjectDetails().getIntDeploymentDetails()
+                    : representative.getData().getProjectDetails().getProdDeploymentDetails();
+            String topLevelStatus = representative.getData().getProjectDetails().getLastBuildOrDeployedStatus();
+            String topLevelEnv = representative.getData().getProjectDetails().getLastBuildOrDeployedEnv();
+            if (!shouldCheckDeployment(deployment)
+                    && "RESTART_REQUESTED".equalsIgnoreCase(topLevelStatus)
+                    && environment.equalsIgnoreCase(topLevelEnv)) {
+                log.info("Recovery: workspace {} has top-level RESTART_REQUESTED for {} but per-env status is {}",
+                        projectName, environment, deployment.getLastDeploymentStatus());
+                deployment.setLastDeploymentStatus("RESTART_REQUESTED");
+            }
+            if (!hasDeploymentHistory(projectName, environment)) {
+                log.info("Clearing stale status for {}-{}: no deployment audit logs exist",
+                        projectName, environment);
+                deployment.setLastDeploymentStatus(null);
+                workspaceCustomRepository.updateDeploymentDetails(projectName, environment, deployment, null);
+                return;
+            }
+            counts.checkedCount++;
+            if (checkAndUpdateDeployment(argoToken, representative, deployment, projectName, environment)) {
+                counts.updatedCount++;
+            }
+        } else if (!repairCandidates.isEmpty()) {
+            CodeServerWorkspaceNsql representative = chooseRepresentative(repairCandidates);
+            String projectName = representative.getData().getProjectDetails().getProjectName();
+            CodeServerDeploymentDetails deployment = "int".equalsIgnoreCase(environment)
+                    ? representative.getData().getProjectDetails().getIntDeploymentDetails()
+                    : representative.getData().getProjectDetails().getProdDeploymentDetails();
+            repairMissingFailureFields(representative, deployment, projectName, environment);
+        }
+    }
+
+    private boolean needsFailureFieldRepair(CodeServerDeploymentDetails deployment) {
+        return deployment != null
+                && "DEPLOYMENT_FAILED".equalsIgnoreCase(deployment.getLastDeploymentStatus())
+                && !isUserCancelled(deployment)
+                && (deployment.getLastDeployedBy() == null || deployment.getLastDeployedOn() == null);
+    }
+
+    private CodeServerWorkspaceNsql chooseRepresentative(List<CodeServerWorkspaceNsql> candidates) {
+        for (CodeServerWorkspaceNsql candidate : candidates) {
+            UserInfo workspaceOwner = candidate.getData().getWorkspaceOwner();
+            UserInfo projectOwner = candidate.getData().getProjectDetails().getProjectOwner();
+            if (workspaceOwner != null && projectOwner != null
+                    && workspaceOwner.getId() != null && projectOwner.getId() != null
+                    && workspaceOwner.getId().equalsIgnoreCase(projectOwner.getId())) {
+                return candidate;
+            }
+        }
+        return candidates.get(0);
+    }
+
+    private static class MonitorCounts {
+        private int checkedCount;
+        private int updatedCount;
     }
 
     public boolean reconcileDeploymentOnDemand(CodeServerWorkspaceNsql workspace, String environment) {
@@ -543,6 +586,7 @@ public class DeploymentStatusMonitorJob {
         if (buildAudit != null && buildAudit.getTriggeredOn() != null) {
             buildPart = " buildTriggeredAt=" + buildAudit.getTriggeredOn();
             if (buildAudit.getBuildOn() != null && !buildAudit.getBuildOn().before(buildAudit.getTriggeredOn())) {
+                buildPart += " buildCompletedAt=" + buildAudit.getBuildOn();
                 long buildSeconds = (buildAudit.getBuildOn().getTime() - buildAudit.getTriggeredOn().getTime()) / 1000L;
                 buildPart += String.format(" buildDuration=%ds (%02d:%02d)", buildSeconds,
                         buildSeconds / 60, buildSeconds % 60);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -148,7 +149,10 @@ public class DeploymentStatusMonitorJob {
                 log.info("Clearing stale status for {}-{}: no deployment audit logs exist",
                         projectName, environment);
                 deployment.setLastDeploymentStatus(null);
+                deployment.setNewPodCrashLooping(false);
+                deployment.setCrashLoopReason(null);
                 workspaceCustomRepository.updateDeploymentDetails(projectName, environment, deployment, null);
+                workspaceCustomRepository.updateDeploymentCrashLoopStatus(projectName, environment, false, null);
                 return;
             }
             counts.checkedCount++;
@@ -161,6 +165,8 @@ public class DeploymentStatusMonitorJob {
             CodeServerDeploymentDetails deployment = "int".equalsIgnoreCase(environment)
                     ? representative.getData().getProjectDetails().getIntDeploymentDetails()
                     : representative.getData().getProjectDetails().getProdDeploymentDetails();
+            deployment.setNewPodCrashLooping(false);
+            deployment.setCrashLoopReason(null);
             repairMissingFailureFields(representative, deployment, projectName, environment);
         }
     }
@@ -421,6 +427,9 @@ public class DeploymentStatusMonitorJob {
             }
             String argoStatus = argoResult.get("status");
             String argoErrorMessage = argoResult.get("errorMessage");
+            boolean hasCrashLoopEvidence = argoResult.containsKey("newPodCrashLooping");
+            boolean argoCrashLooping = Boolean.parseBoolean(argoResult.get("newPodCrashLooping"));
+            String argoCrashLoopReason = argoResult.get("crashLoopReason");
 
             
             boolean needsUpdate = false;
@@ -453,6 +462,8 @@ public class DeploymentStatusMonitorJob {
                 log.info("Reconciling deployment status for {} from {} to {}", appName, currentDbStatus, targetStatus);
                 
                 deployment.setLastDeploymentStatus(targetStatus);
+                deployment.setNewPodCrashLooping(false);
+                deployment.setCrashLoopReason(null);
                 if ("DEPLOYMENT_FAILED".equals(targetStatus) || "RESTART_FAILED".equals(targetStatus)) {
                     deployment.setLastDeploymentError(argoErrorMessage);
                 } else {
@@ -564,6 +575,29 @@ public class DeploymentStatusMonitorJob {
                 sendDeploymentNotification(workspace, deployment, projectName, environment, targetStatus);
                 
                 return true;
+            }
+            boolean inProgress = "DEPLOY_REQUESTED".equalsIgnoreCase(currentDbStatus)
+                    || "DEPLOYING".equalsIgnoreCase(currentDbStatus)
+                    || "RESTART_REQUESTED".equalsIgnoreCase(currentDbStatus);
+            boolean crashLoopChanged = !Objects.equals(
+                    Boolean.TRUE.equals(deployment.getNewPodCrashLooping()), argoCrashLooping)
+                    || !Objects.equals(deployment.getCrashLoopReason(),
+                            argoCrashLooping ? argoCrashLoopReason : null);
+            if (inProgress && hasCrashLoopEvidence && crashLoopChanged) {
+                GenericMessage crashLoopUpdate = workspaceCustomRepository.updateDeploymentCrashLoopStatus(
+                        projectName, environment, argoCrashLooping, argoCrashLoopReason);
+                if (crashLoopUpdate != null && "SUCCESS".equalsIgnoreCase(crashLoopUpdate.getSuccess())) {
+                    boolean wasCrashLooping = Boolean.TRUE.equals(deployment.getNewPodCrashLooping());
+                    deployment.setNewPodCrashLooping(argoCrashLooping);
+                    deployment.setCrashLoopReason(argoCrashLooping ? argoCrashLoopReason : null);
+                    if (!wasCrashLooping && argoCrashLooping) {
+                        log.info("Crash-loop detected for project={} environment={} reason={}",
+                                projectName, environment, argoCrashLoopReason);
+                    } else if (wasCrashLooping && !argoCrashLooping) {
+                        log.info("Crash-loop cleared for project={} environment={}", projectName, environment);
+                    }
+                    return true;
+                }
             }
         } catch (Exception e) {
             log.warn("Failed to check ArgoCD status for {}-{}: {}", projectName, environment, e.getMessage());

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -107,7 +107,6 @@ public class DeploymentStatusMonitorJob {
         List<CodeServerWorkspaceNsql> repairCandidates = new ArrayList<>();
 
         for (CodeServerWorkspaceNsql workspace : projectWorkspaces) {
-            String projectName = workspace.getData().getProjectDetails().getProjectName();
             CodeServerDeploymentDetails deployment = "int".equalsIgnoreCase(environment)
                     ? workspace.getData().getProjectDetails().getIntDeploymentDetails()
                     : workspace.getData().getProjectDetails().getProdDeploymentDetails();

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/workspace/BaseWorkspaceService.java
@@ -30,6 +30,8 @@
  import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
  import java.util.Arrays;
  import java.util.Date;
@@ -1720,6 +1722,7 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 										SimpleDateFormat isoFormat = new SimpleDateFormat(
 												"yyyy-MM-dd'T'HH:mm:ss.SSS+00:00");
 										Date now = isoFormat.parse(isoFormat.format(new Date()));
+										Date completionTime = resolveWorkflowCompletionTime(buildDeployJob, now);
 
 										CodeServerBuildDetails resolvedBuildDetails = "int"
 												.equalsIgnoreCase(environment)
@@ -1733,14 +1736,14 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 
 										// Update workspace entity status
 										entity.getData().getProjectDetails().setLastBuildOrDeployedStatus(finalStatus);
-										entity.getData().getProjectDetails().setLastBuildOrDeployedOn(now);
+										entity.getData().getProjectDetails().setLastBuildOrDeployedOn(completionTime);
 
 										Boolean keepBuildImage = false;
 
 										if ("BUILD_SUCCESS".equalsIgnoreCase(finalStatus)
 												|| "BUILD_FAILED".equalsIgnoreCase(finalStatus)) {
 											resolvedBuildDetails.setLastBuildStatus(finalStatus);
-											resolvedBuildDetails.setLastBuildOn(now);
+											resolvedBuildDetails.setLastBuildOn(completionTime);
 											resolvedBuildDetails.setLastBuildBy(entity.getData().getWorkspaceOwner());
 											resolvedBuildDetails.setGitjobRunID(gitJobRunId);
 											resolvedBuildDetails.setLastBuildFailureReason(null);   // clear stale BUILD_TIMEOUT on a real GitHub result
@@ -1751,7 +1754,7 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 											deploymentDetails.setLastDeploymentStatus(finalStatus);
 											deploymentDetails.setGitjobRunID(gitJobRunId);
 											if ("DEPLOYED".equalsIgnoreCase(finalStatus)) {
-												deploymentDetails.setLastDeployedOn(now);
+												deploymentDetails.setLastDeployedOn(completionTime);
 												deploymentDetails
 														.setLastDeployedBy(entity.getData().getWorkspaceOwner());
 											}
@@ -1772,7 +1775,7 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 												BuildAudit auditEntry = findAuditByVersion(envLogs,
 														resolvedBuildDetails.getVersion());
 												if (auditEntry != null) {
-													auditEntry.setBuildOn(now);
+													auditEntry.setBuildOn(completionTime);
 													auditEntry.setBuildStatus(finalStatus);
 													auditEntry.setFailureReason(null);
 													keepBuildImage = auditEntry.isKeepBuildImage();
@@ -1788,7 +1791,7 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 															.setDeploymentStatus(finalStatus);
 													if ("DEPLOYED".equalsIgnoreCase(finalStatus)) {
 														buildDeployData.getIntDeploymentAuditLogs().get(lastIndex)
-																.setDeployedOn(now);
+																.setDeployedOn(completionTime);
 													}
 												} else if (buildDeployData.getProdDeploymentAuditLogs() != null
 														&& !buildDeployData.getProdDeploymentAuditLogs().isEmpty()) {
@@ -1798,7 +1801,7 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 															.setDeploymentStatus(finalStatus);
 													if ("DEPLOYED".equalsIgnoreCase(finalStatus)) {
 														buildDeployData.getProdDeploymentAuditLogs().get(lastIndex)
-																.setDeployedOn(now);
+																.setDeployedOn(completionTime);
 													}
 												}
 											}
@@ -6198,6 +6201,28 @@ import com.daimler.data.dto.workspace.InitializeWorkspaceResponseVO;
 			"DEPLOY_REQUESTED",
 			"BUILD_REQUESTED"
 		).contains(status != null ? status.toUpperCase() : "");
+	}
+
+	private Date resolveWorkflowCompletionTime(GitHubWorkflowJobsResponseDto.Job job, Date now) {
+		String completedAt = job != null ? job.getCompletedAt() : null;
+		if (completedAt == null || completedAt.isBlank()) {
+			log.debug("GitHub workflow completion timestamp is missing; using refresh time");
+			return now;
+		}
+		try {
+			Date parsedCompletionTime = Date.from(
+					DateTimeFormatter.ISO_DATE_TIME.parse(completedAt, Instant::from));
+			if (parsedCompletionTime.after(now)) {
+				log.warn("GitHub workflow completion timestamp {} is in the future; using refresh time",
+						completedAt);
+				return now;
+			}
+			return parsedCompletionTime;
+		} catch (DateTimeParseException e) {
+			log.warn("Unable to parse GitHub workflow completion timestamp {}; using refresh time",
+					completedAt);
+			return now;
+		}
 	}
 
 	private String resolveFinalStatus(String requestedStatus, String conclusion) {

--- a/packages/code-server/code-server-lib/src/main/resources/api/Workspace.yaml
+++ b/packages/code-server/code-server-lib/src/main/resources/api/Workspace.yaml
@@ -2038,6 +2038,12 @@ definitions:
       lastDeploymentStatus:
         type: string
         description: Status of last deployement
+      newPodCrashLooping:
+        type: boolean
+        description: Whether the deployment's new pod is crash-looping
+      crashLoopReason:
+        type: string
+        description: Human-readable crash-loop reason
       gitjobRunID:
         type: string
         description: "git job run Id of project deployed"

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.19
+    version: 1.12.20
   profile:
     active: production
 

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.21
+    version: 1.12.22
   profile:
     active: production
 

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.20
+    version: 1.12.21
   profile:
     active: production
 

--- a/packages/code-space-mfe/package.json
+++ b/packages/code-space-mfe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-space-mfe",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "private": true,
   "scripts": {
     "start": "env-cmd -f .env webpack server --config config/webpack.config.js",

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -864,6 +864,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                             >
                               <i className="icon mbc-icon refresh"></i>
                             </span>
+                            <span
+                              className={classNames(Styles.syncErrorInfoIcon, Styles.deployLogsInfoIcon)}
+                              onClick={onDeployLogsInfoClick}
+                              tooltip-data="View live deployment logs"
+                            >
+                              <i className="icon mbc-icon info"></i>
+                            </span>
                           </span>
                         </span>
                       )}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -500,8 +500,11 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     setShowDeployLogsModal(false);
     setDeployLogText('');
     setDeployLogsHaveErrors(false);
-    setNewPodCrashLooping(false);
-    setCrashLoopReason('');
+    const deploymentDetails = env === 'int'
+      ? codeSpace?.projectDetails?.intDeploymentDetails
+      : codeSpace?.projectDetails?.prodDeploymentDetails;
+    setNewPodCrashLooping(!!deploymentDetails?.newPodCrashLooping);
+    setCrashLoopReason(deploymentDetails?.crashLoopReason || '');
     setDeployingThresholdExceeded(false);
   };
 
@@ -604,6 +607,15 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
+  const deployingEnvironment = projectDetails?.lastBuildOrDeployedEnv;
+  const activeDeploymentDetails = deployingEnvironment === 'int'
+    ? intDeploymentDetails
+    : prodDeploymentDetails;
+  const persistedCrashLooping = !!activeDeploymentDetails?.newPodCrashLooping;
+  const persistedCrashLoopReason = activeDeploymentDetails?.crashLoopReason || '';
+  const deploymentWorkflowUrl = activeDeploymentDetails?.gitjobRunID
+    ? buildGitJobLogViewAWSURL(activeDeploymentDetails.gitjobRunID)
+    : null;
   const deployingInProgress =
     intDeploymentDetails?.lastDeploymentStatus === 'DEPLOY_REQUESTED' ||
     intDeploymentDetails?.lastDeploymentStatus === 'DEPLOYING' ||
@@ -824,21 +836,25 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                       )}
                       {(projectDetails?.lastBuildOrDeployedStatus === 'DEPLOY_REQUESTED' || 
                         projectDetails?.lastBuildOrDeployedStatus === 'DEPLOYING') && (
-                        <a
-                          href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
-                            ? buildGitJobLogViewAWSURL(projectDetails?.intDeploymentDetails?.gitjobRunID)
-                            : buildGitJobLogViewAWSURL(projectDetails?.prodDeploymentDetails?.gitjobRunID)
-                          }
-                          target="_blank"
-                          rel="noreferrer"
+                        <span
                           className={Styles.deployingLink}
                           tooltip-data={
-                            projectDetails?.lastBuildOrDeployedEnv === 'int'
-                              ? 'Deploying to Staging'
-                              : 'Deploying to Production'
+                            persistedCrashLooping && persistedCrashLoopReason
+                              ? persistedCrashLoopReason
+                              : projectDetails?.lastBuildOrDeployedEnv === 'int'
+                                ? 'Deploying to Staging'
+                                : 'Deploying to Production'
                           }
                         >
-                          <span className={classNames(Styles.statusIndicator, Styles.deploying, Styles.statusWithRefresh)}>
+                          <span
+                            className={classNames(
+                              Styles.statusIndicator,
+                              Styles.deploying,
+                              Styles.statusWithRefresh,
+                              persistedCrashLooping ? Styles.deployCrashLooping : ''
+                            )}
+                            onClick={onDeployLogsInfoClick}
+                          >
                             Deploying...
                             <span 
                               className={Styles.refreshIcon} 
@@ -847,15 +863,8 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                             >
                               <i className="icon mbc-icon refresh"></i>
                             </span>
-                            <span
-                              className={classNames(Styles.syncErrorInfoIcon, Styles.deployLogsInfoIcon)}
-                              onClick={onDeployLogsInfoClick}
-                              tooltip-data="View live deployment logs"
-                            >
-                              <i className="icon mbc-icon info"></i>
-                            </span>
                           </span>
-                        </a>
+                        </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'BUILD_FAILED' && (
                         <span className={classNames(Styles.statusIndicator, Styles.deployFailed)}>
@@ -1227,6 +1236,16 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
           title={
             <div className={Styles.modalHeader}>
               <span>Deployment Logs</span>
+              {deploymentWorkflowUrl && (
+                <a
+                  href={deploymentWorkflowUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={Styles.workflowLogsLink}
+                >
+                  View workflow logs
+                </a>
+              )}
               <i
                 className={classNames('icon mbc-icon copy', Styles.copyLogsIcon, deployLogsCopied ? Styles.copyLogsIconCopied : '')}
                 tooltip-data={deployLogsCopied ? 'Copied!' : 'Copy logs'}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -500,11 +500,8 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     setShowDeployLogsModal(false);
     setDeployLogText('');
     setDeployLogsHaveErrors(false);
-    const deploymentDetails = env === 'int'
-      ? codeSpace?.projectDetails?.intDeploymentDetails
-      : codeSpace?.projectDetails?.prodDeploymentDetails;
-    setNewPodCrashLooping(!!deploymentDetails?.newPodCrashLooping);
-    setCrashLoopReason(deploymentDetails?.crashLoopReason || '');
+    setNewPodCrashLooping(false);
+    setCrashLoopReason('');
     setDeployingThresholdExceeded(false);
   };
 
@@ -522,8 +519,11 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     stopDeployLogsStreams();
     setDeployLogText('');
     setDeployLogsHaveErrors(false);
-    setNewPodCrashLooping(false);
-    setCrashLoopReason('');
+    const deploymentDetails = env === 'int'
+      ? codeSpace?.projectDetails?.intDeploymentDetails
+      : codeSpace?.projectDetails?.prodDeploymentDetails;
+    setNewPodCrashLooping(!!deploymentDetails?.newPodCrashLooping);
+    setCrashLoopReason(deploymentDetails?.crashLoopReason || '');
     setDeployingThresholdExceeded(false);
     setShowDeployLogsModal(true);
 
@@ -851,6 +851,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                               Styles.statusIndicator,
                               Styles.deploying,
                               Styles.statusWithRefresh,
+                              Styles.deployStatusClickable,
                               persistedCrashLooping ? Styles.deployCrashLooping : ''
                             )}
                             onClick={onDeployLogsInfoClick}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -182,6 +182,10 @@
         color: #f3e537;
       }
 
+      &.deployCrashLooping {
+        animation: deployCrashLoopIndicator 1.2s ease-in-out infinite;
+      }
+
       &.deployFailed {
         border: 1px solid #e84d47;
         color: #e84d47;
@@ -214,6 +218,25 @@
     .deployingLink{
       text-decoration: none;
       color: #f3e537;
+    }
+
+    @keyframes deployCrashLoopIndicator {
+      0%, 100% {
+        border-color: #e84d47;
+        color: #e84d47;
+      }
+      50% {
+        border-color: #f3e537;
+        color: #f3e537;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .statusIndicator.deployCrashLooping {
+        animation: none;
+        border-color: #e84d47;
+        color: #e84d47;
+      }
     }
   }
   .cardFooter {
@@ -469,10 +492,6 @@
     }
   }
 
-  .deployLogsInfoIcon {
-    color: inherit;
-  }
-
   .deployLogsModalContent {
     margin-top: 0;
     text-align: left;
@@ -613,6 +632,16 @@
 
     span {
       flex: 1;
+    }
+  }
+
+  .workflowLogsLink {
+    color: #00adef;
+    text-decoration: none;
+    white-space: nowrap;
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -186,6 +186,10 @@
         animation: deployCrashLoopIndicator 1.2s ease-in-out infinite;
       }
 
+      &.deployStatusClickable {
+        cursor: pointer;
+      }
+
       &.deployFailed {
         border: 1px solid #e84d47;
         color: #e84d47;

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -496,6 +496,10 @@
     }
   }
 
+  .deployLogsInfoIcon {
+    color: inherit;
+  }
+
   .deployLogsModalContent {
     margin-top: 0;
     text-align: left;


### PR DESCRIPTION
## Summary

Follow-up to #5258, from its production logs. `workspace_nsql` holds **one row per project member** (owner + each collaborator) and `projectDetails` — including `intDeploymentDetails`/`prodDeploymentDetails` — is replicated across those rows. `monitorDeploymentStatus()` iterated rows, but every action it takes is project-scoped (`... where lower(data->'projectDetails'->>'projectName') = lower(:projectName)`), so a project with N members did N× the work per pass:

```
for row in findDeploymentReconciliationWorkspaces():   # N rows, same project
    GET /api/v1/applications/{project}-{env}           # N ArgoCD calls
    updateReconciledDeploymentStatus(project, env)     # N project-wide writes
    updateBuildDeployAuditLog / cleanupNonRetainedBuildImages
    sendDeploymentNotification(row)                    # N Kafka notifications
    logDeploymentCompletion(..., new Date())           # N log lines, drifting completedAt
```

Observed in prod: the same deployment logged `Deployment completed:` 8 times ~0.3-1s apart with `duration` walking 02:12 → 02:15, because each row stamped its own `new Date()`. The duplicate notifications were user-visible; the duplicate GETs were ArgoCD load proportional to team size.

Now each `(project, environment)` pair is reconciled at most once per pass: rows are grouped by `projectName.toLowerCase(Locale.ROOT)`, and `reconcileProjectEnvironment` picks a single representative row.

The representative is chosen **after** eligibility is evaluated across all rows, not before:

```java
for (row : projectRows) {
    if (needsFailureFieldRepair(deployment))  repairCandidates.add(row);
    if (shouldCheckDeployment(deployment) && !isUserCancelled(deployment)
        || topLevelRestartRecoveryApplies(row))  checkCandidates.add(row);
}
representative = ownerRow(candidates) or candidates.get(0);   // workspaceOwner.id == projectOwner.id
```

Picking up front would be wrong: rows can disagree when an earlier write partially failed, and a representative already at `DEPLOYED` would leave a sibling stuck at `DEPLOY_REQUESTED` forever. The owner row is preferred so the notification's `resourceID` stays the owner workspace, as before. `sendDeploymentNotification` already fans out to owner + all collaborators from a single row, so no recipient is lost. The stale-status clear and the missing-failure-field repair are likewise once per project/env, and `checkedCount`/`updatedCount` now count project/env reconciliations rather than rows.

One deliberate behaviour change: the top-level `RESTART_REQUESTED` recovery path now also requires `!isUserCancelled(deployment)`. Previously it could force a user-cancelled row back into reconciliation, contradicting cancellation being terminal.

Classifier, schedule, status semantics, and the on-demand refresh path (single row by construction) are untouched.

**Completion log.** `BuildAudit.buildOn` is written when a `getById`/refresh path first *observes* a finished build, not when the build finished, so `buildDuration` can be inflated by however long nobody looked (prod showed `buildDuration=13298s (221:38)` for a normal build). The line now carries the raw timestamp so the number is interpretable:

```
... buildTriggeredAt=<triggeredOn> buildCompletedAt=<buildOn> buildDuration=230s (03:50)
```

Existing guards unchanged (omitted when null or inconsistent). How `buildOn` is set is left alone.

For the record, #5258's own goal is confirmed in production: deploy durations are now 34s / 64s / 135s / 371s with `mode=sync-only`, versus the ~30 minutes that motivated it.

## Build/deploy completion timestamps from GitHub, not from refresh time

Root cause of the `221:38` above. Two paths record completion: the GitHub Action's callback into `BaseWorkspaceService.update(...)` (accurate), and the `getById` fallback used when that callback never lands — a user refresh past the stale threshold queries `gitClient.getBuildDeployJob(runId)` and then stamped `now` for `lastBuildOn`, `BuildAudit.buildOn`, `lastDeployedOn`, the deployment audit's `deployedOn`, and `lastBuildOrDeployedOn`. `now` there is *when someone happened to refresh*, so a workflow that finished at 10:53 and was noticed at 14:31 was recorded as finishing at 14:31.

The Jobs API response already carries the real completion instant; `GitHubWorkflowJobsResponseDto.Job` just wasn't mapping it:

```java
@JsonProperty("completed_at") private String completedAt;

Date completionTime = resolveWorkflowCompletionTime(buildDeployJob, now);
// ISO-8601 → Date; falls back to `now` when missing, unparseable, or in the future
```

Only completion timestamps in that fallback block were switched to `completionTime`; requested/triggered timestamps, the `BUILD_TIMEOUT` path, and the primary callback path are unchanged.

---

## 3. Drop the redundant completion log from the SSE stream

Production showed a second, wrong completion line whenever the log modal was open:

```
DeploymentStatusSseController - Deployment completed: project=FFCLERS-WBV-GENERIC-BE environment=prod
  version=prod-v436 deployTriggeredAt=Fri Aug 28 07:51:41 completedAt=Thu Aug 27 13:47:26 ...
```

`version` and `completedAt` there came from `deploymentDetails.getLastDeployedVersion()` / `getLastDeployedOn()` — the *previous* deploy's values, because the SSE controller is read-only and the row is only updated by the monitor. So it reported the prior version with a completion instant before the trigger (hence no `duration`), while the monitor logged the same deploy correctly as `prod-v437`.

The SSE completion log (and its now-unused `findBuildAudit` helper) is removed; `DeploymentStatusMonitorJob` stays the single source of completion logging. The `Deployment finished with status: ...` line, the emitted SSE payloads, and status classification are unchanged.
