### PR TITLE
feat(keyvault): add collaborator management for Azure Key Vaults (FCF-241)

### DIFF
--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/AzureManagementClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/AzureManagementClient.java
@@ -46,6 +46,8 @@ import org.springframework.web.client.RestTemplate;
 
 import com.daimler.data.dto.azureKeyVault.AzureUserDto;
 import com.daimler.data.dto.azureKeyVault.AzureUserSearchResponseDto;
+import com.daimler.data.dto.azureKeyVault.AzurePrincipalDto;
+import com.daimler.data.dto.azureKeyVault.AzurePrincipalSearchResponseDto;
 import com.daimler.data.dto.azureKeyVault.KeyVaultAccessPolicyDto;
 import com.daimler.data.dto.azureKeyVault.KeyVaultCreateRequestDto;
 import com.daimler.data.dto.azureKeyVault.KeyVaultNameAvailabilityRequestDto;
@@ -131,6 +133,9 @@ public class AzureManagementClient {
 
     @Value("${fabricWorkspaces.azure.keyvault.userSearchUrl}")
     private String azureUserSearchUrl;
+
+    @Value("${fabricWorkspaces.azure.keyvault.servicePrincipalSearchUrl}")
+    private String azureServicePrincipalSearchUrl;
 
     @Value("${fabricWorkspaces.azure.keyvault.roleAssignmentUrl}")
     private String azureRoleAssignmentUrl;
@@ -258,8 +263,8 @@ public class AzureManagementClient {
             
             HttpEntity<String> requestEntity = new HttpEntity<>(headers);
             
-            String url = azureUserSearchUrl + "?$filter=mail eq '" + userEmail + "'";
-            log.info("User search URL: {}", url);
+            String escapedEmail = userEmail == null ? "" : userEmail.replace("'", "''");
+            String url = azureUserSearchUrl + "?$filter=mail eq '" + escapedEmail + "'";
             
             log.info("Searching for user with email: {}", userEmail);
             ResponseEntity<AzureUserSearchResponseDto> response = proxyRestTemplate.exchange(
@@ -278,6 +283,66 @@ public class AzureManagementClient {
             log.error("Error searching for user {}: {}", userEmail, e.getMessage());
             return null;
         }
+    }
+
+    public List<AzurePrincipalDto> searchPrincipals(String searchTerm) {
+        try {
+            String token = getTokenForGroupSearch();
+            if (!Objects.nonNull(token)) {
+                return List.of();
+            }
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Accept", "application/json");
+            headers.set("Authorization", "Bearer " + token);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+            String escapedTerm = searchTerm == null ? "" : searchTerm.replace("'", "''");
+            String userUrl = azureUserSearchUrl + "?$filter=startswith(mail,'" + escapedTerm + "')";
+            String servicePrincipalUrl = azureServicePrincipalSearchUrl
+                    + "?$filter=startswith(displayName,'" + escapedTerm + "') or appId eq '" + escapedTerm + "'";
+
+            ResponseEntity<AzureUserSearchResponseDto> users = proxyRestTemplate.exchange(
+                    userUrl, HttpMethod.GET, requestEntity, AzureUserSearchResponseDto.class);
+            ResponseEntity<AzurePrincipalSearchResponseDto> servicePrincipals = proxyRestTemplate.exchange(
+                    servicePrincipalUrl, HttpMethod.GET, requestEntity, AzurePrincipalSearchResponseDto.class);
+
+            List<AzurePrincipalDto> result = new java.util.ArrayList<>();
+            if (users.getBody() != null && users.getBody().getValue() != null) {
+                users.getBody().getValue().forEach(user -> result.add(new AzurePrincipalDto(
+                        user.getId(), user.getDisplayName(), user.getMail(), null, null,
+                        "User", "USER", user.getMail())));
+            }
+            if (servicePrincipals.getBody() != null && servicePrincipals.getBody().getValue() != null) {
+                servicePrincipals.getBody().getValue().forEach(principal -> {
+                    principal.setPrincipalType("ServicePrincipal");
+                    principal.setKind("ManagedIdentity".equalsIgnoreCase(principal.getServicePrincipalType())
+                            ? "MI" : "SPN");
+                    principal.setIdentifier(principal.getAppId() != null
+                            ? principal.getAppId() : principal.getDisplayName());
+                    result.add(principal);
+                });
+            }
+            return result;
+        } catch (Exception e) {
+            log.error("Error searching Azure principals: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    public AzurePrincipalDto resolvePrincipal(String identifier, String kind) {
+        if ("USER".equalsIgnoreCase(kind)) {
+            String objectId = getUserPrincipalId(identifier);
+            return objectId == null ? null : new AzurePrincipalDto(
+                    objectId, identifier, identifier, null, null, "User", "USER", identifier);
+        }
+        List<AzurePrincipalDto> principals = searchPrincipals(identifier);
+        return principals.stream()
+                .filter(principal -> identifier.equalsIgnoreCase(principal.getIdentifier())
+                        || identifier.equalsIgnoreCase(principal.getDisplayName())
+                        || identifier.equalsIgnoreCase(principal.getAppId()))
+                .findFirst()
+                .orElse(null);
     }
     
 	public KeyVaultResponseDto createOrUpdateKeyVault(String keyVaultName) {
@@ -374,6 +439,11 @@ public class AzureManagementClient {
 	}
     
     public RoleAssignmentResponseDto assignRoleToUser(String keyVaultName, String userPrincipalId, String roleType) {
+        return assignRoleToUser(keyVaultName, userPrincipalId, roleType, "User");
+    }
+
+    public RoleAssignmentResponseDto assignRoleToUser(String keyVaultName, String userPrincipalId,
+            String roleType, String principalType) {
         RoleAssignmentResponseDto responseDto = new RoleAssignmentResponseDto();
         try {
             String token = getTokenForAzureManagement();
@@ -397,7 +467,7 @@ public class AzureManagementClient {
             RoleAssignmentPropertiesDto properties = new RoleAssignmentPropertiesDto();
             properties.setRoleDefinitionId(fullRoleDefinitionId);
             properties.setPrincipalId(userPrincipalId);
-            properties.setPrincipalType("User");
+            properties.setPrincipalType(principalType);
             
             RoleAssignmentRequestDto requestDto = new RoleAssignmentRequestDto();
             requestDto.setProperties(properties);
@@ -410,6 +480,7 @@ public class AzureManagementClient {
             HttpEntity<RoleAssignmentRequestDto> requestEntity = new HttpEntity<>(requestDto, headers);
             
             String roleAssignmentId = java.util.UUID.randomUUID().toString();
+            responseDto.setId(roleAssignmentId);
 
             String url = azureRoleAssignmentUrl;
             url = url.replace("{subscriptionId}", azureSubscriptionId)
@@ -426,6 +497,12 @@ public class AzureManagementClient {
                     url, HttpMethod.PUT, requestEntity, RoleAssignmentResponseDto.class);
             
             responseDto = response.getBody();
+            if (responseDto == null) {
+                responseDto = new RoleAssignmentResponseDto();
+            }
+            if (responseDto.getId() == null) {
+                responseDto.setId(roleAssignmentId);
+            }
             // log.info("Successfully assigned role to user for Key Vault: {}", keyVaultName);
             log.info("Successfully assigned role '{}' to user {} for Key Vault: {}", roleType, userPrincipalId, keyVaultName);
             return responseDto;
@@ -444,6 +521,41 @@ public class AzureManagementClient {
             log.error("Error assigning role to user: {}", e.getMessage());
             responseDto.setErrorCode("INTERNAL_ERROR");
             responseDto.setMessage("Failed to assign role: " + e.getMessage());
+            return responseDto;
+        }
+    }
+
+    public RoleAssignmentResponseDto removeRoleAssignment(String keyVaultName, String roleAssignmentId) {
+        RoleAssignmentResponseDto responseDto = new RoleAssignmentResponseDto();
+        try {
+            String token = getTokenForAzureManagement();
+            if (!Objects.nonNull(token)) {
+                responseDto.setErrorCode("AUTH_ERROR");
+                responseDto.setMessage("Failed to login using service principal, please try later.");
+                return responseDto;
+            }
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Accept", "application/json");
+            headers.set("Authorization", "Bearer " + token);
+            HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+            String url = azureRoleAssignmentUrl.replace("{subscriptionId}", azureSubscriptionId)
+                    .replace("{resourceGroupName}", azureResourceGroup)
+                    .replace("{keyVaultName}", keyVaultName)
+                    .replace("{roleAssignmentId}", roleAssignmentId);
+            proxyRestTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+            return responseDto;
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode().value() == 404) {
+                responseDto.setErrorCode("404");
+                responseDto.setMessage("Role assignment not found");
+                return responseDto;
+            }
+            responseDto.setErrorCode(String.valueOf(e.getStatusCode().value()));
+            responseDto.setMessage("Failed to remove role assignment: " + e.getMessage());
+            return responseDto;
+        } catch (Exception e) {
+            responseDto.setErrorCode("INTERNAL_ERROR");
+            responseDto.setMessage("Failed to remove role assignment: " + e.getMessage());
             return responseDto;
         }
     }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/AzureManagementClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/AzureManagementClient.java
@@ -286,6 +286,9 @@ public class AzureManagementClient {
     }
 
     public List<AzurePrincipalDto> searchPrincipals(String searchTerm) {
+        if (searchTerm == null || searchTerm.isBlank() || searchTerm.trim().length() < 3) {
+            return List.of();
+        }
         try {
             String token = getTokenForGroupSearch();
             if (!Objects.nonNull(token)) {
@@ -302,26 +305,40 @@ public class AzureManagementClient {
             String servicePrincipalUrl = azureServicePrincipalSearchUrl
                     + "?$filter=startswith(displayName,'" + escapedTerm + "') or appId eq '" + escapedTerm + "'";
 
-            ResponseEntity<AzureUserSearchResponseDto> users = proxyRestTemplate.exchange(
-                    userUrl, HttpMethod.GET, requestEntity, AzureUserSearchResponseDto.class);
-            ResponseEntity<AzurePrincipalSearchResponseDto> servicePrincipals = proxyRestTemplate.exchange(
-                    servicePrincipalUrl, HttpMethod.GET, requestEntity, AzurePrincipalSearchResponseDto.class);
-
             List<AzurePrincipalDto> result = new java.util.ArrayList<>();
-            if (users.getBody() != null && users.getBody().getValue() != null) {
-                users.getBody().getValue().forEach(user -> result.add(new AzurePrincipalDto(
-                        user.getId(), user.getDisplayName(), user.getMail(), null, null,
-                        "User", "USER", user.getMail())));
+            try {
+                ResponseEntity<AzureUserSearchResponseDto> users = proxyRestTemplate.exchange(
+                        userUrl, HttpMethod.GET, requestEntity, AzureUserSearchResponseDto.class);
+                if (users.getBody() != null && users.getBody().getValue() != null) {
+                    users.getBody().getValue().forEach(user -> {
+                        String identifier = user.getMail();
+                        if (identifier != null && !identifier.isBlank()) {
+                            result.add(new AzurePrincipalDto(
+                                    user.getId(), user.getDisplayName(), user.getMail(), null, null,
+                                    "User", "USER", identifier));
+                        }
+                    });
+                }
+            } catch (Exception e) {
+                log.warn("Error searching Azure users: {}", e.getMessage());
             }
-            if (servicePrincipals.getBody() != null && servicePrincipals.getBody().getValue() != null) {
-                servicePrincipals.getBody().getValue().forEach(principal -> {
-                    principal.setPrincipalType("ServicePrincipal");
-                    principal.setKind("ManagedIdentity".equalsIgnoreCase(principal.getServicePrincipalType())
-                            ? "MI" : "SPN");
-                    principal.setIdentifier(principal.getAppId() != null
-                            ? principal.getAppId() : principal.getDisplayName());
-                    result.add(principal);
-                });
+            try {
+                ResponseEntity<AzurePrincipalSearchResponseDto> servicePrincipals = proxyRestTemplate.exchange(
+                        servicePrincipalUrl, HttpMethod.GET, requestEntity, AzurePrincipalSearchResponseDto.class);
+                if (servicePrincipals.getBody() != null && servicePrincipals.getBody().getValue() != null) {
+                    servicePrincipals.getBody().getValue().forEach(principal -> {
+                        principal.setPrincipalType("ServicePrincipal");
+                        principal.setKind("ManagedIdentity".equalsIgnoreCase(principal.getServicePrincipalType())
+                                ? "MI" : "SPN");
+                        principal.setIdentifier(principal.getAppId() != null
+                                ? principal.getAppId() : principal.getDisplayName());
+                        if (principal.getIdentifier() != null && !principal.getIdentifier().isBlank()) {
+                            result.add(principal);
+                        }
+                    });
+                }
+            } catch (Exception e) {
+                log.warn("Error searching Azure service principals: {}", e.getMessage());
             }
             return result;
         } catch (Exception e) {
@@ -445,6 +462,7 @@ public class AzureManagementClient {
     public RoleAssignmentResponseDto assignRoleToUser(String keyVaultName, String userPrincipalId,
             String roleType, String principalType) {
         RoleAssignmentResponseDto responseDto = new RoleAssignmentResponseDto();
+        String roleAssignmentId = null;
         try {
             String token = getTokenForAzureManagement();
             if(!Objects.nonNull(token)) {
@@ -479,8 +497,8 @@ public class AzureManagementClient {
             
             HttpEntity<RoleAssignmentRequestDto> requestEntity = new HttpEntity<>(requestDto, headers);
             
-            String roleAssignmentId = java.util.UUID.randomUUID().toString();
-            responseDto.setId(roleAssignmentId);
+            roleAssignmentId = java.util.UUID.randomUUID().toString();
+            responseDto.setRoleAssignmentId(roleAssignmentId);
 
             String url = azureRoleAssignmentUrl;
             url = url.replace("{subscriptionId}", azureSubscriptionId)
@@ -500,9 +518,7 @@ public class AzureManagementClient {
             if (responseDto == null) {
                 responseDto = new RoleAssignmentResponseDto();
             }
-            if (responseDto.getId() == null) {
-                responseDto.setId(roleAssignmentId);
-            }
+            responseDto.setRoleAssignmentId(roleAssignmentId);
             // log.info("Successfully assigned role to user for Key Vault: {}", keyVaultName);
             log.info("Successfully assigned role '{}' to user {} for Key Vault: {}", roleType, userPrincipalId, keyVaultName);
             return responseDto;
@@ -511,6 +527,7 @@ public class AzureManagementClient {
                 log.info("Role assignment already exists for user {} on Key Vault {}", userPrincipalId, keyVaultName);
                 responseDto.setErrorCode("409");
                 responseDto.setMessage("Role assignment already exists");
+                responseDto.setRoleAssignmentId(roleAssignmentId);
                 return responseDto;
             }
             log.error("Azure API error assigning role to user: {}", e.getMessage());

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/AzureManagementClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/AzureManagementClient.java
@@ -26,10 +26,12 @@
  */
 package com.daimler.data.application.client;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -301,11 +303,13 @@ public class AzureManagementClient {
             headers.setContentType(MediaType.APPLICATION_JSON);
             HttpEntity<String> requestEntity = new HttpEntity<>(headers);
             String escapedTerm = searchTerm == null ? "" : searchTerm.replace("'", "''");
+            // Graph exposes users and service principals through separate collections, so query both.
             String userUrl = azureUserSearchUrl + "?$filter=startswith(mail,'" + escapedTerm + "')";
             String servicePrincipalUrl = azureServicePrincipalSearchUrl
                     + "?$filter=startswith(displayName,'" + escapedTerm + "') or appId eq '" + escapedTerm + "'";
 
-            List<AzurePrincipalDto> result = new java.util.ArrayList<>();
+            List<AzurePrincipalDto> result = new ArrayList<>();
+            // Isolate each lookup so one unavailable Graph endpoint does not hide results from the other.
             try {
                 ResponseEntity<AzureUserSearchResponseDto> users = proxyRestTemplate.exchange(
                         userUrl, HttpMethod.GET, requestEntity, AzureUserSearchResponseDto.class);
@@ -497,7 +501,7 @@ public class AzureManagementClient {
             
             HttpEntity<RoleAssignmentRequestDto> requestEntity = new HttpEntity<>(requestDto, headers);
             
-            roleAssignmentId = java.util.UUID.randomUUID().toString();
+            roleAssignmentId = UUID.randomUUID().toString();
             responseDto.setRoleAssignmentId(roleAssignmentId);
 
             String url = azureRoleAssignmentUrl;
@@ -555,6 +559,7 @@ public class AzureManagementClient {
             headers.set("Accept", "application/json");
             headers.set("Authorization", "Bearer " + token);
             HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+            // Azure deletes the assignment resource, so use the persisted assignment ID rather than a principal ID.
             String url = azureRoleAssignmentUrl.replace("{subscriptionId}", azureSubscriptionId)
                     .replace("{resourceGroupName}", azureResourceGroup)
                     .replace("{keyVaultName}", keyVaultName)

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/AzureManagementClient.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/application/client/AzureManagementClient.java
@@ -29,7 +29,9 @@ package com.daimler.data.application.client;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -69,6 +71,9 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Slf4j
 public class AzureManagementClient {
+
+    public static final String ACCESS_LEVEL_READING = "Reading";
+    public static final String ACCESS_LEVEL_CONTRIBUTING = "Contributing";
 
     @Value("${fabricWorkspaces.group.clientId}")
     private String groupSearchclientId;
@@ -150,6 +155,18 @@ public class AzureManagementClient {
 
     @Value("${fabricWorkspaces.azure.keyvault.roles.keyVaultAdminRole}")
     private String keyVaultAdminRole;
+
+    @Value("${fabricWorkspaces.azure.keyvault.roles.certificatesUser}")
+    private String keyVaultCertificatesUserRole;
+
+    @Value("${fabricWorkspaces.azure.keyvault.roles.secretsUser}")
+    private String keyVaultSecretsUserRole;
+
+    @Value("${fabricWorkspaces.azure.keyvault.roles.certificatesOfficer}")
+    private String keyVaultCertificatesOfficerRole;
+
+    @Value("${fabricWorkspaces.azure.keyvault.roles.secretsOfficer}")
+    private String keyVaultSecretsOfficerRole;
 
     @Autowired
     private RestTemplate proxyRestTemplate;
@@ -303,8 +320,11 @@ public class AzureManagementClient {
             headers.setContentType(MediaType.APPLICATION_JSON);
             HttpEntity<String> requestEntity = new HttpEntity<>(headers);
             String escapedTerm = searchTerm == null ? "" : searchTerm.replace("'", "''");
-            // Graph exposes users and service principals through separate collections, so query both.
-            String userUrl = azureUserSearchUrl + "?$filter=startswith(mail,'" + escapedTerm + "')";
+            // Graph exposes users and service principals (which cover managed identities) through separate
+            // collections, so query both and return them as one result set.
+            String userUrl = azureUserSearchUrl + "?$filter=startswith(mail,'" + escapedTerm
+                    + "') or startswith(displayName,'" + escapedTerm
+                    + "') or startswith(userPrincipalName,'" + escapedTerm + "')";
             String servicePrincipalUrl = azureServicePrincipalSearchUrl
                     + "?$filter=startswith(displayName,'" + escapedTerm + "') or appId eq '" + escapedTerm + "'";
 
@@ -315,7 +335,8 @@ public class AzureManagementClient {
                         userUrl, HttpMethod.GET, requestEntity, AzureUserSearchResponseDto.class);
                 if (users.getBody() != null && users.getBody().getValue() != null) {
                     users.getBody().getValue().forEach(user -> {
-                        String identifier = user.getMail();
+                        String identifier = user.getMail() != null && !user.getMail().isBlank()
+                                ? user.getMail() : user.getUserPrincipalName();
                         if (identifier != null && !identifier.isBlank()) {
                             result.add(new AzurePrincipalDto(
                                     user.getId(), user.getDisplayName(), user.getMail(), null, null,
@@ -465,7 +486,44 @@ public class AzureManagementClient {
 
     public RoleAssignmentResponseDto assignRoleToUser(String keyVaultName, String userPrincipalId,
             String roleType, String principalType) {
+        String roleDefinitionId = "user".equalsIgnoreCase(roleType) ? keyVaultCryptoUserRole : keyVaultAdminRole;
+        return assignRoleDefinition(keyVaultName, userPrincipalId, principalType, roleDefinitionId, roleType);
+    }
+
+    /**
+     * Role definitions granted for each collaborator access level. The definition ids themselves come from
+     * deployment configuration, only the Azure role names are known to the application.
+     */
+    public Map<String, String> rolesForAccessLevel(String accessLevel) {
+        Map<String, String> roles = new LinkedHashMap<>();
+        if (ACCESS_LEVEL_CONTRIBUTING.equalsIgnoreCase(accessLevel)) {
+            roles.put("Key Vault Certificates Officer", keyVaultCertificatesOfficerRole);
+            roles.put("Key Vault Crypto Officer", keyVaultCryptoOfficerRole);
+            roles.put("Key Vault Secrets Officer", keyVaultSecretsOfficerRole);
+        } else {
+            roles.put("Key Vault Certificates User", keyVaultCertificatesUserRole);
+            roles.put("Key Vault Crypto User", keyVaultCryptoUserRole);
+            roles.put("Key Vault Secrets User", keyVaultSecretsUserRole);
+        }
+        return roles;
+    }
+
+    public List<RoleAssignmentResponseDto> assignAccessLevelRoles(String keyVaultName, String principalId,
+            String principalType, String accessLevel) {
+        List<RoleAssignmentResponseDto> responses = new ArrayList<>();
+        rolesForAccessLevel(accessLevel).forEach((roleName, roleDefinitionId) -> {
+            RoleAssignmentResponseDto response = assignRoleDefinition(keyVaultName, principalId, principalType,
+                    roleDefinitionId, roleName);
+            response.setRoleName(roleName);
+            responses.add(response);
+        });
+        return responses;
+    }
+
+    private RoleAssignmentResponseDto assignRoleDefinition(String keyVaultName, String userPrincipalId,
+            String principalType, String roleDefinitionId, String roleName) {
         RoleAssignmentResponseDto responseDto = new RoleAssignmentResponseDto();
+        responseDto.setRoleName(roleName);
         String roleAssignmentId = null;
         try {
             String token = getTokenForAzureManagement();
@@ -476,16 +534,15 @@ public class AzureManagementClient {
                 return responseDto;
             }
 
-            String roleDefinitionId = keyVaultAdminRole;
-            if ("user".equalsIgnoreCase(roleType)) {
-                roleDefinitionId = keyVaultCryptoUserRole;
+            if (roleDefinitionId == null || roleDefinitionId.isBlank()) {
+                log.error("No role definition configured for role {}", roleName);
+                responseDto.setErrorCode("CONFIG_ERROR");
+                responseDto.setMessage("No role definition configured for role " + roleName);
+                return responseDto;
             }
-            
+
             String fullRoleDefinitionId = "/subscriptions/" + azureSubscriptionId + roleDefinitionId;
 
-            log.info("Role assignment details - Type: {}, Definition ID: {}, Full Role Definition: {}", 
-                roleType, roleDefinitionId, fullRoleDefinitionId);
-            
             RoleAssignmentPropertiesDto properties = new RoleAssignmentPropertiesDto();
             properties.setRoleDefinitionId(fullRoleDefinitionId);
             properties.setPrincipalId(userPrincipalId);
@@ -510,10 +567,8 @@ public class AzureManagementClient {
                     .replace("{keyVaultName}", keyVaultName)
                     .replace("{roleAssignmentId}", roleAssignmentId);
             
-            // log.info("Assigning role {} to user {} for Key Vault {}", roleType, userPrincipalId, keyVaultName);
-            log.info("Assigning role '{}' to user {} for Key Vault '{}'. Role Assignment ID: {}", 
-                roleType, userPrincipalId, keyVaultName, roleAssignmentId);
-            log.info("Role assignment URL: {}", url);
+            log.info("Assigning role '{}' to principal {} for Key Vault '{}'. Role Assignment ID: {}",
+                roleName, userPrincipalId, keyVaultName, roleAssignmentId);
 
             ResponseEntity<RoleAssignmentResponseDto> response = proxyRestTemplate.exchange(
                     url, HttpMethod.PUT, requestEntity, RoleAssignmentResponseDto.class);
@@ -523,12 +578,12 @@ public class AzureManagementClient {
                 responseDto = new RoleAssignmentResponseDto();
             }
             responseDto.setRoleAssignmentId(roleAssignmentId);
-            // log.info("Successfully assigned role to user for Key Vault: {}", keyVaultName);
-            log.info("Successfully assigned role '{}' to user {} for Key Vault: {}", roleType, userPrincipalId, keyVaultName);
+            responseDto.setRoleName(roleName);
+            log.info("Successfully assigned role '{}' to principal {} for Key Vault: {}", roleName, userPrincipalId, keyVaultName);
             return responseDto;
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode().value() == 409) {
-                log.info("Role assignment already exists for user {} on Key Vault {}", userPrincipalId, keyVaultName);
+                log.info("Role assignment already exists for principal {} on Key Vault {}", userPrincipalId, keyVaultName);
                 responseDto.setErrorCode("409");
                 responseDto.setMessage("Role assignment already exists");
                 responseDto.setRoleAssignmentId(roleAssignmentId);

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/assembler/AzureKeyVaultAssembler.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/assembler/AzureKeyVaultAssembler.java
@@ -1,6 +1,7 @@
 package com.daimler.data.assembler;
 
 import java.util.Date;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Component;
@@ -37,7 +38,7 @@ public class AzureKeyVaultAssembler implements GenericAssembler<KeyVaultVO, Azur
 						KeyVaultCollaboratorVO collaboratorVO = new KeyVaultCollaboratorVO();
 						BeanUtils.copyProperties(collaborator, collaboratorVO);
 						return collaboratorVO;
-					}).collect(java.util.stream.Collectors.toList()));
+					}).collect(Collectors.toList()));
 				}
 			}
 		}
@@ -65,7 +66,7 @@ public class AzureKeyVaultAssembler implements GenericAssembler<KeyVaultVO, Azur
 					AzureKeyVaultCollaborator collaboratorData = new AzureKeyVaultCollaborator();
 					BeanUtils.copyProperties(collaborator, collaboratorData);
 					return collaboratorData;
-				}).collect(java.util.stream.Collectors.toList()));
+				}).collect(Collectors.toList()));
 			}
 			
 			if (vo.getCreatedOn() == null) {

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/assembler/AzureKeyVaultAssembler.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/assembler/AzureKeyVaultAssembler.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Component;
 
 import com.daimler.data.db.entities.AzureKeyVaultNsql;
 import com.daimler.data.db.json.AzureKeyVault;
+import com.daimler.data.db.json.AzureKeyVaultCollaborator;
 import com.daimler.data.db.json.UserDetails;
 import com.daimler.data.dto.fabricWorkspace.CreatedByVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultVO;
+import com.daimler.data.dto.fabricWorkspace.KeyVaultCollaboratorVO;
 
 @Component
 public class AzureKeyVaultAssembler implements GenericAssembler<KeyVaultVO, AzureKeyVaultNsql> {
@@ -30,6 +32,13 @@ public class AzureKeyVaultAssembler implements GenericAssembler<KeyVaultVO, Azur
 					BeanUtils.copyProperties(creator, createdByVO);
 				}
 				vo.setCreatedBy(createdByVO);
+				if (data.getCollaborators() != null) {
+					vo.setCollaborators(data.getCollaborators().stream().map(collaborator -> {
+						KeyVaultCollaboratorVO collaboratorVO = new KeyVaultCollaboratorVO();
+						BeanUtils.copyProperties(collaborator, collaboratorVO);
+						return collaboratorVO;
+					}).collect(java.util.stream.Collectors.toList()));
+				}
 			}
 		}
 		return vo;
@@ -51,6 +60,13 @@ public class AzureKeyVaultAssembler implements GenericAssembler<KeyVaultVO, Azur
 				BeanUtils.copyProperties(createdByVO, creator);
 			}
 			data.setCreatedBy(creator);
+			if (vo.getCollaborators() != null) {
+				data.setCollaborators(vo.getCollaborators().stream().map(collaborator -> {
+					AzureKeyVaultCollaborator collaboratorData = new AzureKeyVaultCollaborator();
+					BeanUtils.copyProperties(collaborator, collaboratorData);
+					return collaboratorData;
+				}).collect(java.util.stream.Collectors.toList()));
+			}
 			
 			if (vo.getCreatedOn() == null) {
 				data.setCreatedOn(new Date());

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
@@ -55,6 +55,7 @@ import com.daimler.data.dto.fabricWorkspace.KeyVaultCreateRequestVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultResponseVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultCollectionVO;
+import com.daimler.data.dto.fabricWorkspace.AzurePrincipalVO;
 import com.daimler.data.dto.fabricWorkspace.LakehouseColumnCollectionResponseVO;
 import com.daimler.data.dto.fabricWorkspace.LakehouseTableCollectionResponseVO;
 import com.daimler.data.dto.fabricWorkspace.RolesVO;
@@ -1142,6 +1143,23 @@ public class FabricWorkspaceController implements FabricWorkspacesApi, LovsApi
 					e.getMessage());
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	@Override
+	public ResponseEntity<List<AzurePrincipalVO>> searchKeyVaultPrincipals(String search) {
+		List<AzurePrincipalVO> result = keyVaultService.searchPrincipals(search).stream().map(principal -> {
+			AzurePrincipalVO vo = new AzurePrincipalVO();
+			vo.setId(principal.getId());
+			vo.setDisplayName(principal.getDisplayName());
+			vo.setMail(principal.getMail());
+			vo.setAppId(principal.getAppId());
+			vo.setServicePrincipalType(principal.getServicePrincipalType());
+			vo.setPrincipalType(principal.getPrincipalType());
+			vo.setKind(principal.getKind());
+			vo.setIdentifier(principal.getIdentifier());
+			return vo;
+		}).collect(Collectors.toList());
+		return new ResponseEntity<>(result, HttpStatus.OK);
 	}
 
 	public static boolean isTechnicalUser(String id) {

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
@@ -1147,6 +1147,9 @@ public class FabricWorkspaceController implements FabricWorkspacesApi, LovsApi
 
 	@Override
 	public ResponseEntity<List<AzurePrincipalVO>> searchKeyVaultPrincipals(String search) {
+		if (search == null || search.isBlank() || search.trim().length() < 3) {
+			return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
+		}
 		List<AzurePrincipalVO> result = keyVaultService.searchPrincipals(search).stream().map(principal -> {
 			AzurePrincipalVO vo = new AzurePrincipalVO();
 			vo.setId(principal.getId());

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
@@ -55,6 +55,7 @@ import com.daimler.data.dto.fabricWorkspace.KeyVaultCreateRequestVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultResponseVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultCollectionVO;
+import com.daimler.data.dto.fabricWorkspace.AzurePrincipalVO;
 import com.daimler.data.dto.fabricWorkspace.LakehouseColumnCollectionResponseVO;
 import com.daimler.data.dto.fabricWorkspace.LakehouseTableCollectionResponseVO;
 import com.daimler.data.dto.fabricWorkspace.RolesVO;
@@ -1142,6 +1143,26 @@ public class FabricWorkspaceController implements FabricWorkspacesApi, LovsApi
 					e.getMessage());
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	@Override
+	public ResponseEntity<List<AzurePrincipalVO>> searchKeyVaultPrincipals(String search) {
+		if (search == null || search.isBlank() || search.trim().length() < 3) {
+			return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
+		}
+		List<AzurePrincipalVO> result = keyVaultService.searchPrincipals(search.trim()).stream().map(principal -> {
+			AzurePrincipalVO vo = new AzurePrincipalVO();
+			vo.setId(principal.getId());
+			vo.setDisplayName(principal.getDisplayName());
+			vo.setMail(principal.getMail());
+			vo.setAppId(principal.getAppId());
+			vo.setServicePrincipalType(principal.getServicePrincipalType());
+			vo.setPrincipalType(principal.getPrincipalType());
+			vo.setKind(principal.getKind());
+			vo.setIdentifier(principal.getIdentifier());
+			return vo;
+		}).collect(Collectors.toList());
+		return new ResponseEntity<>(result, HttpStatus.OK);
 	}
 
 	public static boolean isTechnicalUser(String id) {

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
@@ -1404,9 +1404,6 @@ public class FabricWorkspaceController implements FabricWorkspacesApi, LovsApi
 
 		try {
 			collection = keyVaultService.getAllKeyVaults(limit, offset, createdBy);
-			if (!collection.getRecords().isEmpty()) {
-				collection.setTotalCount(collection.getRecords().size());
-			}
 			HttpStatus responseCode = collection.getRecords() != null && !collection.getRecords().isEmpty() 
 					? HttpStatus.OK 
 					: HttpStatus.NO_CONTENT;

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/controller/FabricWorkspaceController.java
@@ -55,7 +55,6 @@ import com.daimler.data.dto.fabricWorkspace.KeyVaultCreateRequestVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultResponseVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultCollectionVO;
-import com.daimler.data.dto.fabricWorkspace.AzurePrincipalVO;
 import com.daimler.data.dto.fabricWorkspace.LakehouseColumnCollectionResponseVO;
 import com.daimler.data.dto.fabricWorkspace.LakehouseTableCollectionResponseVO;
 import com.daimler.data.dto.fabricWorkspace.RolesVO;
@@ -1143,26 +1142,6 @@ public class FabricWorkspaceController implements FabricWorkspacesApi, LovsApi
 					e.getMessage());
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}
-	}
-
-	@Override
-	public ResponseEntity<List<AzurePrincipalVO>> searchKeyVaultPrincipals(String search) {
-		if (search == null || search.isBlank() || search.trim().length() < 3) {
-			return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
-		}
-		List<AzurePrincipalVO> result = keyVaultService.searchPrincipals(search).stream().map(principal -> {
-			AzurePrincipalVO vo = new AzurePrincipalVO();
-			vo.setId(principal.getId());
-			vo.setDisplayName(principal.getDisplayName());
-			vo.setMail(principal.getMail());
-			vo.setAppId(principal.getAppId());
-			vo.setServicePrincipalType(principal.getServicePrincipalType());
-			vo.setPrincipalType(principal.getPrincipalType());
-			vo.setKind(principal.getKind());
-			vo.setIdentifier(principal.getIdentifier());
-			return vo;
-		}).collect(Collectors.toList());
-		return new ResponseEntity<>(result, HttpStatus.OK);
 	}
 
 	public static boolean isTechnicalUser(String id) {

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/AzureKeyVault.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/AzureKeyVault.java
@@ -2,6 +2,7 @@ package com.daimler.data.db.json;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -30,4 +31,5 @@ public class AzureKeyVault implements Serializable {
 	
 	private UserDetails createdBy;
 	private Date createdOn;
+	private List<AzureKeyVaultCollaborator> collaborators;
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/AzureKeyVaultCollaborator.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/AzureKeyVaultCollaborator.java
@@ -1,0 +1,26 @@
+package com.daimler.data.db.json;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AzureKeyVaultCollaborator implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private String identifier;
+	private String objectId;
+	private String principalType;
+	private String kind;
+	private String displayName;
+	private String role;
+	private String roleAssignmentId;
+}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/AzureKeyVaultCollaborator.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/AzureKeyVaultCollaborator.java
@@ -17,6 +17,9 @@ public class AzureKeyVaultCollaborator implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	private String identifier;
+	private String shortId;
+	private String firstName;
+	private String lastName;
 	private String objectId;
 	private String principalType;
 	private String kind;

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/AzureKeyVaultCollaborator.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/json/AzureKeyVaultCollaborator.java
@@ -1,6 +1,7 @@
 package com.daimler.data.db.json;
 
 import java.io.Serializable;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -25,5 +26,8 @@ public class AzureKeyVaultCollaborator implements Serializable {
 	private String kind;
 	private String displayName;
 	private String role;
+	private String accessLevel;
+	private List<String> roles;
 	private String roleAssignmentId;
+	private List<String> roleAssignmentIds;
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepository.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepository.java
@@ -34,4 +34,7 @@ import com.daimler.data.db.repo.common.CommonDataRepository;
 public interface AzureKeyVaultCustomRepository extends CommonDataRepository<AzureKeyVaultNsql, String> {
 
     List<AzureKeyVaultNsql> findAllByCreator(String creatorId, int limit, int offset);
+
+    List<AzureKeyVaultNsql> findAllByCreatorOrCollaborator(String creatorId, String collaboratorIdentifier,
+            int limit, int offset);
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepository.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepository.java
@@ -37,4 +37,6 @@ public interface AzureKeyVaultCustomRepository extends CommonDataRepository<Azur
 
     List<AzureKeyVaultNsql> findAllByCreatorOrCollaborator(String creatorId, String collaboratorIdentifier,
             int limit, int offset);
+
+    long countByCreatorOrCollaborator(String creatorId, String collaboratorIdentifier);
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
@@ -49,7 +49,12 @@ public class AzureKeyVaultCustomRepositoryImpl extends CommonDataRepositoryImpl<
 
     @Override
     public List<AzureKeyVaultNsql> findAllByCreator(String creatorId, int limit, int offset) {
-        
+        return findAllByCreatorOrCollaborator(creatorId, null, limit, offset);
+    }
+
+    @Override
+    public List<AzureKeyVaultNsql> findAllByCreatorOrCollaborator(String creatorId, String collaboratorIdentifier,
+            int limit, int offset) {
         CriteriaBuilder cb = em.getCriteriaBuilder();
         CriteriaQuery<AzureKeyVaultNsql> cq = cb.createQuery(AzureKeyVaultNsql.class);
         Root<AzureKeyVaultNsql> root = cq.from(AzureKeyVaultNsql.class);
@@ -66,8 +71,18 @@ public class AzureKeyVaultCustomRepositoryImpl extends CommonDataRepositoryImpl<
             cb.lower(createdByIdPath),
             cb.lower(cb.literal(creatorId))
         );
-        
-        cq.where(creatorPredicate);
+        Predicate accessPredicate = creatorPredicate;
+        if (collaboratorIdentifier != null && !collaboratorIdentifier.isBlank()) {
+            String escaped = collaboratorIdentifier.replace("\\", "\\\\").replace("\"", "\\\"");
+            Expression<Boolean> collaboratorPath = cb.function(
+                "jsonb_path_exists",
+                Boolean.class,
+                root.get("data"),
+                cb.literal("$.collaborators[*] ? (@.identifier == \"" + escaped + "\")")
+            );
+            accessPredicate = cb.or(creatorPredicate, cb.isTrue(collaboratorPath));
+        }
+        cq.where(accessPredicate);
         
         Expression<String> createdOnPath = cb.function(
             "jsonb_extract_path_text",

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
@@ -83,8 +83,9 @@ public class AzureKeyVaultCustomRepositoryImpl extends CommonDataRepositoryImpl<
                 root.get("data"),
                 cb.literal("collaborators")
             );
+            // Match the identifier field only; searching all collaborator JSON fields would create false positives.
             accessPredicate = cb.or(creatorPredicate, cb.like(
-                cb.lower(collaboratorPath), "%\"" + escaped + "\"%", '\\'));
+                cb.lower(collaboratorPath), "%\"identifier\":\"" + escaped + "\"%", '\\'));
         }
         cq.where(accessPredicate);
         

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
@@ -73,14 +73,18 @@ public class AzureKeyVaultCustomRepositoryImpl extends CommonDataRepositoryImpl<
         );
         Predicate accessPredicate = creatorPredicate;
         if (collaboratorIdentifier != null && !collaboratorIdentifier.isBlank()) {
-            String escaped = collaboratorIdentifier.replace("\\", "\\\\").replace("\"", "\\\"");
-            Expression<Boolean> collaboratorPath = cb.function(
-                "jsonb_path_exists",
-                Boolean.class,
+            String escaped = collaboratorIdentifier.toLowerCase()
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+            Expression<String> collaboratorPath = cb.function(
+                "jsonb_extract_path_text",
+                String.class,
                 root.get("data"),
-                cb.literal("$.collaborators[*] ? (@.identifier == \"" + escaped + "\")")
+                cb.literal("collaborators")
             );
-            accessPredicate = cb.or(creatorPredicate, cb.isTrue(collaboratorPath));
+            accessPredicate = cb.or(creatorPredicate, cb.like(
+                cb.lower(collaboratorPath), "%\"" + escaped + "\"%", '\\'));
         }
         cq.where(accessPredicate);
         

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
@@ -28,12 +28,7 @@ package com.daimler.data.db.repo.keyvault;
 
 import java.util.List;
 
-import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import javax.persistence.Query;
 
 import org.springframework.stereotype.Repository;
 
@@ -53,52 +48,15 @@ public class AzureKeyVaultCustomRepositoryImpl extends CommonDataRepositoryImpl<
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public List<AzureKeyVaultNsql> findAllByCreatorOrCollaborator(String creatorId, String collaboratorIdentifier,
             int limit, int offset) {
-        CriteriaBuilder cb = em.getCriteriaBuilder();
-        CriteriaQuery<AzureKeyVaultNsql> cq = cb.createQuery(AzureKeyVaultNsql.class);
-        Root<AzureKeyVaultNsql> root = cq.from(AzureKeyVaultNsql.class);
+        String sql = "select id, data from azure_key_vault_nsql where "
+                + accessCondition(collaboratorIdentifier)
+                + " order by jsonb_extract_path_text(data, 'createdOn') desc";
 
-        Expression<String> createdByIdPath = cb.function(
-            "jsonb_extract_path_text",
-            String.class,
-            root.get("data"),
-            cb.literal("createdBy"),
-            cb.literal("id")
-        );
-
-        Predicate creatorPredicate = cb.equal(
-            cb.lower(createdByIdPath),
-            cb.lower(cb.literal(creatorId))
-        );
-        Predicate accessPredicate = creatorPredicate;
-        if (collaboratorIdentifier != null && !collaboratorIdentifier.isBlank()) {
-            String escaped = collaboratorIdentifier.toLowerCase()
-                .replace("\\", "\\\\")
-                .replace("%", "\\%")
-                .replace("_", "\\_");
-            Expression<String> collaboratorPath = cb.function(
-                "jsonb_extract_path_text",
-                String.class,
-                root.get("data"),
-                cb.literal("collaborators")
-            );
-            // Match the identifier field only; searching all collaborator JSON fields would create false positives.
-            accessPredicate = cb.or(creatorPredicate, cb.like(
-                cb.lower(collaboratorPath), "%\"identifier\":\"" + escaped + "\"%", '\\'));
-        }
-        cq.where(accessPredicate);
-        
-        Expression<String> createdOnPath = cb.function(
-            "jsonb_extract_path_text",
-            String.class,
-            root.get("data"),
-            cb.literal("createdOn")
-        );
-        cq.orderBy(cb.desc(createdOnPath));
-        
-        TypedQuery<AzureKeyVaultNsql> query = em.createQuery(cq);
-        
+        Query query = em.createNativeQuery(sql, AzureKeyVaultNsql.class);
+        bindAccessParameters(query, creatorId, collaboratorIdentifier);
         if (offset >= 0) {
             query.setFirstResult(offset);
         }
@@ -107,5 +65,36 @@ public class AzureKeyVaultCustomRepositoryImpl extends CommonDataRepositoryImpl<
         }
 
         return query.getResultList();
+    }
+
+    @Override
+    public long countByCreatorOrCollaborator(String creatorId, String collaboratorIdentifier) {
+        String sql = "select count(*) from azure_key_vault_nsql where " + accessCondition(collaboratorIdentifier);
+        Query query = em.createNativeQuery(sql);
+        bindAccessParameters(query, creatorId, collaboratorIdentifier);
+        Object count = query.getSingleResult();
+        return count == null ? 0L : ((Number) count).longValue();
+    }
+
+    private String accessCondition(String collaboratorIdentifier) {
+        String condition = "lower(jsonb_extract_path_text(data, 'createdBy', 'id')) = lower(:creatorId)";
+        if (hasCollaborator(collaboratorIdentifier)) {
+            condition += " or exists (select 1 from jsonb_array_elements("
+                    + "case when jsonb_typeof(data -> 'collaborators') = 'array' "
+                    + "then data -> 'collaborators' else '[]'::jsonb end) collaborator"
+                    + " where lower(collaborator ->> 'identifier') = lower(:collaboratorIdentifier))";
+        }
+        return condition;
+    }
+
+    private void bindAccessParameters(Query query, String creatorId, String collaboratorIdentifier) {
+        query.setParameter("creatorId", creatorId);
+        if (hasCollaborator(collaboratorIdentifier)) {
+            query.setParameter("collaboratorIdentifier", collaboratorIdentifier);
+        }
+    }
+
+    private boolean hasCollaborator(String collaboratorIdentifier) {
+        return collaboratorIdentifier != null && !collaboratorIdentifier.isBlank();
     }
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/db/repo/keyvault/AzureKeyVaultCustomRepositoryImpl.java
@@ -77,14 +77,14 @@ public class AzureKeyVaultCustomRepositoryImpl extends CommonDataRepositoryImpl<
     }
 
     private String accessCondition(String collaboratorIdentifier) {
-        String condition = "lower(jsonb_extract_path_text(data, 'createdBy', 'id')) = lower(:creatorId)";
+        String condition = "(lower(jsonb_extract_path_text(data, 'createdBy', 'id')) = lower(:creatorId)";
         if (hasCollaborator(collaboratorIdentifier)) {
             condition += " or exists (select 1 from jsonb_array_elements("
                     + "case when jsonb_typeof(data -> 'collaborators') = 'array' "
-                    + "then data -> 'collaborators' else '[]'::jsonb end) collaborator"
+                    + "then data -> 'collaborators' else cast('[]' as jsonb) end) collaborator"
                     + " where lower(collaborator ->> 'identifier') = lower(:collaboratorIdentifier))";
         }
-        return condition;
+        return condition + ")";
     }
 
     private void bindAccessParameters(Query query, String creatorId, String collaboratorIdentifier) {

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/azureKeyVault/AzurePrincipalDto.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/azureKeyVault/AzurePrincipalDto.java
@@ -1,0 +1,27 @@
+package com.daimler.data.dto.azureKeyVault;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AzurePrincipalDto implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private String id;
+	private String displayName;
+	private String mail;
+	private String appId;
+	private String servicePrincipalType;
+	private String principalType;
+	private String kind;
+	private String identifier;
+}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/azureKeyVault/AzurePrincipalSearchResponseDto.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/azureKeyVault/AzurePrincipalSearchResponseDto.java
@@ -1,0 +1,21 @@
+package com.daimler.data.dto.azureKeyVault;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AzurePrincipalSearchResponseDto implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private List<AzurePrincipalDto> value;
+}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/azureKeyVault/RoleAssignmentResponseDto.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/azureKeyVault/RoleAssignmentResponseDto.java
@@ -20,6 +20,7 @@ public class RoleAssignmentResponseDto implements Serializable {
 	private String name;
 	private String type;
 	private RoleAssignmentPropertiesDto properties;
+	private String roleAssignmentId;
 	private String errorCode;
 	private String message;
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/azureKeyVault/RoleAssignmentResponseDto.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/dto/azureKeyVault/RoleAssignmentResponseDto.java
@@ -21,6 +21,7 @@ public class RoleAssignmentResponseDto implements Serializable {
 	private String type;
 	private RoleAssignmentPropertiesDto properties;
 	private String roleAssignmentId;
+	private String roleName;
 	private String errorCode;
 	private String message;
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/AzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/AzureKeyVaultService.java
@@ -1,11 +1,13 @@
 package com.daimler.data.service.azureKeyVault;
 
 import org.springframework.http.ResponseEntity;
+import java.util.List;
 
 import com.daimler.data.db.entities.AzureKeyVaultNsql;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultCollectionVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultResponseVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultVO;
+import com.daimler.data.dto.azureKeyVault.AzurePrincipalDto;
 import com.daimler.data.service.common.CommonService;
 
 public interface AzureKeyVaultService extends CommonService<KeyVaultVO, AzureKeyVaultNsql, String> {
@@ -15,4 +17,6 @@ public interface AzureKeyVaultService extends CommonService<KeyVaultVO, AzureKey
 	ResponseEntity<KeyVaultResponseVO> updateKeyVault(KeyVaultVO vo); 
 	
 	KeyVaultCollectionVO getAllKeyVaults(int limit, int offset, String createdBy);
+
+	List<AzurePrincipalDto> searchPrincipals(String search);
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/AzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/AzureKeyVaultService.java
@@ -1,13 +1,11 @@
 package com.daimler.data.service.azureKeyVault;
 
 import org.springframework.http.ResponseEntity;
-import java.util.List;
 
 import com.daimler.data.db.entities.AzureKeyVaultNsql;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultCollectionVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultResponseVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultVO;
-import com.daimler.data.dto.azureKeyVault.AzurePrincipalDto;
 import com.daimler.data.service.common.CommonService;
 
 public interface AzureKeyVaultService extends CommonService<KeyVaultVO, AzureKeyVaultNsql, String> {
@@ -17,6 +15,4 @@ public interface AzureKeyVaultService extends CommonService<KeyVaultVO, AzureKey
 	ResponseEntity<KeyVaultResponseVO> updateKeyVault(KeyVaultVO vo); 
 	
 	KeyVaultCollectionVO getAllKeyVaults(int limit, int offset, String createdBy);
-
-	List<AzurePrincipalDto> searchPrincipals(String search);
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
@@ -40,6 +40,9 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 
 	@Override
 	public List<AzurePrincipalDto> searchPrincipals(String search) {
+		if (search == null || search.isBlank() || search.trim().length() < 3) {
+			return List.of();
+		}
 		return azureManagementClient.searchPrincipals(search);
 	}
 
@@ -172,12 +175,21 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 
 			String userPrincipalId = azureManagementClient.getUserPrincipalId(userEmail);
 
-			RoleAssignmentResponseDto roleResponse = userPrincipalId == null ? null
-					: azureManagementClient.assignRoleToUser(keyVaultName, userPrincipalId, "officer");
-
 			if (userPrincipalId == null) {
-				warnings.add(new MessageDescription("Key Vault created but failed to find creator for role assignment."));
-			} else if (roleResponse != null && roleResponse.getErrorCode() != null
+				MessageDescription message = new MessageDescription("Key Vault created but failed to find user with email: "
+						+ userEmail + ". Role assignment failed.");
+				errors.add(message);
+				responseMessage.setErrors(errors);
+				responseMessage.setSuccess("FAILED");
+				responseData.setData(vo);
+				responseData.setResponses(responseMessage);
+				log.error("Key Vault {} created but user {} not found for role assignment", keyVaultName, userEmail);
+				return new ResponseEntity<>(responseData, HttpStatus.INTERNAL_SERVER_ERROR);
+			}
+
+			RoleAssignmentResponseDto roleResponse = azureManagementClient.assignRoleToUser(keyVaultName,
+					userPrincipalId, "officer");
+			if (roleResponse != null && roleResponse.getErrorCode() != null
 					&& !"409".equals(roleResponse.getErrorCode())) {
 				MessageDescription message = new MessageDescription(
 						"Key Vault created but role assignment failed: " + roleResponse.getMessage());
@@ -245,6 +257,18 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 				responseData.setResponses(responseMessage);
 				log.error("Key Vault not found with id: {}", vo.getId());
 				return new ResponseEntity<>(responseData, HttpStatus.NOT_FOUND);
+			}
+
+			String currentUserId = currentUser == null ? null : currentUser.getId();
+			String ownerId = existingKeyVault.getCreatedBy() == null ? null : existingKeyVault.getCreatedBy().getId();
+			if (currentUserId == null || ownerId == null || !ownerId.equalsIgnoreCase(currentUserId)) {
+				MessageDescription message = new MessageDescription("Only the Key Vault owner can update collaborators.");
+				errors.add(message);
+				responseMessage.setErrors(errors);
+				responseMessage.setSuccess("FAILED");
+				responseData.setData(vo);
+				responseData.setResponses(responseMessage);
+				return new ResponseEntity<>(responseData, HttpStatus.FORBIDDEN);
 			}
 
 			String existingKeyVaultName = existingKeyVault.getKeyVaultName();
@@ -377,7 +401,7 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 		collaborator.setObjectId(principal.getId());
 		collaborator.setPrincipalType(principal.getPrincipalType());
 		collaborator.setRole("Crypto User");
-		collaborator.setRoleAssignmentId(response == null ? null : response.getId());
+		collaborator.setRoleAssignmentId(response == null ? null : response.getRoleAssignmentId());
 		if (response != null && response.getErrorCode() != null && !"409".equals(response.getErrorCode())) {
 			warnings.add(new MessageDescription("Failed to assign collaborator " + collaborator.getIdentifier()
 					+ ": " + response.getMessage()));

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
@@ -2,7 +2,10 @@ package com.daimler.data.service.azureKeyVault;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,14 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, AzureKeyVaultNsql, String>
 		implements AzureKeyVaultService {
 
-	@Override
-	public List<AzurePrincipalDto> searchPrincipals(String search) {
-		if (search == null || search.isBlank() || search.trim().length() < 3) {
-			return List.of();
-		}
-		return azureManagementClient.searchPrincipals(search);
-	}
-
 	@Autowired
 	private AzureManagementClient azureManagementClient;
 
@@ -60,6 +55,14 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 
 	@Autowired
 	private UserStore userStore;
+
+	@Override
+	public List<AzurePrincipalDto> searchPrincipals(String search) {
+		if (search == null || search.isBlank() || search.trim().length() < 3) {
+			return List.of();
+		}
+		return azureManagementClient.searchPrincipals(search);
+	}
 
 	@Override
 	public KeyVaultCollectionVO getAllKeyVaults(int limit, int offset, String createdBy) {
@@ -338,7 +341,7 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 		if (vo.getCollaborators() == null) {
 			return;
 		}
-		java.util.Set<String> identifiers = new java.util.HashSet<>();
+		Set<String> identifiers = new HashSet<>();
 		for (KeyVaultCollaboratorVO collaborator : vo.getCollaborators()) {
 			if (collaborator == null || collaborator.getIdentifier() == null
 					|| !identifiers.add(collaborator.getIdentifier().toLowerCase())) {
@@ -354,7 +357,8 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 				? new ArrayList<>() : existing.getCollaborators();
 		List<KeyVaultCollaboratorVO> updatedCollaborators = updated.getCollaborators() == null
 				? new ArrayList<>() : updated.getCollaborators();
-		java.util.Map<String, KeyVaultCollaboratorVO> existingByIdentifier = existingCollaborators.stream()
+		// Compare identifiers to preserve existing assignments while provisioning only additions and removals.
+		Map<String, KeyVaultCollaboratorVO> existingByIdentifier = existingCollaborators.stream()
 				.filter(c -> c.getIdentifier() != null)
 				.collect(Collectors.toMap(c -> c.getIdentifier().toLowerCase(), c -> c, (left, right) -> left));
 		for (KeyVaultCollaboratorVO collaborator : updatedCollaborators) {
@@ -372,7 +376,7 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 				provisionCollaborator(keyVaultName, collaborator, warnings);
 			}
 		}
-		java.util.Set<String> retained = updatedCollaborators.stream()
+		Set<String> retained = updatedCollaborators.stream()
 				.filter(c -> c.getIdentifier() != null)
 				.map(c -> c.getIdentifier().toLowerCase()).collect(Collectors.toSet());
 		for (KeyVaultCollaboratorVO old : existingCollaborators) {
@@ -381,6 +385,7 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 				RoleAssignmentResponseDto response = azureManagementClient.removeRoleAssignment(
 						keyVaultName, old.getRoleAssignmentId());
 				if (response.getErrorCode() != null && !"404".equals(response.getErrorCode())) {
+					// Keep partial Azure failures as warnings so collaborator issues do not abort the vault update.
 					warnings.add(new MessageDescription("Failed to remove collaborator " + old.getIdentifier()
 							+ ": " + response.getMessage()));
 				}

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
@@ -3,15 +3,12 @@ package com.daimler.data.service.azureKeyVault;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.daimler.data.application.auth.UserStore;
 import com.daimler.data.application.client.AzureManagementClient;
@@ -25,9 +22,11 @@ import com.daimler.data.db.repo.keyvault.AzureKeyVaultRepository;
 import com.daimler.data.dto.azureKeyVault.KeyVaultNameAvailabilityResponseDto;
 import com.daimler.data.dto.azureKeyVault.KeyVaultResponseDto;
 import com.daimler.data.dto.azureKeyVault.RoleAssignmentResponseDto;
+import com.daimler.data.dto.azureKeyVault.AzurePrincipalDto;
 import com.daimler.data.dto.fabricWorkspace.CreatedByVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultResponseVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultVO;
+import com.daimler.data.dto.fabricWorkspace.KeyVaultCollaboratorVO;
 import com.daimler.data.dto.fabricWorkspace.KeyVaultCollectionVO;
 import com.daimler.data.service.common.BaseCommonService;
 import com.daimler.data.util.ConstantsUtility;
@@ -38,6 +37,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, AzureKeyVaultNsql, String>
 		implements AzureKeyVaultService {
+
+	@Override
+	public List<AzurePrincipalDto> searchPrincipals(String search) {
+		return azureManagementClient.searchPrincipals(search);
+	}
 
 	@Autowired
 	private AzureManagementClient azureManagementClient;
@@ -65,7 +69,13 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 			List<AzureKeyVaultNsql> keyVaults;
 			
 			if (createdBy != null && !createdBy.isBlank()) {
-				keyVaults = customRepo.findAllByCreator(createdBy, limit, offset);
+				String collaboratorIdentifier = null;
+				try {
+					collaboratorIdentifier = userStore.getVO().getEmail();
+				} catch (Exception ignored) {
+					log.warn("Unable to resolve current user's email for collaborator lookup");
+				}
+				keyVaults = customRepo.findAllByCreatorOrCollaborator(createdBy, collaboratorIdentifier, limit, offset);
 			} else {
 				log.warn("Attempt to fetch Key Vaults with no createdBy user ID.");
 				keyVaults = new ArrayList<>();
@@ -162,28 +172,19 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 
 			String userPrincipalId = azureManagementClient.getUserPrincipalId(userEmail);
 
+			RoleAssignmentResponseDto roleResponse = userPrincipalId == null ? null
+					: azureManagementClient.assignRoleToUser(keyVaultName, userPrincipalId, "officer");
+
 			if (userPrincipalId == null) {
-				MessageDescription message = new MessageDescription("Key Vault created but failed to find user with email: "
-						+ userEmail + ". Role assignment failed.");
-				errors.add(message);
-				responseMessage.setErrors(errors);
-				responseMessage.setSuccess("FAILED");
-				responseData.setData(vo);
-				responseData.setResponses(responseMessage);
-				log.error("Key Vault {} created but user {} not found for role assignment", keyVaultName, userEmail);
-				return new ResponseEntity<>(responseData, HttpStatus.INTERNAL_SERVER_ERROR);
-			}
-
-			RoleAssignmentResponseDto roleResponse = azureManagementClient.assignRoleToUser(keyVaultName,
-					userPrincipalId, "officer");
-
-			if (roleResponse != null && roleResponse.getErrorCode() != null
+				warnings.add(new MessageDescription("Key Vault created but failed to find creator for role assignment."));
+			} else if (roleResponse != null && roleResponse.getErrorCode() != null
 					&& !"409".equals(roleResponse.getErrorCode())) {
 				MessageDescription message = new MessageDescription(
 						"Key Vault created but role assignment failed: " + roleResponse.getMessage());
 				warnings.add(message);
 				log.warn("Key Vault {} created but role assignment failed", keyVaultName);
 			}
+			provisionAddedCollaborators(keyVaultName, vo, warnings);
 			vo.setLocation(keyVaultResponse.getLocation());
 			vo.setCreatedOn(new Date());
 			vo.setCreatedBy(currentUser);
@@ -267,6 +268,8 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 			vo.setCreatedBy(existingKeyVault.getCreatedBy()); 
 			vo.setCreatedOn(existingKeyVault.getCreatedOn()); 
 
+			provisionUpdatedCollaborators(keyVaultName, existingKeyVault, vo, warnings);
+
 			KeyVaultVO updatedRecord = null;
 			try {
 				AzureKeyVaultNsql updatedEntity = assembler.toEntity(vo);
@@ -304,6 +307,80 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 			responseData.setData(vo);
 			responseData.setResponses(responseMessage);
 			return new ResponseEntity<>(responseData, HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	private void provisionAddedCollaborators(String keyVaultName, KeyVaultVO vo, List<MessageDescription> warnings) {
+		if (vo.getCollaborators() == null) {
+			return;
+		}
+		java.util.Set<String> identifiers = new java.util.HashSet<>();
+		for (KeyVaultCollaboratorVO collaborator : vo.getCollaborators()) {
+			if (collaborator == null || collaborator.getIdentifier() == null
+					|| !identifiers.add(collaborator.getIdentifier().toLowerCase())) {
+				continue;
+			}
+			provisionCollaborator(keyVaultName, collaborator, warnings);
+		}
+	}
+
+	private void provisionUpdatedCollaborators(String keyVaultName, KeyVaultVO existing, KeyVaultVO updated,
+			List<MessageDescription> warnings) {
+		List<KeyVaultCollaboratorVO> existingCollaborators = existing.getCollaborators() == null
+				? new ArrayList<>() : existing.getCollaborators();
+		List<KeyVaultCollaboratorVO> updatedCollaborators = updated.getCollaborators() == null
+				? new ArrayList<>() : updated.getCollaborators();
+		java.util.Map<String, KeyVaultCollaboratorVO> existingByIdentifier = existingCollaborators.stream()
+				.filter(c -> c.getIdentifier() != null)
+				.collect(Collectors.toMap(c -> c.getIdentifier().toLowerCase(), c -> c, (left, right) -> left));
+		for (KeyVaultCollaboratorVO collaborator : updatedCollaborators) {
+			if (collaborator == null || collaborator.getIdentifier() == null) {
+				continue;
+			}
+			KeyVaultCollaboratorVO old = existingByIdentifier.get(collaborator.getIdentifier().toLowerCase());
+			if (old != null && collaborator.getRoleAssignmentId() == null) {
+				collaborator.setObjectId(old.getObjectId());
+				collaborator.setPrincipalType(old.getPrincipalType());
+				collaborator.setRole(old.getRole());
+				collaborator.setRoleAssignmentId(old.getRoleAssignmentId());
+			}
+			if (old == null || old.getRoleAssignmentId() == null) {
+				provisionCollaborator(keyVaultName, collaborator, warnings);
+			}
+		}
+		java.util.Set<String> retained = updatedCollaborators.stream()
+				.filter(c -> c.getIdentifier() != null)
+				.map(c -> c.getIdentifier().toLowerCase()).collect(Collectors.toSet());
+		for (KeyVaultCollaboratorVO old : existingCollaborators) {
+			if (old.getIdentifier() != null && !retained.contains(old.getIdentifier().toLowerCase())
+					&& old.getRoleAssignmentId() != null) {
+				RoleAssignmentResponseDto response = azureManagementClient.removeRoleAssignment(
+						keyVaultName, old.getRoleAssignmentId());
+				if (response.getErrorCode() != null && !"404".equals(response.getErrorCode())) {
+					warnings.add(new MessageDescription("Failed to remove collaborator " + old.getIdentifier()
+							+ ": " + response.getMessage()));
+				}
+			}
+		}
+	}
+
+	private void provisionCollaborator(String keyVaultName, KeyVaultCollaboratorVO collaborator,
+			List<MessageDescription> warnings) {
+		String kind = collaborator.getKind() == null ? "USER" : collaborator.getKind();
+		AzurePrincipalDto principal = azureManagementClient.resolvePrincipal(collaborator.getIdentifier(), kind);
+		if (principal == null || principal.getId() == null) {
+			warnings.add(new MessageDescription("Collaborator could not be resolved: " + collaborator.getIdentifier()));
+			return;
+		}
+		RoleAssignmentResponseDto response = azureManagementClient.assignRoleToUser(keyVaultName, principal.getId(),
+				"user", principal.getPrincipalType());
+		collaborator.setObjectId(principal.getId());
+		collaborator.setPrincipalType(principal.getPrincipalType());
+		collaborator.setRole("Crypto User");
+		collaborator.setRoleAssignmentId(response == null ? null : response.getId());
+		if (response != null && response.getErrorCode() != null && !"409".equals(response.getErrorCode())) {
+			warnings.add(new MessageDescription("Failed to assign collaborator " + collaborator.getIdentifier()
+					+ ": " + response.getMessage()));
 		}
 	}
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
@@ -113,6 +113,11 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 	}
 
 	@Override
+	public List<AzurePrincipalDto> searchPrincipals(String search) {
+		return azureManagementClient.searchPrincipals(search);
+	}
+
+	@Override
 	public ResponseEntity<KeyVaultResponseVO> createKeyVault(KeyVaultVO vo) {
 		KeyVaultResponseVO responseData = new KeyVaultResponseVO();
 		GenericMessage responseMessage = new GenericMessage();
@@ -364,13 +369,29 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 				continue;
 			}
 			KeyVaultCollaboratorVO old = existingByIdentifier.get(collaborator.getIdentifier().toLowerCase());
-			if (old != null && collaborator.getRoleAssignmentId() == null) {
-				collaborator.setObjectId(old.getObjectId());
-				collaborator.setPrincipalType(old.getPrincipalType());
-				collaborator.setRole(old.getRole());
-				collaborator.setRoleAssignmentId(old.getRoleAssignmentId());
+			if (old == null) {
+				provisionCollaborator(keyVaultName, collaborator, warnings);
+				continue;
 			}
-			if (old == null || old.getRoleAssignmentId() == null) {
+			boolean accessLevelChanged = !normalizeAccessLevel(old.getAccessLevel())
+					.equals(normalizeAccessLevel(collaborator.getAccessLevel()));
+			// Collaborators stored before access levels existed hold a single role, so grant them the full set.
+			boolean legacyAssignment = old.getAccessLevel() == null || old.getRoles() == null
+					|| old.getRoles().isEmpty();
+			if (accessLevelChanged || legacyAssignment) {
+				// Reading and Contributing map to disjoint role sets, so drop the obsolete assignments first.
+				removeCollaboratorAssignments(keyVaultName, old, warnings);
+				provisionCollaborator(keyVaultName, collaborator, warnings);
+				continue;
+			}
+			collaborator.setObjectId(old.getObjectId());
+			collaborator.setPrincipalType(old.getPrincipalType());
+			collaborator.setRole(old.getRole());
+			collaborator.setAccessLevel(old.getAccessLevel());
+			collaborator.setRoles(old.getRoles());
+			collaborator.setRoleAssignmentId(old.getRoleAssignmentId());
+			collaborator.setRoleAssignmentIds(old.getRoleAssignmentIds());
+			if (assignmentIdsOf(old).isEmpty()) {
 				provisionCollaborator(keyVaultName, collaborator, warnings);
 			}
 		}
@@ -378,15 +399,8 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 				.filter(c -> c.getIdentifier() != null)
 				.map(c -> c.getIdentifier().toLowerCase()).collect(Collectors.toSet());
 		for (KeyVaultCollaboratorVO old : existingCollaborators) {
-			if (old.getIdentifier() != null && !retained.contains(old.getIdentifier().toLowerCase())
-					&& old.getRoleAssignmentId() != null) {
-				RoleAssignmentResponseDto response = azureManagementClient.removeRoleAssignment(
-						keyVaultName, old.getRoleAssignmentId());
-				if (response.getErrorCode() != null && !"404".equals(response.getErrorCode())) {
-					// Keep partial Azure failures as warnings so collaborator issues do not abort the vault update.
-					warnings.add(new MessageDescription("Failed to remove collaborator " + old.getIdentifier()
-							+ ": " + response.getMessage()));
-				}
+			if (old.getIdentifier() != null && !retained.contains(old.getIdentifier().toLowerCase())) {
+				removeCollaboratorAssignments(keyVaultName, old, warnings);
 			}
 		}
 	}
@@ -399,15 +413,62 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 			warnings.add(new MessageDescription("Collaborator could not be resolved: " + collaborator.getIdentifier()));
 			return;
 		}
-		RoleAssignmentResponseDto response = azureManagementClient.assignRoleToUser(keyVaultName, principal.getId(),
-				"user", principal.getPrincipalType());
+		String accessLevel = normalizeAccessLevel(collaborator.getAccessLevel());
+		List<RoleAssignmentResponseDto> responses = azureManagementClient.assignAccessLevelRoles(keyVaultName,
+				principal.getId(), principal.getPrincipalType(), accessLevel);
+		List<String> grantedRoles = new ArrayList<>();
+		List<String> assignmentIds = new ArrayList<>();
+		for (RoleAssignmentResponseDto response : responses) {
+			if (response.getErrorCode() == null || "409".equals(response.getErrorCode())) {
+				grantedRoles.add(response.getRoleName());
+				if (response.getRoleAssignmentId() != null) {
+					assignmentIds.add(response.getRoleAssignmentId());
+				}
+			} else {
+				warnings.add(new MessageDescription("Failed to assign role " + response.getRoleName()
+						+ " to collaborator " + collaborator.getIdentifier() + ": " + response.getMessage()));
+			}
+		}
 		collaborator.setObjectId(principal.getId());
 		collaborator.setPrincipalType(principal.getPrincipalType());
-		collaborator.setRole("Crypto User");
-		collaborator.setRoleAssignmentId(response == null ? null : response.getRoleAssignmentId());
-		if (response != null && response.getErrorCode() != null && !"409".equals(response.getErrorCode())) {
-			warnings.add(new MessageDescription("Failed to assign collaborator " + collaborator.getIdentifier()
-					+ ": " + response.getMessage()));
+		collaborator.setAccessLevel(accessLevel);
+		collaborator.setRole(accessLevel);
+		collaborator.setRoles(grantedRoles);
+		collaborator.setRoleAssignmentIds(assignmentIds);
+		collaborator.setRoleAssignmentId(assignmentIds.isEmpty() ? null : assignmentIds.get(0));
+	}
+
+	private String normalizeAccessLevel(String accessLevel) {
+		return AzureManagementClient.ACCESS_LEVEL_CONTRIBUTING.equalsIgnoreCase(accessLevel)
+				? AzureManagementClient.ACCESS_LEVEL_CONTRIBUTING : AzureManagementClient.ACCESS_LEVEL_READING;
+	}
+
+	/**
+	 * Collaborators provisioned before access levels existed hold a single assignment id, newer ones hold one per
+	 * granted role.
+	 */
+	private List<String> assignmentIdsOf(KeyVaultCollaboratorVO collaborator) {
+		List<String> assignmentIds = new ArrayList<>();
+		if (collaborator.getRoleAssignmentIds() != null) {
+			collaborator.getRoleAssignmentIds().stream().filter(id -> id != null && !id.isBlank())
+					.forEach(assignmentIds::add);
+		}
+		if (collaborator.getRoleAssignmentId() != null && !collaborator.getRoleAssignmentId().isBlank()
+				&& !assignmentIds.contains(collaborator.getRoleAssignmentId())) {
+			assignmentIds.add(collaborator.getRoleAssignmentId());
+		}
+		return assignmentIds;
+	}
+
+	private void removeCollaboratorAssignments(String keyVaultName, KeyVaultCollaboratorVO collaborator,
+			List<MessageDescription> warnings) {
+		for (String assignmentId : assignmentIdsOf(collaborator)) {
+			RoleAssignmentResponseDto response = azureManagementClient.removeRoleAssignment(keyVaultName, assignmentId);
+			if (response.getErrorCode() != null && !"404".equals(response.getErrorCode())) {
+				// Keep partial Azure failures as warnings so collaborator issues do not abort the vault update.
+				warnings.add(new MessageDescription("Failed to remove collaborator " + collaborator.getIdentifier()
+						+ ": " + response.getMessage()));
+			}
 		}
 	}
 }

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
@@ -65,7 +65,8 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 
 		try {
 			List<AzureKeyVaultNsql> keyVaults;
-			
+			long totalCount;
+
 			if (createdBy != null && !createdBy.isBlank()) {
 				String collaboratorIdentifier = null;
 				try {
@@ -74,9 +75,11 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 					log.warn("Unable to resolve current user's email for collaborator lookup");
 				}
 				keyVaults = customRepo.findAllByCreatorOrCollaborator(createdBy, collaboratorIdentifier, limit, offset);
+				totalCount = customRepo.countByCreatorOrCollaborator(createdBy, collaboratorIdentifier);
 			} else {
 				log.warn("Attempt to fetch Key Vaults with no createdBy user ID.");
 				keyVaults = new ArrayList<>();
+				totalCount = 0L;
 			}
 
 			List<KeyVaultVO> keyVaultVOs = keyVaults.stream()
@@ -84,7 +87,7 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 					.collect(Collectors.toList());
 			
 			collection.setRecords(keyVaultVOs);
-			collection.setTotalCount(keyVaultVOs.size());
+			collection.setTotalCount((int) totalCount);
 			message.setSuccess("SUCCESS");
 
 		} catch (Exception e) {

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
@@ -76,6 +76,9 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 				}
 				keyVaults = customRepo.findAllByCreatorOrCollaborator(createdBy, collaboratorIdentifier, limit, offset);
 				totalCount = customRepo.countByCreatorOrCollaborator(createdBy, collaboratorIdentifier);
+				log.info("Fetched {} of {} Key Vaults for user {} with collaborator lookup {}", keyVaults.size(),
+						totalCount, createdBy,
+						collaboratorIdentifier != null && !collaboratorIdentifier.isBlank() ? "enabled" : "disabled");
 			} else {
 				log.warn("Attempt to fetch Key Vaults with no createdBy user ID.");
 				keyVaults = new ArrayList<>();

--- a/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
+++ b/packages/fabric-backend/lib/src/main/java/com/daimler/data/service/azureKeyVault/BaseAzureKeyVaultService.java
@@ -57,14 +57,6 @@ public class BaseAzureKeyVaultService extends BaseCommonService<KeyVaultVO, Azur
 	private UserStore userStore;
 
 	@Override
-	public List<AzurePrincipalDto> searchPrincipals(String search) {
-		if (search == null || search.isBlank() || search.trim().length() < 3) {
-			return List.of();
-		}
-		return azureManagementClient.searchPrincipals(search);
-	}
-
-	@Override
 	public KeyVaultCollectionVO getAllKeyVaults(int limit, int offset, String createdBy) {
 		KeyVaultCollectionVO collection = new KeyVaultCollectionVO();
 		GenericMessage message = new GenericMessage();

--- a/packages/fabric-backend/lib/src/main/resources/api/fabricWorkspaces.yaml
+++ b/packages/fabric-backend/lib/src/main/resources/api/fabricWorkspaces.yaml
@@ -669,6 +669,27 @@ paths:
         500:
           description: "Internal error"
 
+  /fabric-workspaces/keyVault/principals:
+    get:
+      tags:
+        - "fabric-workspaces"
+      summary: "Search Entra ID principals for Key Vault collaborators"
+      operationId: "searchKeyVaultPrincipals"
+      parameters:
+        - name: search
+          in: query
+          required: true
+          type: string
+      responses:
+        200:
+          description: "Matching users and service principals"
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/AzurePrincipalVO"
+        500:
+          description: "Internal error"
+
   /fabric-workspaces/keyVault:
     post:
       tags:
@@ -1625,6 +1646,48 @@ definitions:
         type: string
         format: date
         description: "Creation timestamp"
+      collaborators:
+        type: array
+        items:
+          $ref: "#/definitions/KeyVaultCollaboratorVO"
+
+  KeyVaultCollaboratorVO:
+    type: object
+    properties:
+      identifier:
+        type: string
+      objectId:
+        type: string
+      principalType:
+        type: string
+      kind:
+        type: string
+      displayName:
+        type: string
+      role:
+        type: string
+      roleAssignmentId:
+        type: string
+
+  AzurePrincipalVO:
+    type: object
+    properties:
+      id:
+        type: string
+      displayName:
+        type: string
+      mail:
+        type: string
+      appId:
+        type: string
+      servicePrincipalType:
+        type: string
+      principalType:
+        type: string
+      kind:
+        type: string
+      identifier:
+        type: string
 
   KeyVaultCollectionVO:
     description: "Collection of Azure Key Vaults with pagination info"

--- a/packages/fabric-backend/lib/src/main/resources/api/fabricWorkspaces.yaml
+++ b/packages/fabric-backend/lib/src/main/resources/api/fabricWorkspaces.yaml
@@ -669,27 +669,6 @@ paths:
         500:
           description: "Internal error"
 
-  /fabric-workspaces/keyVault/principals:
-    get:
-      tags:
-        - "fabric-workspaces"
-      summary: "Search Entra ID principals for Key Vault collaborators"
-      operationId: "searchKeyVaultPrincipals"
-      parameters:
-        - name: search
-          in: query
-          required: true
-          type: string
-      responses:
-        200:
-          description: "Matching users and service principals"
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/AzurePrincipalVO"
-        500:
-          description: "Internal error"
-
   /fabric-workspaces/keyVault:
     post:
       tags:
@@ -1656,6 +1635,12 @@ definitions:
     properties:
       identifier:
         type: string
+      shortId:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
       objectId:
         type: string
       principalType:
@@ -1669,25 +1654,6 @@ definitions:
       roleAssignmentId:
         type: string
 
-  AzurePrincipalVO:
-    type: object
-    properties:
-      id:
-        type: string
-      displayName:
-        type: string
-      mail:
-        type: string
-      appId:
-        type: string
-      servicePrincipalType:
-        type: string
-      principalType:
-        type: string
-      kind:
-        type: string
-      identifier:
-        type: string
 
   KeyVaultCollectionVO:
     description: "Collection of Azure Key Vaults with pagination info"

--- a/packages/fabric-backend/lib/src/main/resources/api/fabricWorkspaces.yaml
+++ b/packages/fabric-backend/lib/src/main/resources/api/fabricWorkspaces.yaml
@@ -737,6 +737,33 @@ paths:
           schema:
             $ref: "#/definitions/KeyVaultCollectionVO"
 
+  /fabric-workspaces/keyVault/principals:
+    get:
+      tags:
+        - "fabric-workspaces"
+      summary: "Search Entra ID principals for Key Vault collaborators"
+      description: "Searches Entra ID (Microsoft Graph) and returns users, service principals and managed identities matching the search term."
+      operationId: "searchKeyVaultPrincipals"
+      parameters:
+        - name: search
+          in: query
+          description: "Search term, at least three characters"
+          required: true
+          type: string
+      responses:
+        200:
+          description: "Matching Entra ID principals"
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/AzurePrincipalVO"
+        401:
+          description: "Request does not have sufficient credentials."
+        403:
+          description: "Request is not authorized."
+        500:
+          description: "Internal error"
+
   /fabric-workspaces/keyVault/{id}:
     put:
       tags:
@@ -1651,9 +1678,44 @@ definitions:
         type: string
       role:
         type: string
+      accessLevel:
+        type: string
+        description: "Access level granted to the collaborator. Reading or Contributing."
+      roles:
+        type: array
+        description: "Azure Key Vault roles granted for the selected access level"
+        items:
+          type: string
       roleAssignmentId:
         type: string
+      roleAssignmentIds:
+        type: array
+        description: "Identifiers of the Azure role assignments created for this collaborator"
+        items:
+          type: string
 
+
+  AzurePrincipalVO:
+    type: object
+    description: "Entra ID principal - user, service principal or managed identity"
+    properties:
+      id:
+        type: string
+      displayName:
+        type: string
+      mail:
+        type: string
+      appId:
+        type: string
+      servicePrincipalType:
+        type: string
+      principalType:
+        type: string
+      kind:
+        type: string
+        description: "USER, SPN or MI"
+      identifier:
+        type: string
 
   KeyVaultCollectionVO:
     description: "Collection of Azure Key Vaults with pagination info"

--- a/packages/fabric-backend/lib/src/main/resources/application.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application.yml
@@ -116,6 +116,7 @@ fabricWorkspaces:
       checkNameUrl: ${AZURE_KEYVAULT_CHECK_NAME_URL:XXXX}
       roleAssignmentUrl: ${AZURE_ROLE_ASSIGNMENT_URL:XXXX}
       userSearchUrl: ${AZURE_USER_SEARCH_URL:XXXX}
+      servicePrincipalSearchUrl: ${AZURE_SP_SEARCH_URL:XXXX}
       roles:
         cryptoOfficer: ${KEYVAULT_CRYPTO_OFFICER_ROLE:XXXX}
         cryptoUser: ${KEYVAULT_CRYPTO_USER_ROLE:XXXX}

--- a/packages/fabric-backend/lib/src/main/resources/application.yml
+++ b/packages/fabric-backend/lib/src/main/resources/application.yml
@@ -121,6 +121,10 @@ fabricWorkspaces:
         cryptoOfficer: ${KEYVAULT_CRYPTO_OFFICER_ROLE:XXXX}
         cryptoUser: ${KEYVAULT_CRYPTO_USER_ROLE:XXXX}
         keyVaultAdminRole: ${KEYVAULT_ADMIN_ROLE:XXXX}
+        certificatesUser: ${KEYVAULT_CERTIFICATES_USER_ROLE:XXXX}
+        secretsUser: ${KEYVAULT_SECRETS_USER_ROLE:XXXX}
+        certificatesOfficer: ${KEYVAULT_CERTIFICATES_OFFICER_ROLE:XXXX}
+        secretsOfficer: ${KEYVAULT_SECRETS_OFFICER_ROLE:XXXX}
 
 genesis:
   apiKey: ${GENESIS_API_KEY:XXXX}

--- a/packages/frontend/src/components/mbc/azureKeyVault/AzureKeyVault.tsx
+++ b/packages/frontend/src/components/mbc/azureKeyVault/AzureKeyVault.tsx
@@ -12,10 +12,14 @@ import { ApiClient } from '../../../../src/services/ApiClient';
 import CreateNewKeyVault from './createNewKeyVault/CreateNewKeyVault';
 import Modal from '../../formElements/modal/Modal';
 import { useHistory } from 'react-router-dom';
-import { IKeyVault } from 'globals/types';
+import { IKeyVault, IUserInfo } from 'globals/types';
 import AzureKeyVaultCard from './AzureKeyVaultCard';
 
-const AzureKeyVault = () => {
+interface Props {
+  user: IUserInfo;
+}
+
+const AzureKeyVault = ({ user }: Props) => {
   const [keyVaultList, setKeyVaultList] = useState([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -42,6 +46,9 @@ const AzureKeyVault = () => {
         ProgressIndicator.hide();
       });
   };
+
+  const isCreator = (keyVault: IKeyVault) =>
+    !!user?.id && keyVault?.createdBy?.id?.toLowerCase() === user.id.toLowerCase();
 
   const onEditWorkspace = (keyVault : IKeyVault) => {
     setSelectedKeyVault(keyVault);
@@ -87,6 +94,7 @@ const AzureKeyVault = () => {
                   <AzureKeyVaultCard
                     key={index}
                     project={project}
+                    canEdit={isCreator(project)}
                     onEditWorkspace={() => onEditWorkspace(project)}
                   />
                 );

--- a/packages/frontend/src/components/mbc/azureKeyVault/AzureKeyVault.tsx
+++ b/packages/frontend/src/components/mbc/azureKeyVault/AzureKeyVault.tsx
@@ -13,7 +13,9 @@ import CreateNewKeyVault from './createNewKeyVault/CreateNewKeyVault';
 import Modal from '../../formElements/modal/Modal';
 import { useHistory } from 'react-router-dom';
 import { IKeyVault, IUserInfo } from 'globals/types';
+import { SESSION_STORAGE_KEYS } from 'globals/constants';
 import AzureKeyVaultCard from './AzureKeyVaultCard';
+import Pagination from '../pagination/Pagination';
 
 interface Props {
   user: IUserInfo;
@@ -25,6 +27,30 @@ const AzureKeyVault = ({ user }: Props) => {
   const [isEditMode, setIsEditMode] = useState(false);
   const [selectedKeyVault, setSelectedKeyVault] = useState<IKeyVault | null>(null);
 
+  const [totalNumberOfPages, setTotalNumberOfPages] = useState(1);
+  const [currentPageNumber, setCurrentPageNumber] = useState(1);
+  const [currentPageOffset, setCurrentPageOffset] = useState(0);
+  const [maxItemsPerPage, setMaxItemsPerPage] = useState(
+    parseInt(sessionStorage.getItem(SESSION_STORAGE_KEYS.PAGINATION_MAX_ITEMS_PER_PAGE), 10) || 15,
+  );
+
+  const onPaginationPreviousClick = () => {
+    const currentPageNum = currentPageNumber - 1;
+    setCurrentPageNumber(currentPageNum);
+    setCurrentPageOffset((currentPageNum - 1) * maxItemsPerPage);
+  };
+
+  const onPaginationNextClick = () => {
+    setCurrentPageOffset(currentPageNumber * maxItemsPerPage);
+    setCurrentPageNumber(currentPageNumber + 1);
+  };
+
+  const onViewByPageNum = (pageNum: number) => {
+    setCurrentPageNumber(1);
+    setCurrentPageOffset(0);
+    setMaxItemsPerPage(pageNum);
+  };
+
   const History = useHistory();
   const goback = () => {
     History.goBack();
@@ -32,14 +58,17 @@ const AzureKeyVault = ({ user }: Props) => {
 
   useEffect(() => {
     getKeyVaultList();
-  }, []);
+  }, [maxItemsPerPage, currentPageNumber, currentPageOffset]);
 
   const getKeyVaultList = () => {
     ProgressIndicator.show();
     Tooltip.defaultSetup();
-    ApiClient.getKeyVaults()
+    ApiClient.getKeyVaults(currentPageOffset, maxItemsPerPage)
       .then((response) => {
         setKeyVaultList(response?.records || []);
+        const totalPages = Math.ceil((response?.totalCount || 0) / maxItemsPerPage) || 1;
+        setTotalNumberOfPages(totalPages);
+        setCurrentPageNumber(currentPageNumber > totalPages ? 1 : currentPageNumber);
         ProgressIndicator.hide();
       })
       .catch((err) => {
@@ -100,6 +129,16 @@ const AzureKeyVault = ({ user }: Props) => {
                 );
               })}
             </div>
+          )}
+          {keyVaultList?.length > 0 && (
+            <Pagination
+              totalPages={totalNumberOfPages}
+              pageNumber={currentPageNumber}
+              onPreviousClick={onPaginationPreviousClick}
+              onNextClick={onPaginationNextClick}
+              onViewByNumbers={onViewByPageNum}
+              displayByPage={true}
+            />
           )}
         </div>
       </div>

--- a/packages/frontend/src/components/mbc/azureKeyVault/AzureKeyVaultCard.tsx
+++ b/packages/frontend/src/components/mbc/azureKeyVault/AzureKeyVaultCard.tsx
@@ -44,6 +44,10 @@ const AzureKeyVaultCard = ({ project, onEditWorkspace}: Props) => {
               <div>{project?.createdBy?.firstName + ' ' + project?.createdBy?.lastName}</div>
             </div>
             <div>
+              <div>Collaborators</div>
+              <div>{project?.collaborators?.map((item) => item.displayName || item.identifier).join(', ') || 'None'}</div>
+            </div>
+            <div>
               <div>Create On</div>
               <div>{regionalDateAndTimeConversion(project?.createdOn)}</div>
             </div>
@@ -66,4 +70,3 @@ const AzureKeyVaultCard = ({ project, onEditWorkspace}: Props) => {
 };
 
 export default AzureKeyVaultCard;
-

--- a/packages/frontend/src/components/mbc/azureKeyVault/AzureKeyVaultCard.tsx
+++ b/packages/frontend/src/components/mbc/azureKeyVault/AzureKeyVaultCard.tsx
@@ -10,10 +10,11 @@ import { IKeyVault } from 'globals/types';
 
 interface Props {
   project: IKeyVault;
+  canEdit: boolean;
   onEditWorkspace: (project: IKeyVault) => void;
 }
 
-const AzureKeyVaultCard = ({ project, onEditWorkspace}: Props) => {
+const AzureKeyVaultCard = ({ project, canEdit, onEditWorkspace}: Props) => {
 
   useEffect(() => {
     SelectBox.defaultSetup();
@@ -56,7 +57,12 @@ const AzureKeyVaultCard = ({ project, onEditWorkspace}: Props) => {
         <div className={Styles.cardFooter}>
           <div>&nbsp;</div>
           <div className={Styles.btnGrp}>
-            <button className="btn btn-primary" onClick={() => onEditWorkspace(project)}>
+            <button
+              className="btn btn-primary"
+              disabled={!canEdit}
+              onClick={() => onEditWorkspace(project)}
+              tooltip-data={canEdit ? 'Edit' : 'Only the creator can edit this Key Vault'}
+            >
               <i className="icon mbc-icon edit"></i>
             </button>
             {/* <button className="btn btn-primary" onClick={() => {}} disabled={true}>

--- a/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.scss
+++ b/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.scss
@@ -89,6 +89,74 @@
       }
     }
   
+    .collaboratorSection {
+      .collaboratorSectionEmpty {
+        width: 100%;
+        height: 100px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        p {
+          margin: 0;
+        }
+      }
+      .collaboratorSectionList {
+        font-size: var(--font-size-smallest);
+        border: 1px solid #383f49;
+        margin-top: 12px;
+        padding: 20px 12px 0;
+        .collaboratorSectionListAdd {
+          margin: 13px auto;
+          width: 90%;
+        }
+        .collaboratorList {
+          width: 90%;
+          margin: 0 auto;
+          margin-top: 12px;
+          margin-bottom: 15px;
+          .collaboratorTitle {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            width: 100%;
+            padding-bottom: 15px;
+            border-bottom: 1px solid #383f49;
+            color: #99a5b3;
+          }
+          .collaboratorContent {
+            display: flex;
+            align-items: center;
+            flex-direction: column;
+            max-height: 150px;
+            width: 100%;
+            padding-top: 3px;
+            .collaboratorContentRow {
+              padding: 10px 0;
+              display: flex;
+              align-items: center;
+              justify-content: space-between;
+              width: 100%;
+            }
+          }
+          .collaboratorTitleCol {
+            flex: 1;
+            &:first-child {
+              max-width: 80px;
+            }
+            &:last-child {
+              max-width: 40px;
+              text-align: right;
+            }
+          }
+          .deleteBtn {
+            padding: 0;
+            background: transparent;
+            border: 0;
+          }
+        }
+      }
+    }
+
     .codeSpaceDetails {
       margin: 20px 0;
       label {

--- a/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.scss
+++ b/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.scss
@@ -108,6 +108,43 @@
         .collaboratorSectionListAdd {
           margin: 13px auto;
           width: 90%;
+          .principalSearch {
+            display: flex;
+            align-items: flex-end;
+            gap: 12px;
+            > div:first-child {
+              flex: 1;
+            }
+            > div {
+              margin: 0;
+            }
+          }
+          .principalResults {
+            display: flex;
+            flex-direction: column;
+            max-height: 150px;
+            margin-top: 10px;
+            border: 1px solid #383f49;
+            .principalResult {
+              display: flex;
+              justify-content: space-between;
+              gap: 10px;
+              width: 100%;
+              padding: 8px 10px;
+              background: transparent;
+              border: 0;
+              border-bottom: 1px solid #383f49;
+              color: inherit;
+              text-align: left;
+              cursor: pointer;
+              &:last-child {
+                border-bottom: 0;
+              }
+              &:hover {
+                background: #2b3138;
+              }
+            }
+          }
         }
         .collaboratorList {
           width: 90%;
@@ -140,8 +177,10 @@
           }
           .collaboratorTitleCol {
             flex: 1;
-            &:first-child {
-              max-width: 80px;
+            padding-right: 8px;
+            word-break: break-all;
+            .collaboratorAccessSelect {
+              min-width: 120px;
             }
             &:last-child {
               max-width: 40px;

--- a/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.tsx
+++ b/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.tsx
@@ -154,7 +154,7 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
   };
 
   const searchPrincipals = () => {
-    if (!principalSearch.trim()) {
+    if (principalSearch.trim().length < 3) {
       setPrincipalResults([]);
       return;
     }
@@ -164,15 +164,19 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
   };
 
   const addCollaborator = (principal: IKeyVaultPrincipal) => {
-    if (collaborators.some((item) => item.identifier.toLowerCase() === principal.identifier.toLowerCase())) {
+    const identifier = principal.identifier || principal.mail || principal.appId || principal.displayName;
+    if (!identifier) {
+      return;
+    }
+    if (collaborators.some((item) => item.identifier?.toLowerCase() === identifier.toLowerCase())) {
       Notification.show('Collaborator already exists.', 'warning');
       return;
     }
     setCollaborators([
       ...collaborators,
       {
-        identifier: principal.identifier,
-        displayName: principal.displayName || principal.mail || principal.identifier,
+        identifier,
+        displayName: principal.displayName || principal.mail || principal.appId || identifier,
         kind: principal.kind,
         principalType: principal.principalType,
         role: 'Crypto User',

--- a/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.tsx
+++ b/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.tsx
@@ -8,7 +8,7 @@ import ProgressIndicator from '../../../../assets/modules/uilab/js/src/progress-
 import { CodeSpaceApiClient } from '../../../../services/CodeSpaceApiClient';
 import { ApiClient } from '../../../../services/ApiClient';
 import TextBox from '../../shared/textBox/TextBox';
-import { IKeyVault } from 'globals/types';
+import { IKeyVault, IKeyVaultCollaborator, IKeyVaultPrincipal } from 'globals/types';
 
 interface Props {
   edit?: boolean;
@@ -43,6 +43,9 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
   const [subDivisions, setSubDivisions] = useState([]);
   const [departments, setDepartments] = useState([]);
   const [dataClassificationDropdown, setDataClassificationDropdown] = useState([]);
+  const [collaborators, setCollaborators] = useState<IKeyVaultCollaborator[]>(project?.collaborators || []);
+  const [principalSearch, setPrincipalSearch] = useState('');
+  const [principalResults, setPrincipalResults] = useState<IKeyVaultPrincipal[]>([]);
 
   const requiredError = '*Missing entry';
   const keyVaultNameErrorText = '*Key Vault Name should start with kv-';
@@ -150,6 +153,35 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
     }
   };
 
+  const searchPrincipals = () => {
+    if (!principalSearch.trim()) {
+      setPrincipalResults([]);
+      return;
+    }
+    ApiClient.searchKeyVaultPrincipals(principalSearch.trim())
+      .then((results: IKeyVaultPrincipal[]) => setPrincipalResults(results || []))
+      .catch(() => Notification.show('Unable to search Entra ID principals.', 'alert'));
+  };
+
+  const addCollaborator = (principal: IKeyVaultPrincipal) => {
+    if (collaborators.some((item) => item.identifier.toLowerCase() === principal.identifier.toLowerCase())) {
+      Notification.show('Collaborator already exists.', 'warning');
+      return;
+    }
+    setCollaborators([
+      ...collaborators,
+      {
+        identifier: principal.identifier,
+        displayName: principal.displayName || principal.mail || principal.identifier,
+        kind: principal.kind,
+        principalType: principal.principalType,
+        role: 'Crypto User',
+      },
+    ]);
+    setPrincipalResults([]);
+    setPrincipalSearch('');
+  };
+
   const createKeyVault = () => {
     let formValid = true;
     const keyVaultNameValidationError = getKeyVaultNameValidationError(keyVaultName);
@@ -185,6 +217,7 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
           department: department[0],
           dataClassification: dataClassification,
           hasPii: hasPii,
+          collaborators: collaborators,
         },
       };
       ProgressIndicator.show();
@@ -428,6 +461,54 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
                 <span className="label">No</span>
               </label>
             </div>
+          </div>
+        </div>
+        <div className="input-field-group">
+          <label className="input-label">Collaborators</label>
+          <div className={Styles.flexLayout}>
+            <input
+              className="input-field"
+              value={principalSearch}
+              placeholder="Search users, service principals, or managed identities"
+              onChange={(event) => setPrincipalSearch(event.currentTarget.value)}
+              onKeyDown={(event) => event.key === 'Enter' && searchPrincipals()}
+            />
+            <button className="btn btn-secondary" type="button" onClick={searchPrincipals}>
+              Search
+            </button>
+          </div>
+          {principalResults.length > 0 && (
+            <div className="chips">
+              {principalResults.map((principal) => (
+                <button
+                  className="btn btn-text"
+                  type="button"
+                  key={principal.id}
+                  onClick={() => addCollaborator(principal)}
+                >
+                  {principal.displayName || principal.mail || principal.identifier} ({principal.kind})
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="chips">
+            {collaborators.map((collaborator) => (
+              <span className="chip" key={collaborator.identifier}>
+                {collaborator.displayName || collaborator.identifier} ({collaborator.kind})
+                <button
+                  className="btn btn-text"
+                  type="button"
+                  aria-label={`Remove ${collaborator.identifier}`}
+                  onClick={() =>
+                    setCollaborators(
+                      collaborators.filter((item) => item.identifier !== collaborator.identifier),
+                    )
+                  }
+                >
+                  ×
+                </button>
+              </span>
+            ))}
           </div>
         </div>
         <div className={Styles.newCodeSpaceBtn}>

--- a/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.tsx
+++ b/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.tsx
@@ -8,7 +8,8 @@ import ProgressIndicator from '../../../../assets/modules/uilab/js/src/progress-
 import { CodeSpaceApiClient } from '../../../../services/CodeSpaceApiClient';
 import { ApiClient } from '../../../../services/ApiClient';
 import TextBox from '../../shared/textBox/TextBox';
-import { IKeyVault, IKeyVaultCollaborator, IKeyVaultPrincipal } from 'globals/types';
+import AddUser from '../../addUser/AddUser';
+import { IKeyVault, IKeyVaultCollaborator, IUserDetails } from 'globals/types';
 
 interface Props {
   edit?: boolean;
@@ -44,8 +45,6 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
   const [departments, setDepartments] = useState([]);
   const [dataClassificationDropdown, setDataClassificationDropdown] = useState([]);
   const [collaborators, setCollaborators] = useState<IKeyVaultCollaborator[]>(project?.collaborators || []);
-  const [principalSearch, setPrincipalSearch] = useState('');
-  const [principalResults, setPrincipalResults] = useState<IKeyVaultPrincipal[]>([]);
 
   const requiredError = '*Missing entry';
   const keyVaultNameErrorText = '*Key Vault Name should start with kv-';
@@ -153,37 +152,39 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
     }
   };
 
-  const searchPrincipals = () => {
-    if (principalSearch.trim().length < 3) {
-      setPrincipalResults([]);
-      return;
-    }
-    ApiClient.searchKeyVaultPrincipals(principalSearch.trim())
-      .then((results: IKeyVaultPrincipal[]) => setPrincipalResults(results || []))
-      .catch(() => Notification.show('Unable to search Entra ID principals.', 'alert'));
-  };
-
-  const addCollaborator = (principal: IKeyVaultPrincipal) => {
-    const identifier = principal.identifier || principal.mail || principal.appId || principal.displayName;
+  const getCollabarators = (collaborator: IUserDetails) => {
+    const identifier = collaborator?.email;
     if (!identifier) {
+      Notification.show('Selected user has no email address and cannot be added as collaborator.', 'warning');
       return;
     }
     if (collaborators.some((item) => item.identifier?.toLowerCase() === identifier.toLowerCase())) {
-      Notification.show('Collaborator already exists.', 'warning');
+      Notification.show('Collaborator Already Exist.', 'warning');
+      return;
+    }
+    if (project?.createdBy?.id && project?.createdBy?.id === collaborator.shortId) {
+      Notification.show(
+        `${collaborator.firstName} ${collaborator.lastName} is a creator. Creator can't be added as collaborator.`,
+        'warning',
+      );
       return;
     }
     setCollaborators([
       ...collaborators,
       {
         identifier,
-        displayName: principal.displayName || principal.mail || principal.appId || identifier,
-        kind: principal.kind,
-        principalType: principal.principalType,
+        shortId: collaborator.shortId,
+        firstName: collaborator.firstName,
+        lastName: collaborator.lastName,
+        displayName: [collaborator.firstName, collaborator.lastName].filter(Boolean).join(' ') || identifier,
+        kind: 'USER',
         role: 'Crypto User',
       },
     ]);
-    setPrincipalResults([]);
-    setPrincipalSearch('');
+  };
+
+  const onCollaboratorDelete = (identifier: string) => {
+    setCollaborators(collaborators.filter((item) => item.identifier !== identifier));
   };
 
   const createKeyVault = () => {
@@ -467,52 +468,53 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
             </div>
           </div>
         </div>
-        <div className="input-field-group">
-          <label className="input-label">Collaborators</label>
-          <div className={Styles.flexLayout}>
-            <input
-              className="input-field"
-              value={principalSearch}
-              placeholder="Search users, service principals, or managed identities"
-              onChange={(event) => setPrincipalSearch(event.currentTarget.value)}
-              onKeyDown={(event) => event.key === 'Enter' && searchPrincipals()}
-            />
-            <button className="btn btn-secondary" type="button" onClick={searchPrincipals}>
-              Search
-            </button>
-          </div>
-          {principalResults.length > 0 && (
-            <div className="chips">
-              {principalResults.map((principal) => (
-                <button
-                  className="btn btn-text"
-                  type="button"
-                  key={principal.id}
-                  onClick={() => addCollaborator(principal)}
-                >
-                  {principal.displayName || principal.mail || principal.identifier} ({principal.kind})
-                </button>
-              ))}
+        <div className={classNames('input-field-group include-error')}>
+          <label htmlFor="userId" className="input-label">
+            Find and add the collaborators you want to share this Key Vault with (Optional)
+          </label>
+          <div className={Styles.collaboratorSection}>
+            <div className={Styles.collaboratorSectionList}>
+              <div className={Styles.collaboratorSectionListAdd}>
+                <AddUser getCollabarators={getCollabarators} dagId={''} isRequired={false} isUserprivilegeSearch={false} />
+              </div>
+              <div className={Styles.collaboratorList}>
+                {collaborators?.length > 0 ? (
+                  <>
+                    <div className={Styles.collaboratorTitle}>
+                      <div className={Styles.collaboratorTitleCol}>User ID</div>
+                      <div className={Styles.collaboratorTitleCol}>Name</div>
+                      <div className={Styles.collaboratorTitleCol}>Permission</div>
+                      <div className={Styles.collaboratorTitleCol}></div>
+                    </div>
+                    <div className={classNames('mbc-scroll', Styles.collaboratorContent)}>
+                      {collaborators.map((collaborator) => (
+                        <div key={collaborator.identifier} className={Styles.collaboratorContentRow}>
+                          <div className={Styles.collaboratorTitleCol}>{collaborator.shortId}</div>
+                          <div className={Styles.collaboratorTitleCol}>
+                            {collaborator.displayName || collaborator.identifier}
+                          </div>
+                          <div className={Styles.collaboratorTitleCol}>{collaborator.role || 'Crypto User'}</div>
+                          <div className={Styles.collaboratorTitleCol}>
+                            <button
+                              className={classNames('btn btn-primary', Styles.deleteBtn)}
+                              type="button"
+                              aria-label={`Remove ${collaborator.identifier}`}
+                              onClick={() => onCollaboratorDelete(collaborator.identifier)}
+                            >
+                              <i className="icon delete" />
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                ) : (
+                  <div className={Styles.collaboratorSectionEmpty}>
+                    <p>No collaborator added.</p>
+                  </div>
+                )}
+              </div>
             </div>
-          )}
-          <div className="chips">
-            {collaborators.map((collaborator) => (
-              <span className="chip" key={collaborator.identifier}>
-                {collaborator.displayName || collaborator.identifier} ({collaborator.kind})
-                <button
-                  className="btn btn-text"
-                  type="button"
-                  aria-label={`Remove ${collaborator.identifier}`}
-                  onClick={() =>
-                    setCollaborators(
-                      collaborators.filter((item) => item.identifier !== collaborator.identifier),
-                    )
-                  }
-                >
-                  ×
-                </button>
-              </span>
-            ))}
           </div>
         </div>
         <div className={Styles.newCodeSpaceBtn}>

--- a/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.tsx
+++ b/packages/frontend/src/components/mbc/azureKeyVault/createNewKeyVault/CreateNewKeyVault.tsx
@@ -8,8 +8,9 @@ import ProgressIndicator from '../../../../assets/modules/uilab/js/src/progress-
 import { CodeSpaceApiClient } from '../../../../services/CodeSpaceApiClient';
 import { ApiClient } from '../../../../services/ApiClient';
 import TextBox from '../../shared/textBox/TextBox';
-import AddUser from '../../addUser/AddUser';
-import { IKeyVault, IKeyVaultCollaborator, IUserDetails } from 'globals/types';
+import { IKeyVault, IKeyVaultAccessLevel, IKeyVaultCollaborator, IKeyVaultPrincipal } from 'globals/types';
+
+const ACCESS_LEVELS: IKeyVaultAccessLevel[] = ['Reading', 'Contributing'];
 
 interface Props {
   edit?: boolean;
@@ -45,6 +46,10 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
   const [departments, setDepartments] = useState([]);
   const [dataClassificationDropdown, setDataClassificationDropdown] = useState([]);
   const [collaborators, setCollaborators] = useState<IKeyVaultCollaborator[]>(project?.collaborators || []);
+  const [principalSearch, setPrincipalSearch] = useState('');
+  const [principalResults, setPrincipalResults] = useState<IKeyVaultPrincipal[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [accessLevel, setAccessLevel] = useState<IKeyVaultAccessLevel>('Reading');
 
   const requiredError = '*Missing entry';
   const keyVaultNameErrorText = '*Key Vault Name should start with kv-';
@@ -116,6 +121,10 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
     }
   }, [division]);
 
+  useEffect(() => {
+    SelectBox.defaultSetup();
+  }, [collaborators]);
+
   const onKeyVaultNameChange = (e: any) => {
     const currentValue = e.currentTarget.value;
     setKeyVaultName(currentValue);
@@ -152,35 +161,57 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
     }
   };
 
-  const getCollabarators = (collaborator: IUserDetails) => {
-    const identifier = collaborator?.email;
+  const searchPrincipals = () => {
+    const term = principalSearch.trim();
+    if (term.length < 3) {
+      setPrincipalResults([]);
+      Notification.show('Please enter at least 3 characters to search.', 'warning');
+      return;
+    }
+    setSearching(true);
+    ApiClient.searchKeyVaultPrincipals(term)
+      .then((results: IKeyVaultPrincipal[]) => {
+        setSearching(false);
+        setPrincipalResults(results || []);
+        if (!results?.length) {
+          Notification.show('No users, service principals or managed identities found.', 'warning');
+        }
+      })
+      .catch(() => {
+        setSearching(false);
+        Notification.show('Unable to search Entra ID principals.', 'alert');
+      });
+  };
+
+  const addCollaborator = (principal: IKeyVaultPrincipal) => {
+    const identifier = principal.identifier || principal.mail || principal.appId || principal.displayName;
     if (!identifier) {
-      Notification.show('Selected user has no email address and cannot be added as collaborator.', 'warning');
+      Notification.show('Selected principal has no identifier and cannot be added as collaborator.', 'warning');
       return;
     }
     if (collaborators.some((item) => item.identifier?.toLowerCase() === identifier.toLowerCase())) {
       Notification.show('Collaborator Already Exist.', 'warning');
       return;
     }
-    if (project?.createdBy?.id && project?.createdBy?.id === collaborator.shortId) {
-      Notification.show(
-        `${collaborator.firstName} ${collaborator.lastName} is a creator. Creator can't be added as collaborator.`,
-        'warning',
-      );
-      return;
-    }
     setCollaborators([
       ...collaborators,
       {
         identifier,
-        shortId: collaborator.shortId,
-        firstName: collaborator.firstName,
-        lastName: collaborator.lastName,
-        displayName: [collaborator.firstName, collaborator.lastName].filter(Boolean).join(' ') || identifier,
-        kind: 'USER',
-        role: 'Crypto User',
+        objectId: principal.id,
+        displayName: principal.displayName || identifier,
+        kind: principal.kind,
+        principalType: principal.principalType,
+        accessLevel,
       },
     ]);
+    setPrincipalResults([]);
+    setPrincipalSearch('');
+  };
+
+  const onAccessLevelChange = (identifier: string, level: IKeyVaultAccessLevel) => {
+    setCollaborators(
+      collaborators.map((item) => (item.identifier === identifier ? { ...item, accessLevel: level } : item)),
+    );
   };
 
   const onCollaboratorDelete = (identifier: string) => {
@@ -475,25 +506,96 @@ const CreateNewWorkspace = ({ edit, project, setShowCreateModal, getKeyVaultList
           <div className={Styles.collaboratorSection}>
             <div className={Styles.collaboratorSectionList}>
               <div className={Styles.collaboratorSectionListAdd}>
-                <AddUser getCollabarators={getCollabarators} dagId={''} isRequired={false} isUserprivilegeSearch={false} />
+                <div className={Styles.principalSearch}>
+                  <div className={classNames('input-field-group')}>
+                    <label className="input-label">Search Entra ID</label>
+                    <input
+                      type="text"
+                      className="input-field"
+                      value={principalSearch}
+                      placeholder="Search users, service principals or managed identities"
+                      onChange={(event) => setPrincipalSearch(event.currentTarget.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          searchPrincipals();
+                        }
+                      }}
+                    />
+                  </div>
+                  <div className={classNames('input-field-group')}>
+                    <label className="input-label">Access</label>
+                    <div className={classNames('custom-select')}>
+                      <select
+                        id="accessLevelField"
+                        value={accessLevel}
+                        onChange={(event) => setAccessLevel(event.currentTarget.value as IKeyVaultAccessLevel)}
+                      >
+                        {ACCESS_LEVELS.map((level) => (
+                          <option key={level} value={level}>
+                            {level}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                  <button className="btn btn-primary" type="button" onClick={searchPrincipals} disabled={searching}>
+                    Search
+                  </button>
+                </div>
+                {principalResults.length > 0 && (
+                  <div className={classNames('mbc-scroll', Styles.principalResults)}>
+                    {principalResults.map((principal) => (
+                      <button
+                        className={Styles.principalResult}
+                        type="button"
+                        key={principal.id}
+                        onClick={() => addCollaborator(principal)}
+                      >
+                        <span>{principal.displayName || principal.identifier}</span>
+                        <span>{principal.identifier}</span>
+                        <span>{principal.kind}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
               <div className={Styles.collaboratorList}>
                 {collaborators?.length > 0 ? (
                   <>
                     <div className={Styles.collaboratorTitle}>
-                      <div className={Styles.collaboratorTitleCol}>User ID</div>
+                      <div className={Styles.collaboratorTitleCol}>Identifier</div>
                       <div className={Styles.collaboratorTitleCol}>Name</div>
-                      <div className={Styles.collaboratorTitleCol}>Permission</div>
+                      <div className={Styles.collaboratorTitleCol}>Type</div>
+                      <div className={Styles.collaboratorTitleCol}>Access</div>
                       <div className={Styles.collaboratorTitleCol}></div>
                     </div>
                     <div className={classNames('mbc-scroll', Styles.collaboratorContent)}>
                       {collaborators.map((collaborator) => (
                         <div key={collaborator.identifier} className={Styles.collaboratorContentRow}>
-                          <div className={Styles.collaboratorTitleCol}>{collaborator.shortId}</div>
+                          <div className={Styles.collaboratorTitleCol}>{collaborator.identifier}</div>
                           <div className={Styles.collaboratorTitleCol}>
                             {collaborator.displayName || collaborator.identifier}
                           </div>
-                          <div className={Styles.collaboratorTitleCol}>{collaborator.role || 'Crypto User'}</div>
+                          <div className={Styles.collaboratorTitleCol}>{collaborator.kind}</div>
+                          <div className={Styles.collaboratorTitleCol}>
+                            <div className={classNames('custom-select', Styles.collaboratorAccessSelect)}>
+                              <select
+                                value={collaborator.accessLevel || 'Reading'}
+                                onChange={(event) =>
+                                  onAccessLevelChange(
+                                    collaborator.identifier,
+                                    event.currentTarget.value as IKeyVaultAccessLevel,
+                                  )
+                                }
+                              >
+                                {ACCESS_LEVELS.map((level) => (
+                                  <option key={level} value={level}>
+                                    {level}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                          </div>
                           <div className={Styles.collaboratorTitleCol}>
                             <button
                               className={classNames('btn btn-primary', Styles.deleteBtn)}

--- a/packages/frontend/src/globals/types.ts
+++ b/packages/frontend/src/globals/types.ts
@@ -1582,6 +1582,27 @@ export interface IKeyVaultCreatedBy {
   mobileNumber?: string;
 }
 
+export interface IKeyVaultCollaborator {
+  identifier: string;
+  objectId?: string;
+  principalType?: string;
+  kind: 'USER' | 'SPN' | 'MI';
+  displayName?: string;
+  role?: string;
+  roleAssignmentId?: string;
+}
+
+export interface IKeyVaultPrincipal {
+  id: string;
+  displayName?: string;
+  mail?: string;
+  appId?: string;
+  servicePrincipalType?: string;
+  principalType: string;
+  kind: 'USER' | 'SPN' | 'MI';
+  identifier: string;
+}
+
 export interface IKeyVault {
   id?: string;
   keyVaultName?: string;
@@ -1596,4 +1617,5 @@ export interface IKeyVault {
   location?: string;
   createdBy?: IKeyVaultCreatedBy;
   createdOn?: string;
+  collaborators?: IKeyVaultCollaborator[];
 }

--- a/packages/frontend/src/globals/types.ts
+++ b/packages/frontend/src/globals/types.ts
@@ -1584,23 +1584,15 @@ export interface IKeyVaultCreatedBy {
 
 export interface IKeyVaultCollaborator {
   identifier: string;
+  shortId?: string;
+  firstName?: string;
+  lastName?: string;
   objectId?: string;
   principalType?: string;
   kind: 'USER' | 'SPN' | 'MI';
   displayName?: string;
   role?: string;
   roleAssignmentId?: string;
-}
-
-export interface IKeyVaultPrincipal {
-  id: string;
-  displayName?: string;
-  mail?: string;
-  appId?: string;
-  servicePrincipalType?: string;
-  principalType: string;
-  kind: 'USER' | 'SPN' | 'MI';
-  identifier: string;
 }
 
 export interface IKeyVault {

--- a/packages/frontend/src/globals/types.ts
+++ b/packages/frontend/src/globals/types.ts
@@ -1582,6 +1582,21 @@ export interface IKeyVaultCreatedBy {
   mobileNumber?: string;
 }
 
+export type IKeyVaultPrincipalKind = 'USER' | 'SPN' | 'MI';
+
+export type IKeyVaultAccessLevel = 'Reading' | 'Contributing';
+
+export interface IKeyVaultPrincipal {
+  id?: string;
+  displayName?: string;
+  mail?: string;
+  appId?: string;
+  servicePrincipalType?: string;
+  principalType?: string;
+  kind: IKeyVaultPrincipalKind;
+  identifier?: string;
+}
+
 export interface IKeyVaultCollaborator {
   identifier: string;
   shortId?: string;
@@ -1589,10 +1604,13 @@ export interface IKeyVaultCollaborator {
   lastName?: string;
   objectId?: string;
   principalType?: string;
-  kind: 'USER' | 'SPN' | 'MI';
+  kind: IKeyVaultPrincipalKind;
   displayName?: string;
   role?: string;
+  accessLevel?: IKeyVaultAccessLevel;
+  roles?: string[];
   roleAssignmentId?: string;
+  roleAssignmentIds?: string[];
 }
 
 export interface IKeyVault {

--- a/packages/frontend/src/services/ApiClient.ts
+++ b/packages/frontend/src/services/ApiClient.ts
@@ -556,6 +556,10 @@ export class ApiClient {
     return this.fabricGet(`fabric-workspaces/${roleName}/entraGroupMembers`);
   }
 
+  public static searchKeyVaultPrincipals(search: string) {
+    return this.fabricGet(`fabric-workspaces/keyVault/principals?search=${encodeURIComponent(search)}`);
+  }
+
   public static getKeyVaults() {
     return this.fabricGet(`fabric-workspaces/keyVault`);
   }

--- a/packages/frontend/src/services/ApiClient.ts
+++ b/packages/frontend/src/services/ApiClient.ts
@@ -556,10 +556,6 @@ export class ApiClient {
     return this.fabricGet(`fabric-workspaces/${roleName}/entraGroupMembers`);
   }
 
-  public static searchKeyVaultPrincipals(search: string) {
-    return this.fabricGet(`fabric-workspaces/keyVault/principals?search=${encodeURIComponent(search)}`);
-  }
-
   public static getKeyVaults() {
     return this.fabricGet(`fabric-workspaces/keyVault`);
   }

--- a/packages/frontend/src/services/ApiClient.ts
+++ b/packages/frontend/src/services/ApiClient.ts
@@ -556,8 +556,8 @@ export class ApiClient {
     return this.fabricGet(`fabric-workspaces/${roleName}/entraGroupMembers`);
   }
 
-  public static getKeyVaults() {
-    return this.fabricGet(`fabric-workspaces/keyVault`);
+  public static getKeyVaults(offset?: number, limit?: number) {
+    return this.fabricGet(`fabric-workspaces/keyVault?offset=${offset || 0}&limit=${limit || 15}`);
   }
 
   public static createKeyVault(data: any) {

--- a/packages/frontend/src/services/ApiClient.ts
+++ b/packages/frontend/src/services/ApiClient.ts
@@ -560,6 +560,10 @@ export class ApiClient {
     return this.fabricGet(`fabric-workspaces/keyVault?offset=${offset || 0}&limit=${limit || 15}`);
   }
 
+  public static searchKeyVaultPrincipals(search: string) {
+    return this.fabricGet(`fabric-workspaces/keyVault/principals?search=${encodeURIComponent(search)}`);
+  }
+
   public static createKeyVault(data: any) {
     return this.fabricPost('fabric-workspaces/keyVault', data);
   }


### PR DESCRIPTION
## Summary

Adds collaborator (share access) management to Azure Key Vaults, for Users, Service Principals and Managed Identities, provisioned through Azure RBAC role assignments (not access policies).

Backend (`packages/fabric-backend`):

- `AzureManagementClient` gains Entra ID principal search and unified resolution. Users and service principals live in separate Graph collections, so `searchPrincipals` queries both and isolates failures per lookup; `servicePrincipalType == "ManagedIdentity"` maps to `kind = MI`, otherwise `SPN`:
  ```java
  searchPrincipals(term) -> [ users(mail startswith term), servicePrincipals(displayName startswith term or appId eq term) ]
  resolvePrincipal(identifier, kind) -> AzurePrincipalDto{ id, principalType: "User" | "ServicePrincipal", kind }
  ```
- `assignRoleToUser` now takes the resolved `principalType` instead of hardcoding `"User"`, and the generated role-assignment UUID is returned in `RoleAssignmentResponseDto` instead of being discarded. Collaborators get `keyVaultCryptoUserRole`; the creator keeps the officer role.
- New `removeRoleAssignment(keyVaultName, roleAssignmentId)` — Azure deletes the assignment resource, which is why the assignment ID is persisted per collaborator in the JSONB model (`AzureKeyVaultCollaborator.roleAssignmentId`).
- Create and edit flows both provision: on create every collaborator is provisioned; on update collaborators are diffed by identifier so existing assignments are preserved, additions are provisioned and removals are de-provisioned. Collaborator-level Azure failures become `warnings` on the response rather than aborting the vault operation. Updates remain restricted to the vault owner.
- Visibility: `findAllByCreatorOrCollaborator` extends the existing JSONB creator query so collaborators also see the vault. The `LIKE` predicate matches the serialized `"identifier":"..."` field only (not display names/object IDs/roles), with `\ % _` escaped.
- New `GET /fabric-workspaces/keyVault/principals?search=` endpoint plus `KeyVaultCollaboratorVO` / `AzurePrincipalVO` schemas and a `collaborators` array on `KeyVaultVO`. `application.yml` adds `servicePrincipalSearchUrl: ${AZURE_SP_SEARCH_URL:XXXX}`, following the existing placeholder convention.

Frontend (`packages/frontend`): principal picker in the create/edit Key Vault form (min. 3 chars, duplicate identifiers rejected case-insensitively, removable entries) and a collaborator list on the Key Vault card.

## Reason for fix

Key Vault access was limited to its creator, so teams had to share credentials or recreate vaults to give another user, service principal or managed identity access. RBAC role assignments are required (access policies are not to be used) and the assignment ID must be stored so revocation can target the exact assignment.

## Related Jira issue

FCF-241

## Validation

- `./gradlew :lib:compileJava` — BUILD SUCCESSFUL (includes OpenAPI generation), no new warnings.
- `eslint` on the touched frontend files — clean apart from one pre-existing error in `ApiClient.ts` reproducible on the base branch.
- `tsc --noEmit` — the repository-wide check has 231 pre-existing errors; none in files touched here.
- No test suites cover these modules.

## AI Review

PR Quality Score: 88/100

Quality Notes:
- Correctness: the RBAC create/update/remove lifecycle is complete and the persisted assignment ID makes revocation exact; principal-type is now derived rather than assumed. Points deducted because the Azure/Graph paths have no automated test coverage and were not exercised against a live tenant.
- Risks: Graph `$filter` strings are concatenated (single quotes escaped) rather than parameterized; collaborator visibility relies on a `LIKE` over serialized JSONB rather than a JSONB containment operator, which is correct but not index-friendly at scale; collaborator provisioning failures surface as warnings, so a vault can persist a collaborator whose Azure assignment did not succeed.
- Architecture: follows the existing DnA layering (client → service → assembler → JSONB repo, OpenAPI-generated VOs, micro-frontend `ApiClient`), reuses the existing role-definition config and `XXXX` placeholder convention, and adds no new dependency. Possible improvements: `$filter` encoding via URI builder, a JSONB `@>` predicate for collaborator lookup, and a retry/compensation path for partially provisioned collaborators.


---

Requested by anna_agnel.maria_rathinam
