### PR TITLE
feat(code-space): surface crash-looping deployments on the card and open logs from the status mark

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/assembler/WorkspaceAssembler.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/assembler/WorkspaceAssembler.java
@@ -290,6 +290,8 @@ import com.daimler.data.dto.workspace.DeploymentAuditVO;
 		 CodeServerDeploymentDetails deploymentDetails = new CodeServerDeploymentDetails();
 		 if (vo != null) {
 			 BeanUtils.copyProperties(vo, deploymentDetails);
+			 deploymentDetails.setNewPodCrashLooping(vo.isNewPodCrashLooping());
+			 deploymentDetails.setCrashLoopReason(vo.getCrashLoopReason());
 			 if(vo.isSecureWithIAMRequired()!=null)
 			 {
 				deploymentDetails.setSecureWithIAMRequired(vo.isSecureWithIAMRequired());
@@ -394,6 +396,8 @@ import com.daimler.data.dto.workspace.DeploymentAuditVO;
 		 SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS+00:00");
 		 if (deploymentDetails != null) {
 			 BeanUtils.copyProperties(deploymentDetails, deploymentDetailsVO);
+			 deploymentDetailsVO.setNewPodCrashLooping(deploymentDetails.getNewPodCrashLooping());
+			 deploymentDetailsVO.setCrashLoopReason(deploymentDetails.getCrashLoopReason());
 			 deploymentDetailsVO.setLastDeployedBy(toUserInfoVO(deploymentDetails.getLastDeployedBy()));
 			 if (Objects.isNull(deploymentDetails.getSecureWithIAMRequired())) {
 				 deploymentDetailsVO.setSecureWithIAMRequired(false);

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/json/CodeServerDeploymentDetails.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/json/CodeServerDeploymentDetails.java
@@ -38,5 +38,7 @@ public class CodeServerDeploymentDetails implements Serializable {
 	private List<String> selectedAliceRoles;
 	private List<DeploymentAudit> deploymentAuditLogs;
 	private String lastDeploymentError;
+	private Boolean newPodCrashLooping;
+	private String crashLoopReason;
 	
 }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepository.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepository.java
@@ -71,6 +71,9 @@ public interface WorkspaceCustomRepository extends CommonDataRepository<CodeServ
 	GenericMessage updateCancelledDeploymentStatus(String projectName, String environment,
 			String lastDeploymentStatus, String lastDeploymentError, Date lastDeployedOn);
 
+	GenericMessage updateDeploymentCrashLoopStatus(String projectName, String environment,
+			Boolean newPodCrashLooping, String crashLoopReason);
+
 	GenericMessage updateDeployedAppConfig(String projectName, String environment, boolean secureWithIAMRequired,
 			String oneApiVersionShortName, boolean isSecuredWithCookie, String deploymentType, String clientID,
 			String redirectUri, String ignorePaths, String scope, String ssoType, boolean secureWithDnaRequired,

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepositoryImpl.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/db/repo/workspace/WorkspaceCustomRepositoryImpl.java
@@ -559,6 +559,22 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 		fields.lastBuildOrDeployedStatus = lastDeploymentStatus;
 		fields.lastBuildOrDeployedEnv = environment;
 		fields.lastBuildOrDeployedOn = lastDeployedOn;
+		fields.crashLoopUpdate = CrashLoopUpdate.CLEAR;
+		return updateDeploymentStatusFields(projectName, environment, fields);
+	}
+
+	@Transactional
+	@Override
+	public GenericMessage updateDeploymentCrashLoopStatus(String projectName, String environment,
+			Boolean newPodCrashLooping, String crashLoopReason) {
+		DeploymentStatusFields fields = new DeploymentStatusFields();
+		if (Boolean.TRUE.equals(newPodCrashLooping)) {
+			fields.crashLooping = true;
+			fields.crashLoopReason = crashLoopReason;
+			fields.crashLoopUpdate = CrashLoopUpdate.SET;
+		} else {
+			fields.crashLoopUpdate = CrashLoopUpdate.CLEAR;
+		}
 		return updateDeploymentStatusFields(projectName, environment, fields);
 	}
 
@@ -590,6 +606,27 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 			} else if (fields.errorUpdate == ErrorUpdate.CLEAR) {
 				updateExpression = jsonbSet(updateExpression,
 						"{projectDetails," + environmentJsonbName + ",lastDeploymentError}",
+						"CAST('null' AS jsonb)");
+			}
+			if (fields.crashLoopUpdate == CrashLoopUpdate.SET) {
+				updateExpression = jsonbSet(updateExpression,
+						"{projectDetails," + environmentJsonbName + ",newPodCrashLooping}",
+						"to_jsonb(CAST(:newPodCrashLooping AS boolean))");
+				if (fields.crashLoopReason != null) {
+					updateExpression = jsonbSet(updateExpression,
+							"{projectDetails," + environmentJsonbName + ",crashLoopReason}",
+							"to_jsonb(CAST(:crashLoopReason AS text))");
+				} else {
+					updateExpression = jsonbSet(updateExpression,
+							"{projectDetails," + environmentJsonbName + ",crashLoopReason}",
+							"CAST('null' AS jsonb)");
+				}
+			} else if (fields.crashLoopUpdate == CrashLoopUpdate.CLEAR) {
+				updateExpression = jsonbSet(updateExpression,
+						"{projectDetails," + environmentJsonbName + ",newPodCrashLooping}",
+						"to_jsonb(false)");
+				updateExpression = jsonbSet(updateExpression,
+						"{projectDetails," + environmentJsonbName + ",crashLoopReason}",
 						"CAST('null' AS jsonb)");
 			}
 			if (fields.lastDeployedVersion != null) {
@@ -644,6 +681,12 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 			if (fields.errorUpdate == ErrorUpdate.SET) {
 				query.setParameter("lastDeploymentError", fields.lastDeploymentError);
 			}
+			if (fields.crashLoopUpdate == CrashLoopUpdate.SET) {
+				query.setParameter("newPodCrashLooping", fields.crashLooping);
+				if (fields.crashLoopReason != null) {
+					query.setParameter("crashLoopReason", fields.crashLoopReason);
+				}
+			}
 			if (fields.lastDeployedVersion != null) {
 				query.setParameter("lastDeployedVersion", fields.lastDeployedVersion);
 			}
@@ -695,10 +738,17 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 		NONE, SET, CLEAR
 	}
 
+	private enum CrashLoopUpdate {
+		NONE, SET, CLEAR
+	}
+
 	private static class DeploymentStatusFields {
 		private String lastDeploymentStatus;
 		private String lastDeploymentError;
 		private ErrorUpdate errorUpdate = ErrorUpdate.NONE;
+		private Boolean crashLooping;
+		private String crashLoopReason;
+		private CrashLoopUpdate crashLoopUpdate = CrashLoopUpdate.NONE;
 		private String lastDeployedVersion;
 		private String lastDeployedBranch;
 		private Date lastDeployedOn;
@@ -715,6 +765,7 @@ public class WorkspaceCustomRepositoryImpl extends CommonDataRepositoryImpl<Code
 			fields.lastDeploymentError = deploymentDetails.getLastDeploymentError();
 			fields.errorUpdate = deploymentDetails.getLastDeploymentError() == null
 					? ErrorUpdate.CLEAR : ErrorUpdate.SET;
+			fields.crashLoopUpdate = CrashLoopUpdate.CLEAR;
 			fields.lastDeployedVersion = deploymentDetails.getLastDeployedVersion();
 			fields.lastDeployedBranch = deploymentDetails.getLastDeployedBranch();
 			fields.lastDeployedOn = deploymentDetails.getLastDeployedOn();

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -924,22 +924,38 @@ public class ArgoCdService {
             String healthStatus = rootNode.path("status").path("health").path("status").asText("");
             String lastSyncPhase = rootNode.path("status").path("operationState").path("phase").asText("");
 
-            String failureMessage = getConfirmedDeploymentFailure(token, rootNode, appName, deployTriggerTime);
+            Map<String, Object> crashLoopStatus = null;
+            String failureMessage;
+            boolean operationFailed = "Failed".equalsIgnoreCase(lastSyncPhase)
+                    || "Error".equalsIgnoreCase(lastSyncPhase);
+            if ("Degraded".equalsIgnoreCase(healthStatus) && !operationFailed) {
+                crashLoopStatus = getNewPodCrashLoopStatus(token, appName, rootNode);
+                failureMessage = getConfirmedDeploymentFailure(
+                        token, rootNode, appName, deployTriggerTime, crashLoopStatus);
+            } else {
+                failureMessage = getConfirmedDeploymentFailure(token, rootNode, appName, deployTriggerTime);
+            }
             if (failureMessage != null) {
                 result.put("status", "DEPLOYMENT_FAILED");
                 result.put("errorMessage", failureMessage);
                 return result;
             }
             if ("Degraded".equalsIgnoreCase(healthStatus)) {
+                if (crashLoopStatus == null) {
+                    crashLoopStatus = getNewPodCrashLoopStatus(token, appName, rootNode);
+                }
+                addCrashLoopEvidence(result, crashLoopStatus);
                 result.put("status", "DEPLOYING");
                 return result;
             }
             if ("Running".equalsIgnoreCase(lastSyncPhase)) {
+                addCrashLoopEvidence(result, getNewPodCrashLoopStatus(token, appName, rootNode));
                 return result; 
             }
  
             String syncStatus = rootNode.path("status").path("sync").path("status").asText("");
             if ("OutOfSync".equalsIgnoreCase(syncStatus)) {
+                addCrashLoopEvidence(result, getNewPodCrashLoopStatus(token, appName, rootNode));
                 return result; 
             }
             if ("Healthy".equalsIgnoreCase(healthStatus)) {
@@ -950,6 +966,7 @@ public class ArgoCdService {
                 result.put("status", "DEPLOYED");
                 return result;
             }
+            addCrashLoopEvidence(result, getNewPodCrashLoopStatus(token, appName, rootNode));
             return result;
         } catch (Exception e) {
             log.error("Failed to check ArgoCD deployment status for {}", appName, e);
@@ -964,6 +981,11 @@ public class ArgoCdService {
      */
     public String getConfirmedDeploymentFailure(String token, JsonNode rootNode, String appName,
             Date deployTriggerTime) {
+        return getConfirmedDeploymentFailure(token, rootNode, appName, deployTriggerTime, null);
+    }
+
+    private String getConfirmedDeploymentFailure(String token, JsonNode rootNode, String appName,
+            Date deployTriggerTime, Map<String, Object> computedCrashLoopStatus) {
         JsonNode operationState = rootNode.path("status").path("operationState");
         String healthStatus = rootNode.path("status").path("health").path("status").asText("");
         String phase = operationState.path("phase").asText("");
@@ -1002,7 +1024,9 @@ public class ArgoCdService {
                     log.warn("Degraded ArgoCD deployment {} lacks a desired image tag; failure is not proven", appName);
                     return null;
                 }
-                Map<String, Object> crashLoopStatus = getNewPodCrashLoopStatus(token, appName, rootNode);
+                Map<String, Object> crashLoopStatus = computedCrashLoopStatus != null
+                        ? computedCrashLoopStatus
+                        : getNewPodCrashLoopStatus(token, appName, rootNode);
                 if (!Boolean.TRUE.equals(crashLoopStatus.get("newPodCrashLooping"))
                         || Boolean.TRUE.equals(crashLoopStatus.get("fallbackSelected"))
                         || !Boolean.TRUE.equals(crashLoopStatus.get("strongCrashReason"))) {
@@ -1021,6 +1045,16 @@ public class ArgoCdService {
             }
         }
         return null;
+    }
+
+    private void addCrashLoopEvidence(Map<String, String> result, Map<String, Object> crashLoopStatus) {
+        if (crashLoopStatus == null) {
+            return;
+        }
+        result.put("newPodCrashLooping",
+                String.valueOf(Boolean.TRUE.equals(crashLoopStatus.get("newPodCrashLooping"))));
+        Object reason = crashLoopStatus.get("crashLoopReason");
+        result.put("crashLoopReason", reason == null ? "" : String.valueOf(reason));
     }
 
     private boolean isWithinDeploymentGracePeriod(Date deployTriggerTime) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/ArgoCdService.java
@@ -960,6 +960,8 @@ public class ArgoCdService {
             }
             if ("Healthy".equalsIgnoreCase(healthStatus)) {
                 if (!isDeploymentReady(rootNode, appName, expectedVersion, deployTriggerTime)) {
+                    result.put("newPodCrashLooping", "false");
+                    result.put("crashLoopReason", "");
                     result.put("status", "DEPLOYING");
                     return result;
                 }

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -596,7 +596,7 @@ public class DeploymentStatusMonitorJob {
                     } else if (wasCrashLooping && !argoCrashLooping) {
                         log.info("Crash-loop cleared for project={} environment={}", projectName, environment);
                     }
-                    return true;
+                    return false;
                 }
             }
         } catch (Exception e) {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/service/scheduler/DeploymentStatusMonitorJob.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -148,7 +149,10 @@ public class DeploymentStatusMonitorJob {
                 log.info("Clearing stale status for {}-{}: no deployment audit logs exist",
                         projectName, environment);
                 deployment.setLastDeploymentStatus(null);
+                deployment.setNewPodCrashLooping(false);
+                deployment.setCrashLoopReason(null);
                 workspaceCustomRepository.updateDeploymentDetails(projectName, environment, deployment, null);
+                workspaceCustomRepository.updateDeploymentCrashLoopStatus(projectName, environment, false, null);
                 return;
             }
             counts.checkedCount++;
@@ -161,6 +165,8 @@ public class DeploymentStatusMonitorJob {
             CodeServerDeploymentDetails deployment = "int".equalsIgnoreCase(environment)
                     ? representative.getData().getProjectDetails().getIntDeploymentDetails()
                     : representative.getData().getProjectDetails().getProdDeploymentDetails();
+            deployment.setNewPodCrashLooping(false);
+            deployment.setCrashLoopReason(null);
             repairMissingFailureFields(representative, deployment, projectName, environment);
         }
     }
@@ -421,6 +427,9 @@ public class DeploymentStatusMonitorJob {
             }
             String argoStatus = argoResult.get("status");
             String argoErrorMessage = argoResult.get("errorMessage");
+            boolean hasCrashLoopEvidence = argoResult.containsKey("newPodCrashLooping");
+            boolean argoCrashLooping = Boolean.parseBoolean(argoResult.get("newPodCrashLooping"));
+            String argoCrashLoopReason = argoResult.get("crashLoopReason");
 
             
             boolean needsUpdate = false;
@@ -453,6 +462,8 @@ public class DeploymentStatusMonitorJob {
                 log.info("Reconciling deployment status for {} from {} to {}", appName, currentDbStatus, targetStatus);
                 
                 deployment.setLastDeploymentStatus(targetStatus);
+                deployment.setNewPodCrashLooping(false);
+                deployment.setCrashLoopReason(null);
                 if ("DEPLOYMENT_FAILED".equals(targetStatus) || "RESTART_FAILED".equals(targetStatus)) {
                     deployment.setLastDeploymentError(argoErrorMessage);
                 } else {
@@ -564,6 +575,29 @@ public class DeploymentStatusMonitorJob {
                 sendDeploymentNotification(workspace, deployment, projectName, environment, targetStatus);
                 
                 return true;
+            }
+            boolean inProgress = "DEPLOY_REQUESTED".equalsIgnoreCase(currentDbStatus)
+                    || "DEPLOYING".equalsIgnoreCase(currentDbStatus)
+                    || "RESTART_REQUESTED".equalsIgnoreCase(currentDbStatus);
+            boolean crashLoopChanged = !Objects.equals(
+                    Boolean.TRUE.equals(deployment.getNewPodCrashLooping()), argoCrashLooping)
+                    || !Objects.equals(deployment.getCrashLoopReason(),
+                            argoCrashLooping ? argoCrashLoopReason : null);
+            if (inProgress && hasCrashLoopEvidence && crashLoopChanged) {
+                GenericMessage crashLoopUpdate = workspaceCustomRepository.updateDeploymentCrashLoopStatus(
+                        projectName, environment, argoCrashLooping, argoCrashLoopReason);
+                if (crashLoopUpdate != null && "SUCCESS".equalsIgnoreCase(crashLoopUpdate.getSuccess())) {
+                    boolean wasCrashLooping = Boolean.TRUE.equals(deployment.getNewPodCrashLooping());
+                    deployment.setNewPodCrashLooping(argoCrashLooping);
+                    deployment.setCrashLoopReason(argoCrashLooping ? argoCrashLoopReason : null);
+                    if (!wasCrashLooping && argoCrashLooping) {
+                        log.info("Crash-loop detected for project={} environment={} reason={}",
+                                projectName, environment, argoCrashLoopReason);
+                    } else if (wasCrashLooping && !argoCrashLooping) {
+                        log.info("Crash-loop cleared for project={} environment={}", projectName, environment);
+                    }
+                    return true;
+                }
             }
         } catch (Exception e) {
             log.warn("Failed to check ArgoCD status for {}-{}: {}", projectName, environment, e.getMessage());

--- a/packages/code-server/code-server-lib/src/main/resources/api/Workspace.yaml
+++ b/packages/code-server/code-server-lib/src/main/resources/api/Workspace.yaml
@@ -2038,6 +2038,12 @@ definitions:
       lastDeploymentStatus:
         type: string
         description: Status of last deployement
+      newPodCrashLooping:
+        type: boolean
+        description: Whether the deployment's new pod is crash-looping
+      crashLoopReason:
+        type: string
+        description: Human-readable crash-loop reason
       gitjobRunID:
         type: string
         description: "git job run Id of project deployed"

--- a/packages/code-server/code-server-lib/src/main/resources/application.yml
+++ b/packages/code-server/code-server-lib/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   mvc.pathmatch.matching-strategy: ant_path_matcher
   application:
     name: dna-codeserver-service
-    version: 1.12.21
+    version: 1.12.22
   profile:
     active: production
 

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -864,6 +864,13 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                             >
                               <i className="icon mbc-icon refresh"></i>
                             </span>
+                            <span
+                              className={classNames(Styles.syncErrorInfoIcon, Styles.deployLogsInfoIcon)}
+                              onClick={onDeployLogsInfoClick}
+                              tooltip-data="View live deployment logs"
+                            >
+                              <i className="icon mbc-icon info"></i>
+                            </span>
                           </span>
                         </span>
                       )}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -500,8 +500,11 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     setShowDeployLogsModal(false);
     setDeployLogText('');
     setDeployLogsHaveErrors(false);
-    setNewPodCrashLooping(false);
-    setCrashLoopReason('');
+    const deploymentDetails = env === 'int'
+      ? codeSpace?.projectDetails?.intDeploymentDetails
+      : codeSpace?.projectDetails?.prodDeploymentDetails;
+    setNewPodCrashLooping(!!deploymentDetails?.newPodCrashLooping);
+    setCrashLoopReason(deploymentDetails?.crashLoopReason || '');
     setDeployingThresholdExceeded(false);
   };
 
@@ -604,6 +607,15 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
   const projectDetails = codeSpace?.projectDetails;
   const intDeploymentDetails = projectDetails?.intDeploymentDetails;
   const prodDeploymentDetails = projectDetails?.prodDeploymentDetails;
+  const deployingEnvironment = projectDetails?.lastBuildOrDeployedEnv;
+  const activeDeploymentDetails = deployingEnvironment === 'int'
+    ? intDeploymentDetails
+    : prodDeploymentDetails;
+  const persistedCrashLooping = !!activeDeploymentDetails?.newPodCrashLooping;
+  const persistedCrashLoopReason = activeDeploymentDetails?.crashLoopReason || '';
+  const deploymentWorkflowUrl = activeDeploymentDetails?.gitjobRunID
+    ? buildGitJobLogViewAWSURL(activeDeploymentDetails.gitjobRunID)
+    : null;
   const deployingInProgress =
     intDeploymentDetails?.lastDeploymentStatus === 'DEPLOY_REQUESTED' ||
     intDeploymentDetails?.lastDeploymentStatus === 'DEPLOYING' ||
@@ -824,21 +836,25 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                       )}
                       {(projectDetails?.lastBuildOrDeployedStatus === 'DEPLOY_REQUESTED' || 
                         projectDetails?.lastBuildOrDeployedStatus === 'DEPLOYING') && (
-                        <a
-                          href={(projectDetails?.lastBuildOrDeployedEnv === 'int')
-                            ? buildGitJobLogViewAWSURL(projectDetails?.intDeploymentDetails?.gitjobRunID)
-                            : buildGitJobLogViewAWSURL(projectDetails?.prodDeploymentDetails?.gitjobRunID)
-                          }
-                          target="_blank"
-                          rel="noreferrer"
+                        <span
                           className={Styles.deployingLink}
                           tooltip-data={
-                            projectDetails?.lastBuildOrDeployedEnv === 'int'
-                              ? 'Deploying to Staging'
-                              : 'Deploying to Production'
+                            persistedCrashLooping && persistedCrashLoopReason
+                              ? persistedCrashLoopReason
+                              : projectDetails?.lastBuildOrDeployedEnv === 'int'
+                                ? 'Deploying to Staging'
+                                : 'Deploying to Production'
                           }
                         >
-                          <span className={classNames(Styles.statusIndicator, Styles.deploying, Styles.statusWithRefresh)}>
+                          <span
+                            className={classNames(
+                              Styles.statusIndicator,
+                              Styles.deploying,
+                              Styles.statusWithRefresh,
+                              persistedCrashLooping ? Styles.deployCrashLooping : ''
+                            )}
+                            onClick={onDeployLogsInfoClick}
+                          >
                             Deploying...
                             <span 
                               className={Styles.refreshIcon} 
@@ -847,15 +863,8 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                             >
                               <i className="icon mbc-icon refresh"></i>
                             </span>
-                            <span
-                              className={classNames(Styles.syncErrorInfoIcon, Styles.deployLogsInfoIcon)}
-                              onClick={onDeployLogsInfoClick}
-                              tooltip-data="View live deployment logs"
-                            >
-                              <i className="icon mbc-icon info"></i>
-                            </span>
                           </span>
-                        </a>
+                        </span>
                       )}
                       {projectDetails?.lastBuildOrDeployedStatus === 'BUILD_FAILED' && (
                         <span className={classNames(Styles.statusIndicator, Styles.deployFailed)}>
@@ -1227,6 +1236,16 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
           title={
             <div className={Styles.modalHeader}>
               <span>Deployment Logs</span>
+              {deploymentWorkflowUrl && (
+                <a
+                  href={deploymentWorkflowUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={Styles.workflowLogsLink}
+                >
+                  View workflow logs
+                </a>
+              )}
               <i
                 className={classNames('icon mbc-icon copy', Styles.copyLogsIcon, deployLogsCopied ? Styles.copyLogsIconCopied : '')}
                 tooltip-data={deployLogsCopied ? 'Copied!' : 'Copy logs'}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.js
@@ -500,11 +500,8 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     setShowDeployLogsModal(false);
     setDeployLogText('');
     setDeployLogsHaveErrors(false);
-    const deploymentDetails = env === 'int'
-      ? codeSpace?.projectDetails?.intDeploymentDetails
-      : codeSpace?.projectDetails?.prodDeploymentDetails;
-    setNewPodCrashLooping(!!deploymentDetails?.newPodCrashLooping);
-    setCrashLoopReason(deploymentDetails?.crashLoopReason || '');
+    setNewPodCrashLooping(false);
+    setCrashLoopReason('');
     setDeployingThresholdExceeded(false);
   };
 
@@ -522,8 +519,11 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
     stopDeployLogsStreams();
     setDeployLogText('');
     setDeployLogsHaveErrors(false);
-    setNewPodCrashLooping(false);
-    setCrashLoopReason('');
+    const deploymentDetails = env === 'int'
+      ? codeSpace?.projectDetails?.intDeploymentDetails
+      : codeSpace?.projectDetails?.prodDeploymentDetails;
+    setNewPodCrashLooping(!!deploymentDetails?.newPodCrashLooping);
+    setCrashLoopReason(deploymentDetails?.crashLoopReason || '');
     setDeployingThresholdExceeded(false);
     setShowDeployLogsModal(true);
 
@@ -851,6 +851,7 @@ const CodeSpaceCardItem = forwardRef((props, ref) => {
                               Styles.statusIndicator,
                               Styles.deploying,
                               Styles.statusWithRefresh,
+                              Styles.deployStatusClickable,
                               persistedCrashLooping ? Styles.deployCrashLooping : ''
                             )}
                             onClick={onDeployLogsInfoClick}

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -182,6 +182,10 @@
         color: #f3e537;
       }
 
+      &.deployCrashLooping {
+        animation: deployCrashLoopIndicator 1.2s ease-in-out infinite;
+      }
+
       &.deployFailed {
         border: 1px solid #e84d47;
         color: #e84d47;
@@ -214,6 +218,25 @@
     .deployingLink{
       text-decoration: none;
       color: #f3e537;
+    }
+
+    @keyframes deployCrashLoopIndicator {
+      0%, 100% {
+        border-color: #e84d47;
+        color: #e84d47;
+      }
+      50% {
+        border-color: #f3e537;
+        color: #f3e537;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .statusIndicator.deployCrashLooping {
+        animation: none;
+        border-color: #e84d47;
+        color: #e84d47;
+      }
     }
   }
   .cardFooter {
@@ -469,10 +492,6 @@
     }
   }
 
-  .deployLogsInfoIcon {
-    color: inherit;
-  }
-
   .deployLogsModalContent {
     margin-top: 0;
     text-align: left;
@@ -613,6 +632,16 @@
 
     span {
       flex: 1;
+    }
+  }
+
+  .workflowLogsLink {
+    color: #00adef;
+    text-decoration: none;
+    white-space: nowrap;
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -186,6 +186,10 @@
         animation: deployCrashLoopIndicator 1.2s ease-in-out infinite;
       }
 
+      &.deployStatusClickable {
+        cursor: pointer;
+      }
+
       &.deployFailed {
         border: 1px solid #e84d47;
         color: #e84d47;

--- a/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
+++ b/packages/code-space-mfe/src/components/codeSpaceCardItem/CodeSpaceCardItem.scss
@@ -496,6 +496,10 @@
     }
   }
 
+  .deployLogsInfoIcon {
+    color: inherit;
+  }
+
   .deployLogsModalContent {
     margin-top: 0;
     text-align: left;


### PR DESCRIPTION
## Summary

Makes a crash-looping deployment visible on the Codespace card without the user opening anything, and turns the `Deploying...` status mark itself into an entry point for the live log modal (where `Cancel Deployment` lives) alongside the existing info icon, which stays as the affordance that there is something to click.

Crash-loop detection previously existed only inside the deployment-status SSE stream, i.e. it was computed *only while the log modal was open* and never persisted. So a card could sit at `Deploying...` for the whole stuck rollout with no hint that the new pod was in `CrashLoopBackOff`, and the user had to know to click the info icon to find out.

Rather than adding ArgoCD calls to the card's auto-poll, the 20s monitor now persists the verdict and the card reads it from the workspace row like any other deployment field:

```
monitor pass (already deduped per project+environment)
  argoResult = checkArgoAppDeploymentStatusWithError(...)   // Application GET, as before
  if status still in-progress:
      argoResult also carries newPodCrashLooping / crashLoopReason
      persist ONLY when it differs from the row  -> no write on a stable state
  on any status transition / cancellation / repair -> flag+reason cleared
```

Notes on the cost and on correctness:

- No second Application GET: the evidence is derived from the JSON already parsed inside `checkArgoAppDeploymentStatusWithError`, via the existing `getNewPodCrashLoopStatus(token, appName, appNode)` overload.
- The `Degraded` path already computed crash-loop status inside `getConfirmedDeploymentFailure`; that status is now computed once and shared, so a degraded in-flight app does not fetch the resource tree twice per pass.
- A `Healthy` application reports `newPodCrashLooping=false` with no resource-tree call at all, which is also what clears the flag when a pod crash-loops and then recovers while the deploy is still in progress.
- What counts as a *confirmed* deployment failure is unchanged (precise version match, non-fallback pod, strong crash reason). The flag is a warning only; it never flips a deployment to `DEPLOYMENT_FAILED`.
- Persisting the flag is not counted as a reconciled status update in the monitor's summary log.
- The on-demand refresh (refresh icon -> `getById`) inherits this for free, since it reconciles through the same monitor method.

Frontend: the persisted flag drives a blinking red/warning animation on the status mark (static red under `prefers-reduced-motion`), with the persisted reason as its tooltip. The `Deploying...` label is no longer an `<a>` to the workflow log — that link now lives inside the log modal header, so nothing is lost — and opening the modal (from the label or the info icon) seeds crash-loop state from the persisted flag so `Cancel Deployment` is enabled immediately instead of after the first SSE tick.

Persisted as `newPodCrashLooping` / `crashLoopReason` on the int/prod deployment details (JSONB, field-level `jsonb_set` writes through the existing parameterised helper).

Stacked on #5267 (base `hotfix/deploy-status-fix`) because the monitor changes build on that branch's per-project/environment dedupe; GitHub will retarget this to `dev` once #5267 merges.
