### PR TITLE
FCF-551 fix admin promotion of collaborators on private recipe workspaces

### DIFF
--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/application/client/GitClient.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/application/client/GitClient.java
@@ -43,6 +43,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GitClient {
 
+	public enum RepoAdminCheckStatus { ADMIN, NOT_ADMIN, CHECK_FAILED }
+
 	private static final class EtagEntry<T> {
 		final String etag;
 		final T value;
@@ -840,41 +842,66 @@ public class GitClient {
 		return HttpStatus.INTERNAL_SERVER_ERROR;
 		
 	}
-	public Boolean isUserAdmin( String orgName,String username, String repoName) {
-		return isUserAdmin(orgName, username, repoName, gitBaseUri, personalAccessToken);
+
+	public RepoAdminCheckStatus getUserRepoAdminStatus(String orgName, String username, String repoName) {
+		return getUserRepoAdminStatus(orgName, username, repoName, gitBaseUri, personalAccessToken);
 	}
-	
-	public Boolean isUserAdmin( String orgName,String username, String repoName, String baseUri, String pat) {
-		Boolean isAdmin = false;
+
+	public RepoAdminCheckStatus getUserRepoAdminStatus(String orgName, String username, String repoName, String baseUri, String pat) {
 		try {
-			log.info("Checking if user is admin: user={}, org={}, repo={}, baseUri={}", 
-					username, orgName, repoName, baseUri);
-			
 			HttpHeaders headers = new HttpHeaders();
 			headers.set("Accept", "application/json");
 			headers.set("Content-Type", "application/json");
-			headers.set("Authorization", "token "+ pat);
-			String url = baseUri+"/repos/" + orgName + "/"+ repoName+ "/collaborators/" + username+"/permission";
+			headers.set("Authorization", "token " + pat);
+			String url = baseUri + "/repos/" + orgName + "/" + repoName + "/collaborators/" + username + "/permission";
 			HttpEntity entity = new HttpEntity<>(headers);
 			ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-			if (response != null && response.getStatusCode()!=null) {
-				if(response.getStatusCode().is2xxSuccessful()){
-					String responseBody = response.getBody();
-					JSONObject jsonResponse = new JSONObject(responseBody);
-					if(jsonResponse !=null && jsonResponse.has("permission")) {
-						log.info("completed checking user {} as admin for git repo {} at {}.", username, repoName, baseUri);
-						String permission = jsonResponse.get("permission").toString();
-						if("admin".equalsIgnoreCase(permission)){
-							isAdmin = true;
-						}
-					}
+			if (response != null && response.getStatusCode() != null && response.getStatusCode().is2xxSuccessful()) {
+				JSONObject jsonResponse = new JSONObject(response.getBody());
+				if (!jsonResponse.has("permission")) {
+					log.error("Git permission response has no 'permission' field for user {} on repo {}/{}", username, orgName, repoName);
+					return RepoAdminCheckStatus.CHECK_FAILED;
 				}
+
+				String permission = jsonResponse.optString("permission", null);
+				String roleName = jsonResponse.optString("role_name", null);
+				JSONObject permissions = jsonResponse.optJSONObject("permissions");
+				boolean isAdmin = "admin".equalsIgnoreCase(permission)
+						|| "admin".equalsIgnoreCase(roleName)
+						|| (permissions != null && permissions.optBoolean("admin", false));
+				log.info("Resolved permission for user {} on repo {}/{} using {}: permission={}, role_name={}",
+						username, orgName, repoName, baseUri, permission, roleName);
+				return isAdmin ? RepoAdminCheckStatus.ADMIN : RepoAdminCheckStatus.NOT_ADMIN;
 			}
+			log.error("Git permission check returned non-success status {} for user {} on repo {}/{}",
+					response == null ? null : response.getStatusCode(), username, orgName, repoName);
+			return RepoAdminCheckStatus.CHECK_FAILED;
+		} catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+				log.warn("user {} has no access to repo {}/{}", username, orgName, repoName);
+				return RepoAdminCheckStatus.NOT_ADMIN;
+			}
+			log.error("Git permission check failed with status {} for user {} on repo {}/{}",
+					e.getStatusCode(), username, orgName, repoName, e);
+			return RepoAdminCheckStatus.CHECK_FAILED;
 		} catch (Exception e) {
-			log.error("Error occured while checking admin {} for git repo {} at {} with exception {}", username, repoName, baseUri, e.getMessage());
+			log.error("Unexpected error checking admin permission for user {} on repo {}/{}",
+					username, orgName, repoName, e);
+			return RepoAdminCheckStatus.CHECK_FAILED;
 		}
-		return isAdmin;
-		
+	}
+
+	public boolean isCodeServerOrg(String orgName, boolean isGheHostedRepo) {
+		String configuredOrg = isGheHostedRepo ? gitOrgName : codeServerGitOrgName;
+		return orgName != null && orgName.equalsIgnoreCase(configuredOrg);
+	}
+
+	public Boolean isUserAdmin( String orgName,String username, String repoName) {
+		return RepoAdminCheckStatus.ADMIN == getUserRepoAdminStatus(orgName, username, repoName);
+	}
+
+	public Boolean isUserAdmin( String orgName,String username, String repoName, String baseUri, String pat) {
+		return RepoAdminCheckStatus.ADMIN == getUserRepoAdminStatus(orgName, username, repoName, baseUri, pat);
 	}
 
 	public JSONObject getFileContent(String repoName, String repoOwner, String gitUrl, String folderPath, String fileName, String branch) throws Exception {

--- a/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/WorkspaceController.java
+++ b/packages/code-server/code-server-lib/src/main/java/com/daimler/data/controller/WorkspaceController.java
@@ -2929,25 +2929,52 @@ import org.springframework.beans.factory.annotation.Value;
 			}
 			if(isCollabIdPartOfProject){
 				if(isAdmin && vo.getProjectDetails().getRecipeDetails().getRecipeId().name().toLowerCase().startsWith("private")){
-					List<String> repoDetails = CommonUtils.getRepoNameFromGitUrl(vo.getProjectDetails().getRecipeDetails().getRepodetails());
+					String repoUrl = vo.getProjectDetails().getRecipeDetails().getRepodetails();
+					List<String> repoDetails = CommonUtils.getRepoNameFromGitUrl(repoUrl);
 					String orgName = repoDetails.get(0);
 					String repoName = repoDetails.get(1);
-					String gitHubUrl = gitOrgUri + orgName;
-					Boolean isUserAdmin;
-					if(!vo.getProjectDetails().getRecipeDetails().getRepodetails().contains(gitHubUrl)){
-						isUserAdmin = gitClient.isUserAdmin(orgName, collabUserId, repoName, gheBaseUri, ghePat);
+					boolean isGheHostedRepo = !repoUrl.contains(gitOrgUri + orgName);
+					if (gitClient.isCodeServerOrg(orgName, isGheHostedRepo)) {
+						// In-organisation repos can be granted admin access; external repos are validate-only.
+						HttpStatus grantAdminStatus = gitClient.addAdminAccessToRepo(collabUserId, repoName, isGheHostedRepo);
+						if (!grantAdminStatus.is2xxSuccessful()) {
+							log.error("Failed while granting admin permission to user {} on repo {}/{}, status {}",
+									collabUserId, orgName, repoName, grantAdminStatus);
+							warnings.add(new MessageDescription("Failed while granting admin permission to " + collabUserId
+									+ " on repository " + orgName + "/" + repoName + ". Please grant it manually."));
+							responseMessage.setWarnings(warnings);
+						}
 					} else {
-						isUserAdmin = gitClient.isUserAdmin(orgName, collabUserId, repoName);
-					}
-					if(!isUserAdmin){
-						log.error("collab user is not an admin for the private repo, cannot make user as admin");
-						GenericMessage emptyResponse = new GenericMessage();
-						List<MessageDescription> errors = new ArrayList<>();
-						msg.setMessage("Invalid User, Please make sure that collab user should be an admin of the repo. Bad request");
-						errors.add(msg);
-						emptyResponse.setErrors(errors);
-						emptyResponse.setSuccess("FAILED");
-						return new ResponseEntity<>(emptyResponse, HttpStatus.BAD_REQUEST);
+						GitClient.RepoAdminCheckStatus adminCheckStatus = isGheHostedRepo
+								? gitClient.getUserRepoAdminStatus(orgName, collabUserId, repoName, gheBaseUri, ghePat)
+								: gitClient.getUserRepoAdminStatus(orgName, collabUserId, repoName);
+						// A failed permission check must not be treated as proof that the user is not an admin.
+						if (GitClient.RepoAdminCheckStatus.CHECK_FAILED == adminCheckStatus) {
+							log.error("Could not verify admin permission of user {} on external repo {}/{}",
+									collabUserId, orgName, repoName);
+							GenericMessage emptyResponse = new GenericMessage();
+							List<MessageDescription> errors = new ArrayList<>();
+							msg.setMessage("Unable to verify admin permission of " + collabUserId + " on repository "
+									+ orgName + "/" + repoName
+									+ " because the Git permission API call failed. Please try again later.");
+							errors.add(msg);
+							emptyResponse.setErrors(errors);
+							emptyResponse.setSuccess("FAILED");
+							return new ResponseEntity<>(emptyResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+						}
+						if (GitClient.RepoAdminCheckStatus.NOT_ADMIN == adminCheckStatus) {
+							log.error("collab user {} is not an admin of the external private repo {}/{}, cannot make user as admin",
+									collabUserId, orgName, repoName);
+							GenericMessage emptyResponse = new GenericMessage();
+							List<MessageDescription> errors = new ArrayList<>();
+							msg.setMessage("Invalid User, " + collabUserId + " must be an admin of the external repository "
+									+ orgName + "/" + repoName
+									+ ". DnA cannot grant access on repositories outside the codespace organisation. Bad request");
+							errors.add(msg);
+							emptyResponse.setErrors(errors);
+							emptyResponse.setSuccess("FAILED");
+							return new ResponseEntity<>(emptyResponse, HttpStatus.BAD_REQUEST);
+						}
 					}
 				}
 				if(isAdmin && !vo.getProjectDetails().getRecipeDetails().getRecipeId().name().toLowerCase().startsWith("private")){


### PR DESCRIPTION
## Summary

Promoting a collaborator to admin on a **private-recipe** codespace workspace (`POST /workspaces/{id}/collaborator/{collabUserId}/admin`) only ever *validated* repo admin permission and rejected the request with `"Invalid User, Please make sure that collab user should be an admin of the repo"`. Two problems: the check could not distinguish a genuine "not admin" from a failed Git API call, and for repos inside the codespace org it rejected instead of granting admin — unlike the public-recipe path, which already calls `addAdminAccessToRepo`.

`GitClient`: the boolean check is replaced by a tri-state result, and the permission response is evaluated beyond the bare `permission` string.

```java
public enum RepoAdminCheckStatus { ADMIN, NOT_ADMIN, CHECK_FAILED }

getUserRepoAdminStatus(org, user, repo[, baseUri, pat]):
  2xx  + no "permission" field      -> CHECK_FAILED (logged as error)
  2xx                               -> ADMIN if permission=="admin" || role_name=="admin"
                                              || permissions.admin == true, else NOT_ADMIN
                                       (resolved permission + role_name are logged)
  404                               -> NOT_ADMIN (user is not a collaborator)
  other status / exception          -> CHECK_FAILED
```
Both `isUserAdmin` overloads stay, now one-liners delegating to `ADMIN == getUserRepoAdminStatus(...)`. New `isCodeServerOrg(orgName, isGheHostedRepo)` compares the org parsed from the recipe repo URL against the configured org (`codeServer.git.orgname` for GHE, `codeServer.git.gitOrgname` otherwise) — the same selection `addAdminAccessToRepo(user, repo, isWorkspaceMigratedToGHE)` already uses, so grant and check stay consistent.

`WorkspaceController.makeAdmin`, private-recipe branch — in-org repos now behave like public recipes; external repos keep validate-and-reject, with API failure separated from a negative result:

```java
isGheHostedRepo = !repoUrl.contains(gitOrgUri + orgName);   // unchanged instance detection
if (gitClient.isCodeServerOrg(orgName, isGheHostedRepo))
    addAdminAccessToRepo(collabUserId, repoName, isGheHostedRepo);  // non-2xx -> warning naming user + repo, logged
else switch (getUserRepoAdminStatus(...)) {
    CHECK_FAILED -> 500 "Unable to verify admin permission ... Git permission API call failed"
    NOT_ADMIN    -> 400 "... must be an admin of the external repository <org>/<repo>. DnA cannot grant access ..."
    ADMIN        -> proceed
}
```

Reason for fix: admins could not promote eligible collaborators on private-recipe workspaces in production, forcing manual workspace/repo administration; failed permission API calls were reported to users as "user is not an admin".

Related Jira issue: FCF-551

Note on validation: the Gradle build of `packages/code-server` requires internal Artifactory credentials (`ARTIFACTORY_URL/USER/PASSWORD`), which are not available in this environment, so the module could not be compiled locally; there are no unit tests in this package. Changes were reviewed line by line instead and are confined to the two files above.

## AI Review
PR Quality Score: 88/100

Quality Notes:
- Code correctness: the tri-state result removes the failure/negative conflation that produced the misleading error, and the in-org grant reuses the existing `addAdminAccessToRepo` overload rather than a new code path; `role_name` / `permissions.admin` are read defensively via `optString`/`optJSONObject`.
- Risks: no local compilation or test run was possible (no Artifactory access, no tests in the package) — CI must confirm the build. Behaviour now depends on the configured org names matching the org parsed from the recipe repo URL; a misconfigured `codeServer.git.orgname` / `git.gitOrgname` would route an in-org repo down the external validate-only path (same values already govern the public-recipe grant, so no new configuration surface). Granting repo admin for in-org private repos is a genuine permission escalation on the Git side, gated as before by workspace-owner/admin authorisation.
- Architecture alignment: follows the existing `GitClient` + controller split, existing base-URI/PAT selection, existing warning/`GenericMessage` error conventions; only the two files named in the ticket are touched, no API signature or DB change.

[Written by Devin](https://mercedes-benz.devinenterprise.com/sessions/76abf43ec2454456ab4a0eb3007a95fc)
